### PR TITLE
Add canonical offer compatibility layer

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -284,6 +284,7 @@ class NormalizedOdds(BaseModel):
     over_odds: Optional[float] = None
     under_odds: Optional[float] = None
     start_time: Optional[str] = None
+    scraped_at: Optional[str] = None
 
 
 # ── Generic outcome offers ─────────────────────────────────
@@ -318,6 +319,34 @@ class NormalizedOutcomeOffer(BaseModel):
     line: Optional[float] = None
     raw_label: Optional[str] = None
     start_time: Optional[str] = None
+    scraped_at: Optional[str] = None
+
+
+class CanonicalMarket(BaseModel):
+    market_key: str
+    match_id: str
+    event_id: Optional[str] = None
+    bookmaker_match_id: Optional[str] = None
+    sport: str
+    market_type: str
+    source_market_type: str
+    subject_type: str
+    subject_key: Optional[str] = None
+    subject_name: Optional[str] = None
+    line: Optional[float] = None
+    period: Optional[str] = None
+    scope: Optional[str] = None
+
+
+class CanonicalOffer(BaseModel):
+    market_key: str
+    market: CanonicalMarket
+    bookmaker_id: str
+    outcome_code: str
+    odds: float
+    source_url: Optional[str] = None
+    raw_label: Optional[str] = None
+    scraped_at: Optional[str] = None
 
 
 class OutcomeOfferOut(BaseModel):

--- a/backend/app/services/canonical_offers.py
+++ b/backend/app/services/canonical_offers.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+import unicodedata
+
+from ..models.schemas import (
+    CanonicalMarket,
+    CanonicalOffer,
+    NormalizedOdds,
+    NormalizedOutcomeOffer,
+)
+
+
+_CANONICAL_MARKET_TYPES = {
+    "football_result": "result",
+    "football_double_chance": "double_chance",
+    "tennis_match_winner": "match_winner",
+}
+
+
+def canonical_market_type(market_type: str) -> str:
+    normalized = " ".join(market_type.strip().split())
+    return _CANONICAL_MARKET_TYPES.get(normalized, normalized)
+
+
+def build_market_key(
+    *,
+    match_id: str,
+    event_id: str | None,
+    sport: str,
+    market_type: str,
+    subject_type: str,
+    subject_key: str | None,
+    subject_name: str | None,
+    line: float | None,
+    period: str | None,
+    scope: str | None,
+) -> str:
+    event_identity = _clean_part(event_id) if event_id else f"match:{match_id}"
+    subject_identity = _clean_part(subject_key) or _subject_key(subject_type, subject_name)
+    payload = {
+        "event": event_identity,
+        "line": _normalize_line(line),
+        "market_type": market_type,
+        "period": _clean_part(period),
+        "scope": _clean_part(scope),
+        "sport": sport,
+        "subject": subject_identity,
+        "subject_type": subject_type,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def canonical_offers_from_normalized_odds(
+    odds: NormalizedOdds,
+    *,
+    event_id: str | None = None,
+    bookmaker_match_id: str | None = None,
+    scraped_at: str | None = None,
+    period: str | None = None,
+    scope: str | None = None,
+) -> list[CanonicalOffer]:
+    effective_scraped_at = scraped_at if scraped_at is not None else odds.scraped_at
+    market = canonical_market_from_normalized_odds(
+        odds,
+        event_id=event_id,
+        bookmaker_match_id=bookmaker_match_id,
+        period=period,
+        scope=scope,
+    )
+    offers: list[CanonicalOffer] = []
+    if odds.over_odds is not None:
+        offers.append(
+            _offer(
+                market=market,
+                bookmaker_id=odds.bookmaker_id,
+                outcome_code="over",
+                odds=odds.over_odds,
+                source_url=odds.source_url,
+                raw_label=None,
+                scraped_at=effective_scraped_at,
+            )
+        )
+    if odds.under_odds is not None:
+        offers.append(
+            _offer(
+                market=market,
+                bookmaker_id=odds.bookmaker_id,
+                outcome_code="under",
+                odds=odds.under_odds,
+                source_url=odds.source_url,
+                raw_label=None,
+                scraped_at=effective_scraped_at,
+            )
+        )
+    return offers
+
+
+def canonical_market_from_normalized_odds(
+    odds: NormalizedOdds,
+    *,
+    event_id: str | None = None,
+    bookmaker_match_id: str | None = None,
+    period: str | None = None,
+    scope: str | None = None,
+) -> CanonicalMarket:
+    subject_type, subject_key, subject_name = _subject_from_normalized_odds(odds)
+    market_type = canonical_market_type(odds.market_type)
+    line = _normalize_line(odds.threshold)
+    market_key = build_market_key(
+        match_id=odds.match_id,
+        event_id=event_id,
+        sport=odds.sport,
+        market_type=market_type,
+        subject_type=subject_type,
+        subject_key=subject_key,
+        subject_name=subject_name,
+        line=line,
+        period=period,
+        scope=scope,
+    )
+    return CanonicalMarket(
+        market_key=market_key,
+        match_id=odds.match_id,
+        event_id=event_id,
+        bookmaker_match_id=bookmaker_match_id,
+        sport=odds.sport,
+        market_type=market_type,
+        source_market_type=odds.market_type,
+        subject_type=subject_type,
+        subject_key=subject_key,
+        subject_name=subject_name,
+        line=line,
+        period=period,
+        scope=scope,
+    )
+
+
+def canonical_offer_from_normalized_outcome_offer(
+    offer: NormalizedOutcomeOffer,
+    *,
+    event_id: str | None = None,
+    bookmaker_match_id: str | None = None,
+    scraped_at: str | None = None,
+    period: str | None = None,
+    scope: str | None = None,
+) -> CanonicalOffer:
+    effective_scraped_at = (
+        scraped_at if scraped_at is not None else offer.scraped_at
+    )
+    market = canonical_market_from_normalized_outcome_offer(
+        offer,
+        event_id=event_id,
+        bookmaker_match_id=bookmaker_match_id,
+        period=period,
+        scope=scope,
+    )
+    return _offer(
+        market=market,
+        bookmaker_id=offer.bookmaker_id,
+        outcome_code=offer.outcome_code,
+        odds=offer.odds,
+        source_url=offer.source_url,
+        raw_label=offer.raw_label,
+        scraped_at=effective_scraped_at,
+    )
+
+
+def canonical_market_from_normalized_outcome_offer(
+    offer: NormalizedOutcomeOffer,
+    *,
+    event_id: str | None = None,
+    bookmaker_match_id: str | None = None,
+    period: str | None = None,
+    scope: str | None = None,
+) -> CanonicalMarket:
+    subject_type, subject_key, subject_name = _subject_from_outcome_offer(offer)
+    market_type = canonical_market_type(offer.market_type)
+    line = _normalize_line(offer.line)
+    market_key = build_market_key(
+        match_id=offer.match_id,
+        event_id=event_id,
+        sport=offer.sport,
+        market_type=market_type,
+        subject_type=subject_type,
+        subject_key=subject_key,
+        subject_name=subject_name,
+        line=line,
+        period=period,
+        scope=scope,
+    )
+    return CanonicalMarket(
+        market_key=market_key,
+        match_id=offer.match_id,
+        event_id=event_id,
+        bookmaker_match_id=bookmaker_match_id,
+        sport=offer.sport,
+        market_type=market_type,
+        source_market_type=offer.market_type,
+        subject_type=subject_type,
+        subject_key=subject_key,
+        subject_name=subject_name,
+        line=line,
+        period=period,
+        scope=scope,
+    )
+
+
+def _subject_from_normalized_odds(
+    odds: NormalizedOdds,
+) -> tuple[str, str | None, str | None]:
+    if odds.player_name:
+        subject_name = odds.player_name.strip()
+        return "player", _subject_key("player", subject_name), subject_name
+    return "event", None, None
+
+
+def _subject_from_outcome_offer(
+    offer: NormalizedOutcomeOffer,
+) -> tuple[str, str | None, str | None]:
+    return "event", None, None
+
+
+def _offer(
+    *,
+    market: CanonicalMarket,
+    bookmaker_id: str,
+    outcome_code: str,
+    odds: float,
+    source_url: str | None,
+    raw_label: str | None,
+    scraped_at: str | None,
+) -> CanonicalOffer:
+    return CanonicalOffer(
+        market_key=market.market_key,
+        market=market,
+        bookmaker_id=bookmaker_id,
+        outcome_code=outcome_code,
+        odds=odds,
+        source_url=source_url,
+        raw_label=raw_label,
+        scraped_at=scraped_at,
+    )
+
+
+def _subject_key(subject_type: str, subject_name: str | None) -> str | None:
+    normalized_name = _clean_part(subject_name)
+    if not normalized_name:
+        return None
+    return f"{subject_type}:{normalized_name}"
+
+
+def _clean_part(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    normalized = " ".join(normalized.split())
+    return normalized or None
+
+
+def _normalize_line(line: float | None) -> float | None:
+    if line is None:
+        return None
+    normalized = float(line)
+    if normalized == 0:
+        return 0.0
+    return normalized

--- a/backend/app/services/canonical_offers.py
+++ b/backend/app/services/canonical_offers.py
@@ -56,6 +56,8 @@ def canonical_offers_from_normalized_odds(
     *,
     event_id: str | None = None,
     bookmaker_match_id: str | None = None,
+    subject_key_override: str | None = None,
+    subject_name_override: str | None = None,
     scraped_at: str | None = None,
     period: str | None = None,
     scope: str | None = None,
@@ -65,6 +67,8 @@ def canonical_offers_from_normalized_odds(
         odds,
         event_id=event_id,
         bookmaker_match_id=bookmaker_match_id,
+        subject_key_override=subject_key_override,
+        subject_name_override=subject_name_override,
         period=period,
         scope=scope,
     )
@@ -101,10 +105,16 @@ def canonical_market_from_normalized_odds(
     *,
     event_id: str | None = None,
     bookmaker_match_id: str | None = None,
+    subject_key_override: str | None = None,
+    subject_name_override: str | None = None,
     period: str | None = None,
     scope: str | None = None,
 ) -> CanonicalMarket:
     subject_type, subject_key, subject_name = _subject_from_normalized_odds(odds)
+    if subject_key_override is not None:
+        subject_key = subject_key_override
+    if subject_name_override is not None:
+        subject_name = subject_name_override
     market_type = canonical_market_type(odds.market_type)
     line = _normalize_line(odds.threshold)
     market_key = build_market_key(

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -12,6 +12,7 @@ from ..config import settings
 from ..database import get_db
 from ..models.schemas import (
     BookmakerOut,
+    CanonicalOffer,
     CanonicalTeamOut,
     DiscrepancyDetail,
     DiscrepancyOut,
@@ -39,6 +40,10 @@ from ..models.schemas import (
     TeamReviewOut,
     UnresolvedOddsDiagnostic,
     UnresolvedOddsOut,
+)
+from ..services.canonical_offers import (
+    canonical_offer_from_normalized_outcome_offer,
+    canonical_offers_from_normalized_odds,
 )
 
 
@@ -1500,10 +1505,11 @@ async def get_current_normalized_odds_for_matches(
                    s.source_url,
                    o.market_type,
                    o.player_name,
-                   o.threshold,
-                   o.over_odds,
-                   o.under_odds,
-                   m.start_time
+                    o.threshold,
+                    o.over_odds,
+                    o.under_odds,
+                    m.start_time,
+                    o.scraped_at
             FROM odds o
             JOIN matches m ON m.id = o.match_id
             LEFT JOIN match_bookmaker_sources s
@@ -1542,10 +1548,11 @@ async def get_current_normalized_outcome_offers_for_matches(
                    s.source_url,
                    o.market_type,
                    o.outcome_code,
-                   o.odds,
-                   o.line,
-                   o.raw_label,
-                   m.start_time
+                    o.odds,
+                    o.line,
+                    o.raw_label,
+                    m.start_time,
+                    o.scraped_at
             FROM outcome_offers o
             JOIN matches m ON m.id = o.match_id
             LEFT JOIN match_bookmaker_sources s
@@ -1557,6 +1564,57 @@ async def get_current_normalized_outcome_offers_for_matches(
         [*selected_match_ids, *snapshot_params],
     )
     return [NormalizedOutcomeOffer(**_row_to_dict(row)) for row in rows]
+
+
+async def get_current_canonical_offers_for_matches(
+    match_ids: list[str],
+) -> list[CanonicalOffer]:
+    selected_match_ids = list(dict.fromkeys(match_ids))
+    if not selected_match_ids:
+        return []
+
+    odds_rows = await get_current_normalized_odds_for_matches(selected_match_ids)
+    outcome_offer_rows = await get_current_normalized_outcome_offers_for_matches(
+        selected_match_ids
+    )
+    resolved_event_ids = await _resolved_event_ids_for_offer_rows(
+        [*odds_rows, *outcome_offer_rows]
+    )
+    canonical_offers: list[CanonicalOffer] = []
+    for odds in odds_rows:
+        canonical_offers.extend(
+            canonical_offers_from_normalized_odds(
+                odds,
+                event_id=resolved_event_ids.get((odds.match_id, odds.bookmaker_id)),
+            )
+        )
+    for offer in outcome_offer_rows:
+        canonical_offers.append(
+            canonical_offer_from_normalized_outcome_offer(
+                offer,
+                event_id=resolved_event_ids.get((offer.match_id, offer.bookmaker_id)),
+            )
+        )
+    return canonical_offers
+
+
+async def _resolved_event_ids_for_offer_rows(
+    rows: list[NormalizedOdds | NormalizedOutcomeOffer],
+) -> dict[tuple[str, str], str]:
+    row_keys = {(row.match_id, row.bookmaker_id) for row in rows}
+    if not row_keys:
+        return {}
+
+    members = await get_eligible_resolved_event_members_for_matches(
+        sorted({match_id for match_id, _ in row_keys}),
+        bookmaker_ids=sorted({bookmaker_id for _, bookmaker_id in row_keys}),
+    )
+    event_ids: dict[tuple[str, str], str] = {}
+    for member in members:
+        key = (member.match_id, member.bookmaker_id)
+        if key in row_keys and key not in event_ids:
+            event_ids[key] = member.resolved_event_id
+    return event_ids
 
 
 # ── Odds ───────────────────────────────────────────────────

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -45,6 +45,7 @@ from ..services.canonical_offers import (
     canonical_offer_from_normalized_outcome_offer,
     canonical_offers_from_normalized_odds,
 )
+from ..services.event_player_resolver import build_event_scoped_player_odds
 
 
 def _row_to_dict(row: aiosqlite.Row) -> dict:
@@ -1492,6 +1493,21 @@ async def get_current_normalized_odds_for_matches(
     if snapshot_filter is None:
         return []
 
+    return await _get_normalized_odds_for_matches_snapshot(
+        db,
+        selected_match_ids,
+        snapshot_filter=snapshot_filter,
+        snapshot_params=snapshot_params,
+    )
+
+
+async def _get_normalized_odds_for_matches_snapshot(
+    db: aiosqlite.Connection,
+    selected_match_ids: list[str],
+    *,
+    snapshot_filter: str,
+    snapshot_params: list[object],
+) -> list[NormalizedOdds]:
     placeholders = _sql_placeholders(selected_match_ids)
     rows = await db.execute_fetchall(
         f"""SELECT o.match_id,
@@ -1505,11 +1521,11 @@ async def get_current_normalized_odds_for_matches(
                    s.source_url,
                    o.market_type,
                    o.player_name,
-                    o.threshold,
-                    o.over_odds,
-                    o.under_odds,
-                    m.start_time,
-                    o.scraped_at
+                   o.threshold,
+                   o.over_odds,
+                   o.under_odds,
+                   m.start_time,
+                   o.scraped_at
             FROM odds o
             JOIN matches m ON m.id = o.match_id
             LEFT JOIN match_bookmaker_sources s
@@ -1535,6 +1551,21 @@ async def get_current_normalized_outcome_offers_for_matches(
     if snapshot_filter is None:
         return []
 
+    return await _get_normalized_outcome_offers_for_matches_snapshot(
+        db,
+        selected_match_ids,
+        snapshot_filter=snapshot_filter,
+        snapshot_params=snapshot_params,
+    )
+
+
+async def _get_normalized_outcome_offers_for_matches_snapshot(
+    db: aiosqlite.Connection,
+    selected_match_ids: list[str],
+    *,
+    snapshot_filter: str,
+    snapshot_params: list[object],
+) -> list[NormalizedOutcomeOffer]:
     placeholders = _sql_placeholders(selected_match_ids)
     rows = await db.execute_fetchall(
         f"""SELECT o.match_id,
@@ -1548,11 +1579,11 @@ async def get_current_normalized_outcome_offers_for_matches(
                    s.source_url,
                    o.market_type,
                    o.outcome_code,
-                    o.odds,
-                    o.line,
-                    o.raw_label,
-                    m.start_time,
-                    o.scraped_at
+                   o.odds,
+                   o.line,
+                   o.raw_label,
+                   m.start_time,
+                   o.scraped_at
             FROM outcome_offers o
             JOIN matches m ON m.id = o.match_id
             LEFT JOIN match_bookmaker_sources s
@@ -1573,19 +1604,51 @@ async def get_current_canonical_offers_for_matches(
     if not selected_match_ids:
         return []
 
-    odds_rows = await get_current_normalized_odds_for_matches(selected_match_ids)
-    outcome_offer_rows = await get_current_normalized_outcome_offers_for_matches(
-        selected_match_ids
+    db = await get_db()
+    snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(db, "o")
+    if snapshot_filter is None:
+        return []
+
+    odds_rows = await _get_normalized_odds_for_matches_snapshot(
+        db,
+        selected_match_ids,
+        snapshot_filter=snapshot_filter,
+        snapshot_params=snapshot_params,
     )
-    resolved_event_ids = await _resolved_event_ids_for_offer_rows(
+    outcome_offer_rows = await _get_normalized_outcome_offers_for_matches_snapshot(
+        db,
+        selected_match_ids,
+        snapshot_filter=snapshot_filter,
+        snapshot_params=snapshot_params,
+    )
+    resolved_event_members = await _eligible_resolved_event_members_for_offer_rows(
         [*odds_rows, *outcome_offer_rows]
     )
+    resolved_event_ids = _resolved_event_ids_for_offer_rows(
+        [*odds_rows, *outcome_offer_rows],
+        resolved_event_members,
+    )
+    event_scoped_player_odds = {
+        id(item.odds): item
+        for item in build_event_scoped_player_odds(odds_rows, resolved_event_members)
+    }
     canonical_offers: list[CanonicalOffer] = []
     for odds in odds_rows:
+        player_identity = event_scoped_player_odds.get(id(odds))
         canonical_offers.extend(
             canonical_offers_from_normalized_odds(
                 odds,
                 event_id=resolved_event_ids.get((odds.match_id, odds.bookmaker_id)),
+                subject_key_override=(
+                    player_identity.event_scoped_player_key
+                    if player_identity is not None
+                    else None
+                ),
+                subject_name_override=(
+                    player_identity.event_player_display_name
+                    if player_identity is not None
+                    else None
+                ),
             )
         )
     for offer in outcome_offer_rows:
@@ -1598,17 +1661,24 @@ async def get_current_canonical_offers_for_matches(
     return canonical_offers
 
 
-async def _resolved_event_ids_for_offer_rows(
+async def _eligible_resolved_event_members_for_offer_rows(
     rows: list[NormalizedOdds | NormalizedOutcomeOffer],
-) -> dict[tuple[str, str], str]:
+) -> list[ResolvedEventMemberOut]:
     row_keys = {(row.match_id, row.bookmaker_id) for row in rows}
     if not row_keys:
-        return {}
+        return []
 
-    members = await get_eligible_resolved_event_members_for_matches(
+    return await get_eligible_resolved_event_members_for_matches(
         sorted({match_id for match_id, _ in row_keys}),
         bookmaker_ids=sorted({bookmaker_id for _, bookmaker_id in row_keys}),
     )
+
+
+def _resolved_event_ids_for_offer_rows(
+    rows: list[NormalizedOdds | NormalizedOutcomeOffer],
+    members: list[ResolvedEventMemberOut],
+) -> dict[tuple[str, str], str]:
+    row_keys = {(row.match_id, row.bookmaker_id) for row in rows}
     event_ids: dict[tuple[str, str], str] = {}
     for member in members:
         key = (member.match_id, member.bookmaker_id)

--- a/backend/tests/test_canonical_offers.py
+++ b/backend/tests/test_canonical_offers.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from app.models.schemas import NormalizedOdds, NormalizedOutcomeOffer
+from app.services.canonical_offers import (
+    canonical_offer_from_normalized_outcome_offer,
+    canonical_offers_from_normalized_odds,
+)
+
+
+def _odds(
+    bookmaker_id: str = "mozzart",
+    *,
+    match_id: str = "basketball-match-1",
+    market_type: str = "player_points",
+    player_name: str | None = "Nikola Jovic",
+    threshold: float = 16.5,
+    over_odds: float | None = 1.9,
+    under_odds: float | None = 1.9,
+) -> NormalizedOdds:
+    return NormalizedOdds(
+        match_id=match_id,
+        bookmaker_id=bookmaker_id,
+        league_id="euroleague",
+        sport="basketball",
+        home_team_id=1,
+        away_team_id=2,
+        home_team="Partizan",
+        away_team="Crvena Zvezda",
+        source_url=f"https://example.com/{bookmaker_id}/{match_id}",
+        market_type=market_type,
+        player_name=player_name,
+        threshold=threshold,
+        over_odds=over_odds,
+        under_odds=under_odds,
+        start_time="2030-01-01T20:00:00+00:00",
+    )
+
+
+def _outcome_offer(
+    bookmaker_id: str = "maxbet",
+    *,
+    match_id: str = "football-match-1",
+    market_type: str = "football_total_goals",
+    outcome_code: str = "over",
+    odds: float = 1.85,
+    line: float | None = 2.5,
+    sport: str = "football",
+) -> NormalizedOutcomeOffer:
+    return NormalizedOutcomeOffer(
+        match_id=match_id,
+        bookmaker_id=bookmaker_id,
+        league_id=f"{sport}_league",
+        sport=sport,
+        home_team_id=1,
+        away_team_id=2,
+        home_team="Team Alpha",
+        away_team="Team Beta",
+        source_url=f"https://example.com/{bookmaker_id}/{match_id}",
+        market_type=market_type,
+        outcome_code=outcome_code,
+        odds=odds,
+        line=line,
+        raw_label=outcome_code,
+        start_time="2030-01-01T20:00:00+00:00",
+    )
+
+
+def test_normalized_odds_player_prop_becomes_two_player_subject_offers():
+    offers = canonical_offers_from_normalized_odds(
+        _odds(over_odds=1.91, under_odds=1.87),
+        scraped_at="2030-01-01T19:55:00+00:00",
+    )
+
+    assert [offer.outcome_code for offer in offers] == ["over", "under"]
+    assert {offer.odds for offer in offers} == {1.91, 1.87}
+    assert len({offer.market_key for offer in offers}) == 1
+    market = offers[0].market
+    assert market.market_type == "player_points"
+    assert market.source_market_type == "player_points"
+    assert market.subject_type == "player"
+    assert market.subject_key == "player:nikola jovic"
+    assert market.subject_name == "Nikola Jovic"
+    assert market.line == 16.5
+    assert offers[0].scraped_at == "2030-01-01T19:55:00+00:00"
+
+
+def test_normalized_odds_market_key_excludes_bookmaker_and_odds():
+    first = canonical_offers_from_normalized_odds(
+        _odds("mozzart", over_odds=1.91, under_odds=None)
+    )[0]
+    second = canonical_offers_from_normalized_odds(
+        _odds("maxbet", over_odds=2.05, under_odds=None)
+    )[0]
+
+    assert first.market_key == second.market_key
+    assert first.bookmaker_id != second.bookmaker_id
+    assert first.odds != second.odds
+
+
+def test_normalized_odds_emits_only_available_sides():
+    under_only = canonical_offers_from_normalized_odds(
+        _odds(over_odds=None, under_odds=1.88)
+    )
+    empty = canonical_offers_from_normalized_odds(
+        _odds(over_odds=None, under_odds=None)
+    )
+
+    assert [(offer.outcome_code, offer.odds) for offer in under_only] == [("under", 1.88)]
+    assert empty == []
+
+
+def test_basketball_game_total_remains_distinct_event_market():
+    offers = canonical_offers_from_normalized_odds(
+        _odds(
+            market_type="game_total_ot",
+            player_name=None,
+            threshold=168.5,
+            over_odds=1.95,
+            under_odds=1.85,
+        )
+    )
+
+    assert {offer.outcome_code for offer in offers} == {"over", "under"}
+    assert offers[0].market.market_type == "game_total_ot"
+    assert offers[0].market.subject_type == "event"
+    assert offers[0].market.line == 168.5
+
+
+def test_football_total_goals_outcome_offer_maps_directly():
+    canonical = canonical_offer_from_normalized_outcome_offer(
+        _outcome_offer(market_type="football_total_goals", outcome_code="over", line=2.5)
+    )
+
+    assert canonical.outcome_code == "over"
+    assert canonical.odds == 1.85
+    assert canonical.raw_label == "over"
+    assert canonical.market.market_type == "football_total_goals"
+    assert canonical.market.source_market_type == "football_total_goals"
+    assert canonical.market.subject_type == "event"
+    assert canonical.market.line == 2.5
+
+
+def test_football_result_and_double_chance_use_conservative_market_names():
+    result = canonical_offer_from_normalized_outcome_offer(
+        _outcome_offer(market_type="football_result", outcome_code="home", line=None)
+    )
+    double_chance = canonical_offer_from_normalized_outcome_offer(
+        _outcome_offer(
+            market_type="football_double_chance",
+            outcome_code="draw_or_away",
+            line=None,
+        )
+    )
+
+    assert result.market.market_type == "result"
+    assert result.market.source_market_type == "football_result"
+    assert double_chance.market.market_type == "double_chance"
+    assert double_chance.market.source_market_type == "football_double_chance"
+    assert result.market_key != double_chance.market_key
+
+
+def test_synthetic_tennis_match_winner_maps_to_event_level_match_winner():
+    canonical = canonical_offer_from_normalized_outcome_offer(
+        _outcome_offer(
+            market_type="tennis_match_winner",
+            outcome_code="home",
+            line=None,
+            sport="tennis",
+        )
+    )
+
+    assert canonical.market.market_type == "match_winner"
+    assert canonical.market.source_market_type == "tennis_match_winner"
+    assert canonical.market.subject_type == "event"
+    assert canonical.market.line is None
+
+
+def test_market_key_uses_event_identity_when_available():
+    match_scoped = canonical_offer_from_normalized_outcome_offer(
+        _outcome_offer(match_id="bookmaker-match-a")
+    )
+    event_scoped = canonical_offer_from_normalized_outcome_offer(
+        _outcome_offer(match_id="bookmaker-match-b"),
+        event_id="resolved-event-1",
+    )
+    same_event_scoped = canonical_offer_from_normalized_outcome_offer(
+        _outcome_offer(match_id="bookmaker-match-c"),
+        event_id="resolved-event-1",
+    )
+
+    assert match_scoped.market_key != event_scoped.market_key
+    assert event_scoped.market_key == same_event_scoped.market_key

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -216,9 +216,9 @@ async def test_current_canonical_offers_use_active_resolved_event_identity():
             method="manual",
         )
     )
-    for match_id, bookmaker_id in (
-        ("bookmaker-match-a", "mozzart"),
-        ("bookmaker-match-b", "maxbet"),
+    for match_id, bookmaker_id, player_name in (
+        ("bookmaker-match-a", "mozzart", "Nikola Jokić"),
+        ("bookmaker-match-b", "maxbet", "N. Jokic"),
     ):
         await odds_store.link_resolved_event_member(
             ResolvedEventMemberIn(
@@ -236,7 +236,7 @@ async def test_current_canonical_offers_use_active_resolved_event_identity():
                 home_team="Partizan",
                 away_team="Crvena Zvezda",
                 market_type="player_points",
-                player_name="Nikola Jovic",
+                player_name=player_name,
                 threshold=16.5,
                 over_odds=1.91,
                 under_odds=None,
@@ -252,6 +252,88 @@ async def test_current_canonical_offers_use_active_resolved_event_identity():
     assert len(offers) == 2
     assert {offer.market.event_id for offer in offers} == {"resolved-partizan-zvezda"}
     assert len({offer.market_key for offer in offers}) == 1
+    assert {offer.market.subject_name for offer in offers} == {"Nikola Jokić"}
+    assert {offer.market.subject_key for offer in offers} == {
+        offers[0].market.subject_key
+    }
+    assert offers[0].market.subject_key
+    assert offers[0].market.subject_key.startswith("ply_")
+
+
+@pytest.mark.asyncio
+async def test_current_canonical_offers_capture_snapshot_once(monkeypatch):
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_league("premier_league", "Premier League", "football")
+    await odds_store.upsert_match(
+        "basketball-match",
+        "euroleague",
+        "Partizan",
+        "Crvena Zvezda",
+        sport="basketball",
+    )
+    await odds_store.upsert_match(
+        "football-match",
+        "premier_league",
+        "Team Alpha",
+        "Team Beta",
+        sport="football",
+    )
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+    stable_snapshot = "2030-01-01T19:55:00+00:00"
+    await odds_store.upsert_odds(
+        NormalizedOdds(
+            match_id="basketball-match",
+            bookmaker_id="mozzart",
+            league_id="euroleague",
+            sport="basketball",
+            home_team="Partizan",
+            away_team="Crvena Zvezda",
+            market_type="player_points",
+            player_name="Nikola Jovic",
+            threshold=16.5,
+            over_odds=1.91,
+            under_odds=None,
+        ),
+        scraped_at=stable_snapshot,
+    )
+    await odds_store.upsert_outcome_offer(
+        NormalizedOutcomeOffer(
+            match_id="football-match",
+            bookmaker_id="maxbet",
+            league_id="premier_league",
+            sport="football",
+            home_team="Team Alpha",
+            away_team="Team Beta",
+            market_type="football_total_goals",
+            outcome_code="over",
+            odds=1.85,
+            line=2.5,
+        ),
+        scraped_at=stable_snapshot,
+    )
+    calls = 0
+
+    async def fake_snapshot_filter(db, alias):
+        nonlocal calls
+        calls += 1
+        return f"{alias}.scraped_at = ?", [stable_snapshot]
+
+    monkeypatch.setattr(
+        odds_store,
+        "_current_or_legacy_snapshot_filter",
+        fake_snapshot_filter,
+    )
+
+    offers = await odds_store.get_current_canonical_offers_for_matches(
+        ["basketball-match", "football-match"]
+    )
+
+    assert calls == 1
+    assert [(offer.bookmaker_id, offer.scraped_at) for offer in offers] == [
+        ("mozzart", stable_snapshot),
+        ("maxbet", stable_snapshot),
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -11,6 +11,9 @@ from app.database import close_db, get_db, init_db
 from app.models.schemas import (
     EventReviewCaseIn,
     NormalizedOdds,
+    NormalizedOutcomeOffer,
+    ResolvedEventIn,
+    ResolvedEventMemberIn,
     TeamReviewDiagnostic,
     UnresolvedOddsDiagnostic,
 )
@@ -103,6 +106,152 @@ async def test_upsert_odds_and_history():
 
     history = await odds_store.get_odds_history_for_match("m1")
     assert len(history) >= 1
+
+
+@pytest.mark.asyncio
+async def test_get_current_canonical_offers_for_matches_reads_odds_and_outcome_offers():
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_league("premier_league", "Premier League", "football")
+    await odds_store.upsert_match(
+        "basketball-match",
+        "euroleague",
+        "Partizan",
+        "Crvena Zvezda",
+        sport="basketball",
+    )
+    await odds_store.upsert_match(
+        "football-match",
+        "premier_league",
+        "Team Alpha",
+        "Team Beta",
+        sport="football",
+    )
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+    scraped_at = "2030-01-01T19:55:00+00:00"
+
+    await odds_store.upsert_odds(
+        NormalizedOdds(
+            match_id="basketball-match",
+            bookmaker_id="mozzart",
+            league_id="euroleague",
+            sport="basketball",
+            home_team="Partizan",
+            away_team="Crvena Zvezda",
+            source_url="https://example.com/basketball",
+            market_type="player_points",
+            player_name="Nikola Jovic",
+            threshold=16.5,
+            over_odds=1.91,
+            under_odds=1.87,
+        ),
+        scraped_at=scraped_at,
+    )
+    await odds_store.upsert_outcome_offer(
+        NormalizedOutcomeOffer(
+            match_id="football-match",
+            bookmaker_id="maxbet",
+            league_id="premier_league",
+            sport="football",
+            home_team="Team Alpha",
+            away_team="Team Beta",
+            source_url="https://example.com/football",
+            market_type="football_total_goals",
+            outcome_code="over",
+            odds=1.85,
+            line=2.5,
+            raw_label="3+",
+        ),
+        scraped_at=scraped_at,
+    )
+    await odds_store.set_current_snapshot(scraped_at)
+
+    offers = await odds_store.get_current_canonical_offers_for_matches(
+        ["basketball-match", "football-match"]
+    )
+
+    assert [(offer.bookmaker_id, offer.outcome_code) for offer in offers] == [
+        ("mozzart", "over"),
+        ("mozzart", "under"),
+        ("maxbet", "over"),
+    ]
+    basketball_market = offers[0].market
+    football_market = offers[2].market
+    assert basketball_market.market_type == "player_points"
+    assert basketball_market.subject_type == "player"
+    assert basketball_market.subject_name == "Nikola Jovic"
+    assert offers[0].scraped_at == scraped_at
+    assert football_market.market_type == "football_total_goals"
+    assert football_market.subject_type == "event"
+    assert football_market.line == 2.5
+    assert offers[2].scraped_at == scraped_at
+
+
+@pytest.mark.asyncio
+async def test_current_canonical_offers_use_active_resolved_event_identity():
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_match(
+        "bookmaker-match-a",
+        "euroleague",
+        "Partizan",
+        "Crvena Zvezda",
+        sport="basketball",
+    )
+    await odds_store.upsert_match(
+        "bookmaker-match-b",
+        "euroleague",
+        "Partizan",
+        "Crvena Zvezda",
+        sport="basketball",
+    )
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+    scraped_at = "2030-01-01T19:55:00+00:00"
+    await odds_store.upsert_resolved_event(
+        ResolvedEventIn(
+            id="resolved-partizan-zvezda",
+            sport="basketball",
+            start_time="2030-01-01T20:00:00+00:00",
+            primary_match_id="bookmaker-match-a",
+            method="manual",
+        )
+    )
+    for match_id, bookmaker_id in (
+        ("bookmaker-match-a", "mozzart"),
+        ("bookmaker-match-b", "maxbet"),
+    ):
+        await odds_store.link_resolved_event_member(
+            ResolvedEventMemberIn(
+                resolved_event_id="resolved-partizan-zvezda",
+                match_id=match_id,
+                bookmaker_id=bookmaker_id,
+            )
+        )
+        await odds_store.upsert_odds(
+            NormalizedOdds(
+                match_id=match_id,
+                bookmaker_id=bookmaker_id,
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Partizan",
+                away_team="Crvena Zvezda",
+                market_type="player_points",
+                player_name="Nikola Jovic",
+                threshold=16.5,
+                over_odds=1.91,
+                under_odds=None,
+            ),
+            scraped_at=scraped_at,
+        )
+    await odds_store.set_current_snapshot(scraped_at)
+
+    offers = await odds_store.get_current_canonical_offers_for_matches(
+        ["bookmaker-match-a", "bookmaker-match-b"]
+    )
+
+    assert len(offers) == 2
+    assert {offer.market.event_id for offer in offers} == {"resolved-partizan-zvezda"}
+    assert len({offer.market_key for offer in offers}) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add canonical market and offer domain models for the unified event-market-offer architecture
- add converters from existing normalized odds and normalized outcome-offer rows
- add a compatibility store reader that builds canonical offers from both current storage paths while preserving resolved event identity and scrape timestamps

## Verification
- cd backend && ./venv/bin/python -m compileall -q app tests
- cd backend && ./venv/bin/pytest tests/test_canonical_offers.py tests/test_store.py tests/test_opportunity_analyzer.py tests/test_outcome_normalizer.py -q
- cd backend && ./venv/bin/pytest -q

Closes #52