### PR TITLE
Optimize scrape cycle persistence

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from pathlib import Path
+import tempfile
+
 import aiosqlite
 
 _SCHEMA = """
@@ -319,6 +322,21 @@ CREATE TABLE IF NOT EXISTS scrape_state (
 """
 
 _db_connection: aiosqlite.Connection | None = None
+_db_path: str | None = None
+_db_uri: bool = False
+_db_temp_path: str | None = None
+
+
+def _connection_target(db_path: str) -> tuple[str, bool, str | None]:
+    if db_path == ":memory:":
+        temp_file = tempfile.NamedTemporaryFile(
+            prefix="kvotolovac-memory-",
+            suffix=".db",
+            delete=False,
+        )
+        temp_file.close()
+        return temp_file.name, False, temp_file.name
+    return db_path, db_path.startswith("file:"), None
 
 
 async def _table_has_foreign_key(
@@ -854,11 +872,25 @@ async def get_db() -> aiosqlite.Connection:
     return _db_connection
 
 
+async def open_db_connection(db_path: str | None = None) -> aiosqlite.Connection:
+    if db_path is None:
+        active_db_path = _db_path
+        active_uri = _db_uri
+    else:
+        active_db_path, active_uri, _ = _connection_target(db_path)
+    if active_db_path is None:
+        raise RuntimeError("Database not initialised – call init_db() first")
+    conn = await aiosqlite.connect(active_db_path, uri=active_uri)
+    conn.row_factory = aiosqlite.Row
+    await conn.execute("PRAGMA busy_timeout = 5000")
+    await conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
 async def init_db(db_path: str = ":memory:") -> aiosqlite.Connection:
-    global _db_connection
-    _db_connection = await aiosqlite.connect(db_path)
-    _db_connection.row_factory = aiosqlite.Row
-    await _db_connection.execute("PRAGMA busy_timeout = 5000")
+    global _db_connection, _db_path, _db_uri, _db_temp_path
+    _db_path, _db_uri, _db_temp_path = _connection_target(db_path)
+    _db_connection = await open_db_connection()
     await _db_connection.execute("PRAGMA foreign_keys = OFF")
     await _db_connection.executescript(_SCHEMA)
     await _ensure_schema_compatibility(_db_connection)
@@ -868,7 +900,16 @@ async def init_db(db_path: str = ":memory:") -> aiosqlite.Connection:
 
 
 async def close_db() -> None:
-    global _db_connection
+    global _db_connection, _db_path, _db_uri, _db_temp_path
     if _db_connection is not None:
         await _db_connection.close()
         _db_connection = None
+    if _db_temp_path is not None:
+        for suffix in ("", "-wal", "-shm"):
+            try:
+                Path(_db_temp_path + suffix).unlink()
+            except FileNotFoundError:
+                pass
+        _db_temp_path = None
+    _db_path = None
+    _db_uri = False

--- a/backend/app/services/event_resolver.py
+++ b/backend/app/services/event_resolver.py
@@ -460,6 +460,21 @@ class EventResolverResult:
     review_cases: int
 
 
+@dataclass(frozen=True)
+class EventResolutionRows:
+    events: list[ResolvedEventIn]
+    members: list[ResolvedEventMemberIn]
+    review_cases: list[EventReviewCaseIn]
+
+
+@dataclass(frozen=True)
+class EventResolutionBatch:
+    result: EventResolverResult
+    events: list[ResolvedEventIn]
+    members: list[ResolvedEventMemberIn]
+    review_cases: list[EventReviewCaseIn]
+
+
 def _league_source(raw_league_id: str, bookmaker_id: str) -> tuple[str, str]:
     resolution = resolve_league(raw_league_id, bookmaker_id=bookmaker_id)
     return resolution.league_id, resolution.display_name
@@ -1156,10 +1171,10 @@ def build_event_resolution_groups(
     )
 
 
-async def persist_event_resolution_groups(
+def build_event_resolution_rows(
     resolutions: list[EventResolutionGroup],
     review_cases: list[EventReviewCaseIn],
-) -> EventResolverResult:
+) -> EventResolutionRows:
     events: list[ResolvedEventIn] = []
     members: list[ResolvedEventMemberIn] = []
     for resolution in resolutions:
@@ -1218,15 +1233,66 @@ async def persist_event_resolution_groups(
                 )
             )
 
-    await odds_store.upsert_resolved_events_bulk(events)
-    await odds_store.link_resolved_event_members_bulk(members)
-    persisted_review_cases = await odds_store.upsert_event_review_cases_bulk(review_cases)
+    return EventResolutionRows(
+        events=events,
+        members=members,
+        review_cases=review_cases,
+    )
+
+
+async def persist_event_resolution_groups(
+    resolutions: list[EventResolutionGroup],
+    review_cases: list[EventReviewCaseIn],
+) -> EventResolverResult:
+    rows = build_event_resolution_rows(resolutions, review_cases)
+
+    await odds_store.upsert_resolved_events_bulk(rows.events)
+    await odds_store.link_resolved_event_members_bulk(rows.members)
+    persisted_review_cases = await odds_store.upsert_event_review_cases_bulk(
+        rows.review_cases
+    )
 
     return EventResolverResult(
-        candidates=len(members),
-        resolved_events=len(resolutions),
-        resolved_event_members=len(members),
+        candidates=len(rows.members),
+        resolved_events=len(rows.events),
+        resolved_event_members=len(rows.members),
         review_cases=persisted_review_cases,
+    )
+
+
+def prepare_event_resolution(
+    *,
+    raw_odds: list[RawOddsData],
+    raw_outcome_offers: list[RawOutcomeOffer],
+    normalized_odds: list[NormalizedOdds],
+    normalized_outcome_offers: list[NormalizedOutcomeOffer],
+) -> EventResolutionBatch:
+    candidates = extract_event_candidates(
+        raw_odds=raw_odds,
+        raw_outcome_offers=raw_outcome_offers,
+        normalized_odds=normalized_odds,
+        normalized_outcome_offers=normalized_outcome_offers,
+    )
+    resolutions, review_cases = build_event_resolution_groups(candidates)
+    rows = build_event_resolution_rows(resolutions, review_cases)
+    result = EventResolverResult(
+        candidates=len(candidates),
+        resolved_events=len(rows.events),
+        resolved_event_members=len(rows.members),
+        review_cases=len(rows.review_cases),
+    )
+    logger.info(
+        "Resolved %d source-event candidates into %d events (%d members, %d review cases)",
+        result.candidates,
+        result.resolved_events,
+        result.resolved_event_members,
+        result.review_cases,
+    )
+    return EventResolutionBatch(
+        result=result,
+        events=rows.events,
+        members=rows.members,
+        review_cases=rows.review_cases,
     )
 
 
@@ -1237,24 +1303,20 @@ async def resolve_and_persist_events(
     normalized_odds: list[NormalizedOdds],
     normalized_outcome_offers: list[NormalizedOutcomeOffer],
 ) -> EventResolverResult:
-    candidates = extract_event_candidates(
+    batch = prepare_event_resolution(
         raw_odds=raw_odds,
         raw_outcome_offers=raw_outcome_offers,
         normalized_odds=normalized_odds,
         normalized_outcome_offers=normalized_outcome_offers,
     )
-    resolutions, review_cases = build_event_resolution_groups(candidates)
-    result = await persist_event_resolution_groups(resolutions, review_cases)
-    logger.info(
-        "Resolved %d source-event candidates into %d events (%d members, %d review cases)",
-        len(candidates),
-        result.resolved_events,
-        result.resolved_event_members,
-        result.review_cases,
+    await odds_store.upsert_resolved_events_bulk(batch.events)
+    await odds_store.link_resolved_event_members_bulk(batch.members)
+    persisted_review_cases = await odds_store.upsert_event_review_cases_bulk(
+        batch.review_cases
     )
     return EventResolverResult(
-        candidates=len(candidates),
-        resolved_events=result.resolved_events,
-        resolved_event_members=result.resolved_event_members,
-        review_cases=result.review_cases,
+        candidates=batch.result.candidates,
+        resolved_events=batch.result.resolved_events,
+        resolved_event_members=batch.result.resolved_event_members,
+        review_cases=persisted_review_cases,
     )

--- a/backend/app/services/event_resolver.py
+++ b/backend/app/services/event_resolver.py
@@ -1160,7 +1160,8 @@ async def persist_event_resolution_groups(
     resolutions: list[EventResolutionGroup],
     review_cases: list[EventReviewCaseIn],
 ) -> EventResolverResult:
-    member_count = 0
+    events: list[ResolvedEventIn] = []
+    members: list[ResolvedEventMemberIn] = []
     for resolution in resolutions:
         source_league_labels = sorted(
             {
@@ -1170,7 +1171,7 @@ async def persist_event_resolution_groups(
             }
         )
         source_match_ids = sorted({member.match_id for member in resolution.members})
-        await odds_store.upsert_resolved_event(
+        events.append(
             ResolvedEventIn(
                 id=resolution.event_id,
                 sport=resolution.sport,
@@ -1194,7 +1195,7 @@ async def persist_event_resolution_groups(
             key=lambda candidate: (candidate.match_id, candidate.bookmaker_id),
         )
         for member in resolution.members:
-            await odds_store.link_resolved_event_member(
+            members.append(
                 ResolvedEventMemberIn(
                     resolved_event_id=resolution.event_id,
                     match_id=member.match_id,
@@ -1216,17 +1217,15 @@ async def persist_event_resolution_groups(
                     },
                 )
             )
-            member_count += 1
 
-    persisted_review_cases = 0
-    for review_case in review_cases:
-        await odds_store.upsert_event_review_case(review_case)
-        persisted_review_cases += 1
+    await odds_store.upsert_resolved_events_bulk(events)
+    await odds_store.link_resolved_event_members_bulk(members)
+    persisted_review_cases = await odds_store.upsert_event_review_cases_bulk(review_cases)
 
     return EventResolverResult(
-        candidates=member_count,
+        candidates=len(members),
         resolved_events=len(resolutions),
-        resolved_event_members=member_count,
+        resolved_event_members=len(members),
         review_cases=persisted_review_cases,
     )
 

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1010,30 +1010,12 @@ class Scheduler:
                     event_members=opportunity_event_members,
                     event_primary_match_ids=opportunity_event_primary_match_ids,
                 )
-                for opportunity in opportunities:
-                    await odds_store.insert_opportunity(
-                        opportunity,
-                        detected_at=cycle_scraped_at,
-                    )
+                await odds_store.insert_opportunities_bulk(
+                    opportunities,
+                    detected_at=cycle_scraped_at,
+                )
 
-                for d in discrepancies:
-                    await odds_store.insert_discrepancy(
-                        match_id=d.match_id,
-                        market_type=d.market_type,
-                        player_name=d.player_name,
-                        bookmaker_a_id=d.bookmaker_a_id,
-                        bookmaker_b_id=d.bookmaker_b_id,
-                        threshold_a=d.threshold_a,
-                        threshold_b=d.threshold_b,
-                        odds_a=d.odds_a,
-                        odds_b=d.odds_b,
-                        gap=d.gap,
-                        profit_margin=d.profit_margin,
-                        middle_profit_margin=d.middle_profit_margin,
-                        resolved_event_id=d.resolved_event_id,
-                        bookmaker_a_match_id=d.bookmaker_a_match_id,
-                        bookmaker_b_match_id=d.bookmaker_b_match_id,
-                    )
+                await odds_store.insert_discrepancies_bulk(discrepancies)
 
                 self._scan_phase = "notifying"
                 notified = await self._notification_service.notify_discrepancies(

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -7,7 +7,12 @@ from collections import defaultdict
 from datetime import datetime
 
 from ..config import settings
-from ..models.schemas import RawOddsData, RawOutcomeOffer, TeamReviewDiagnostic
+from ..models.schemas import (
+    RawOddsData,
+    RawOutcomeOffer,
+    ResolvedEventMemberOut,
+    TeamReviewDiagnostic,
+)
 from ..scrapers.base import BaseScraper
 from ..scrapers.registry import registry
 from ..models.schemas import ScanProgressOut
@@ -26,7 +31,7 @@ from ..services.event_resolver import (
     _is_unsafe_compound_subset_match,
     _normalize_merge_pairings,
     _same_time_slot_orientation,
-    resolve_and_persist_events,
+    prepare_event_resolution,
 )
 from ..services.opportunity_analyzer import analyze_outcome_offers
 from ..services.outcome_normalizer import normalize_outcome_offers_with_diagnostics
@@ -72,6 +77,75 @@ def _is_auto_alias_candidate(case) -> bool:
 
 def _candidate_merge_source_ids(case) -> set[int]:
     return _contextual_merge_source_ids(case)
+
+
+def _pending_event_member_out(
+    member,
+    *,
+    synthetic_id: int,
+) -> ResolvedEventMemberOut:
+    return ResolvedEventMemberOut(
+        **member.model_dump(),
+        id=synthetic_id,
+    )
+
+
+def _pending_event_members_for_matches(
+    *,
+    event_members,
+    event_methods_by_id: dict[str, str],
+    match_ids: set[str],
+    bookmaker_ids: set[str],
+    event_methods: tuple[str, ...] = (
+        "exact",
+        "auto_fuzzy_high",
+        "manual",
+        "manual_review",
+    ),
+) -> list[ResolvedEventMemberOut]:
+    if not match_ids or not bookmaker_ids:
+        return []
+
+    pending_members: list[ResolvedEventMemberOut] = []
+    allowed_methods = set(event_methods)
+    for index, member in enumerate(event_members):
+        if member.match_id not in match_ids or member.bookmaker_id not in bookmaker_ids:
+            continue
+        if member.status != "active":
+            continue
+        method = event_methods_by_id.get(member.resolved_event_id)
+        if method not in allowed_methods:
+            continue
+        pending_members.append(
+            _pending_event_member_out(member, synthetic_id=-(index + 1))
+        )
+    return pending_members
+
+
+def _merge_committed_and_pending_event_members(
+    committed_members: list[ResolvedEventMemberOut],
+    pending_members: list[ResolvedEventMemberOut],
+    *,
+    protected_manual_keys: set[tuple[str, str]],
+) -> list[ResolvedEventMemberOut]:
+    by_member_key = {
+        (member.match_id, member.bookmaker_id): member
+        for member in committed_members
+    }
+    for member in pending_members:
+        member_key = (member.match_id, member.bookmaker_id)
+        if member_key in protected_manual_keys:
+            continue
+        by_member_key[member_key] = member
+    return sorted(
+        by_member_key.values(),
+        key=lambda member: (
+            member.resolved_event_id,
+            member.id,
+            member.match_id,
+            member.bookmaker_id,
+        ),
+    )
 
 
 class Scheduler:
@@ -983,12 +1057,22 @@ class Scheduler:
                     (time.perf_counter() - prerequisite_db_started_at) * 1000
                 )
                 event_resolve_started_at = time.perf_counter()
-                await resolve_and_persist_events(
+                event_resolution = prepare_event_resolution(
                     raw_odds=all_raw,
                     raw_outcome_offers=all_raw_outcome_offers,
                     normalized_odds=normalized,
                     normalized_outcome_offers=normalized_outcome_offers,
                 )
+                event_methods_by_id = {
+                    event.id: event.method
+                    for event in event_resolution.events
+                    if event.id is not None
+                }
+                pending_event_primary_match_ids = {
+                    event.id: event.primary_match_id
+                    for event in event_resolution.events
+                    if event.id is not None
+                }
                 event_resolve_duration_ms = int(
                     (time.perf_counter() - event_resolve_started_at) * 1000
                 )
@@ -998,10 +1082,30 @@ class Scheduler:
 
                 self._scan_phase = "analyzing"
                 event_lookup_started_at = time.perf_counter()
-                discrepancy_event_members = (
+                discrepancy_committed_event_members = (
                     await odds_store.get_eligible_resolved_event_members_for_odds(
                         normalized
                     )
+                )
+                discrepancy_manual_event_members = (
+                    await odds_store.get_eligible_resolved_event_members_for_odds(
+                        normalized,
+                        event_methods=("manual", "manual_review"),
+                    )
+                )
+                discrepancy_pending_event_members = _pending_event_members_for_matches(
+                    event_members=event_resolution.members,
+                    event_methods_by_id=event_methods_by_id,
+                    match_ids={odds.match_id for odds in normalized},
+                    bookmaker_ids={odds.bookmaker_id for odds in normalized},
+                )
+                discrepancy_event_members = _merge_committed_and_pending_event_members(
+                    discrepancy_committed_event_members,
+                    discrepancy_pending_event_members,
+                    protected_manual_keys={
+                        (member.match_id, member.bookmaker_id)
+                        for member in discrepancy_manual_event_members
+                    },
                 )
                 discrepancy_event_primary_match_ids = (
                     await odds_store.get_resolved_event_primary_match_ids(
@@ -1011,10 +1115,35 @@ class Scheduler:
                         ]
                     )
                 )
-                opportunity_event_members = (
+                discrepancy_event_primary_match_ids.update(
+                    pending_event_primary_match_ids
+                )
+                opportunity_committed_event_members = (
                     await odds_store.get_eligible_resolved_event_members_for_outcome_offers(
                         normalized_outcome_offers
                     )
+                )
+                opportunity_manual_event_members = (
+                    await odds_store.get_eligible_resolved_event_members_for_outcome_offers(
+                        normalized_outcome_offers,
+                        event_methods=("manual", "manual_review"),
+                    )
+                )
+                opportunity_pending_event_members = _pending_event_members_for_matches(
+                    event_members=event_resolution.members,
+                    event_methods_by_id=event_methods_by_id,
+                    match_ids={offer.match_id for offer in normalized_outcome_offers},
+                    bookmaker_ids={
+                        offer.bookmaker_id for offer in normalized_outcome_offers
+                    },
+                )
+                opportunity_event_members = _merge_committed_and_pending_event_members(
+                    opportunity_committed_event_members,
+                    opportunity_pending_event_members,
+                    protected_manual_keys={
+                        (member.match_id, member.bookmaker_id)
+                        for member in opportunity_manual_event_members
+                    },
                 )
                 opportunity_event_primary_match_ids = (
                     await odds_store.get_resolved_event_primary_match_ids(
@@ -1023,6 +1152,9 @@ class Scheduler:
                             for member in opportunity_event_members
                         ]
                     )
+                )
+                opportunity_event_primary_match_ids.update(
+                    pending_event_primary_match_ids
                 )
                 event_lookup_duration_ms = int(
                     (time.perf_counter() - event_lookup_started_at) * 1000
@@ -1045,6 +1177,9 @@ class Scheduler:
                 self._scan_phase = "storing"
                 snapshot_store_started_at = time.perf_counter()
                 await odds_store.replace_cycle_outputs_and_activate_snapshot(
+                    resolved_events=event_resolution.events,
+                    resolved_event_members=event_resolution.members,
+                    event_review_cases=event_resolution.review_cases,
                     odds=normalized,
                     outcome_offers=normalized_outcome_offers,
                     unresolved_odds=unresolved_odds,

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -14,7 +14,6 @@ from ..models.schemas import ScanProgressOut
 from ..services.league_registry import league_country, league_display_name
 from ..services.normalizer import (
     ANCHORED_AUTO_APPLY_THRESHOLD,
-    log_unresolved_shared_platform_diagnostics,
     normalize_odds_with_diagnostics,
     resolve_team_name,
 )
@@ -833,13 +832,15 @@ class Scheduler:
             )
 
             self._scan_phase = "registering"
-            for scraper in scrapers:
-                await odds_store.upsert_bookmaker(
-                    id=scraper.get_bookmaker_id(),
-                    name=scraper.get_bookmaker_name(),
-                )
+            await odds_store.upsert_bookmakers_bulk(
+                [
+                    (scraper.get_bookmaker_id(), scraper.get_bookmaker_name(), None)
+                    for scraper in scrapers
+                ]
+            )
 
             self._scan_phase = "normalizing"
+            normalizing_started_at = time.perf_counter()
             normalized = []
             normalized_outcome_offers = []
             seen_matches: set[str] = set()
@@ -862,13 +863,21 @@ class Scheduler:
             ) = normalize_outcome_offers_with_diagnostics(all_raw_outcome_offers)
             unresolved_odds = [*unresolved_odds, *unresolved_outcome_offers]
             team_review_cases = [*team_review_cases, *outcome_team_review_cases]
+            initial_normalize_duration_ms = int(
+                (time.perf_counter() - normalizing_started_at) * 1000
+            )
             applied_auto_aliases: list[tuple[str, str, str]] = []
             applied_auto_merges: list[tuple[int, int]] = []
             try:
+                same_time_auto_started_at = time.perf_counter()
                 (
                     same_time_auto_reviews,
                     same_time_auto_merges,
                 ) = await self._same_time_canonical_merge_candidates(all_raw)
+                same_time_auto_duration_ms = int(
+                    (time.perf_counter() - same_time_auto_started_at) * 1000
+                )
+                anchored_alias_started_at = time.perf_counter()
                 (
                     auto_approved_team_reviews,
                     applied_auto_aliases,
@@ -876,6 +885,9 @@ class Scheduler:
                 ) = await self._auto_apply_anchored_aliases(
                     team_review_cases,
                     all_raw,
+                )
+                anchored_alias_duration_ms = int(
+                    (time.perf_counter() - anchored_alias_started_at) * 1000
                 )
                 auto_approved_team_reviews = [
                     *same_time_auto_reviews,
@@ -885,11 +897,19 @@ class Scheduler:
                     *same_time_auto_merges,
                     *pending_auto_merges,
                 ]
+                apply_merges_duration_ms = 0
                 if pending_auto_merges:
+                    apply_merges_started_at = time.perf_counter()
                     applied_auto_merges = await self._apply_canonical_merges(
                         pending_auto_merges
                     )
-                if auto_approved_team_reviews or applied_auto_merges:
+                    apply_merges_duration_ms = int(
+                        (time.perf_counter() - apply_merges_started_at) * 1000
+                    )
+                renormalize_duration_ms = 0
+                should_renormalize = bool(applied_auto_aliases or applied_auto_merges)
+                if should_renormalize:
+                    renormalize_started_at = time.perf_counter()
                     (
                         normalized,
                         unresolved_odds,
@@ -902,77 +922,82 @@ class Scheduler:
                     ) = normalize_outcome_offers_with_diagnostics(all_raw_outcome_offers)
                     unresolved_odds = [*unresolved_odds, *unresolved_outcome_offers]
                     team_review_cases = [*team_review_cases, *outcome_team_review_cases]
+                    renormalize_duration_ms = int(
+                        (time.perf_counter() - renormalize_started_at) * 1000
+                    )
                 else:
-                    log_unresolved_shared_platform_diagnostics(unresolved_odds)
+                    logger.info(
+                        "Skipping unresolved shared-platform detail diagnostics for %d rows; "
+                        "run normalize_odds_with_diagnostics(..., log_unresolved_shared_platform=True) "
+                        "in a targeted debug session for full grouped warnings",
+                        len(unresolved_odds),
+                    )
 
                 self._scan_phase = "storing"
                 cycle_scraped_at = datetime.utcnow().isoformat()
-                for o in normalized:
-                    if o.match_id not in seen_matches:
-                        await odds_store.upsert_league(
-                            id=o.league_id,
-                            name=league_display_name(o.league_id),
-                            sport=o.sport,
-                            country=league_country(o.league_id),
-                        )
-                        await odds_store.upsert_match(
-                            id=o.match_id,
-                            league_id=o.league_id,
-                            home_team=o.home_team,
-                            away_team=o.away_team,
-                            sport=o.sport,
-                            home_team_id=o.home_team_id,
-                            away_team_id=o.away_team_id,
-                            start_time=o.start_time,
-                        )
-                        seen_matches.add(o.match_id)
-                    await odds_store.upsert_odds(o, scraped_at=cycle_scraped_at)
-                for offer in normalized_outcome_offers:
-                    if offer.match_id not in seen_matches:
-                        await odds_store.upsert_league(
-                            id=offer.league_id,
-                            name=league_display_name(offer.league_id),
-                            sport=offer.sport,
-                            country=league_country(offer.league_id),
-                        )
-                        await odds_store.upsert_match(
-                            id=offer.match_id,
-                            league_id=offer.league_id,
-                            home_team=offer.home_team,
-                            away_team=offer.away_team,
-                            sport=offer.sport,
-                            home_team_id=offer.home_team_id,
-                            away_team_id=offer.away_team_id,
-                            start_time=offer.start_time,
-                        )
-                        seen_matches.add(offer.match_id)
-                    await odds_store.upsert_outcome_offer(
-                        offer,
-                        scraped_at=cycle_scraped_at,
+                prerequisite_store_started_at = time.perf_counter()
+                league_rows: dict[str, tuple[str, str, str, str | None]] = {}
+                match_rows: list[
+                    tuple[
+                        str,
+                        str,
+                        str,
+                        str,
+                        str,
+                        int | None,
+                        int | None,
+                        str | None,
+                        str,
+                    ]
+                ] = []
+                for item in [*normalized, *normalized_outcome_offers]:
+                    league_rows[item.league_id] = (
+                        item.league_id,
+                        league_display_name(item.league_id),
+                        item.sport,
+                        league_country(item.league_id),
                     )
+                    if item.match_id in seen_matches:
+                        continue
+                    match_rows.append(
+                        (
+                            item.match_id,
+                            item.league_id,
+                            item.home_team,
+                            item.away_team,
+                            item.sport,
+                            item.home_team_id,
+                            item.away_team_id,
+                            item.start_time,
+                            "upcoming",
+                        )
+                    )
+                    seen_matches.add(item.match_id)
+                prerequisite_build_duration_ms = int(
+                    (time.perf_counter() - prerequisite_store_started_at) * 1000
+                )
+                prerequisite_db_started_at = time.perf_counter()
+                await odds_store.upsert_leagues_bulk(list(league_rows.values()))
+                await odds_store.upsert_matches_bulk(match_rows)
+                prerequisite_db_duration_ms = int(
+                    (time.perf_counter() - prerequisite_db_started_at) * 1000
+                )
+                event_resolve_started_at = time.perf_counter()
                 await resolve_and_persist_events(
                     raw_odds=all_raw,
                     raw_outcome_offers=all_raw_outcome_offers,
                     normalized_odds=normalized,
                     normalized_outcome_offers=normalized_outcome_offers,
                 )
-                for unresolved in unresolved_odds:
-                    await odds_store.insert_unresolved_odds(
-                        unresolved, scraped_at=cycle_scraped_at
-                    )
-                for team_review_case in team_review_cases:
-                    await odds_store.insert_team_review_case(
-                        team_review_case, scraped_at=cycle_scraped_at
-                    )
-                for team_review_case in auto_approved_team_reviews:
-                    case_id = await odds_store.insert_team_review_case(
-                        team_review_case, scraped_at=cycle_scraped_at
-                    )
-                    await odds_store.mark_team_review_case_approved(case_id)
-                await odds_store.set_current_snapshot(cycle_scraped_at)
+                event_resolve_duration_ms = int(
+                    (time.perf_counter() - event_resolve_started_at) * 1000
+                )
+                prerequisite_store_duration_ms = int(
+                    (time.perf_counter() - prerequisite_store_started_at) * 1000
+                )
 
                 self._scan_phase = "analyzing"
-                await odds_store.deactivate_all_discrepancies()
+                event_lookup_started_at = time.perf_counter()
                 discrepancy_event_members = (
                     await odds_store.get_eligible_resolved_event_members_for_odds(
                         normalized
@@ -986,12 +1011,6 @@ class Scheduler:
                         ]
                     )
                 )
-                discrepancies = analyze(
-                    normalized,
-                    event_members=discrepancy_event_members,
-                    event_primary_match_ids=discrepancy_event_primary_match_ids,
-                )
-                await odds_store.deactivate_opportunities()
                 opportunity_event_members = (
                     await odds_store.get_eligible_resolved_event_members_for_outcome_offers(
                         normalized_outcome_offers
@@ -1005,17 +1024,61 @@ class Scheduler:
                         ]
                     )
                 )
+                event_lookup_duration_ms = int(
+                    (time.perf_counter() - event_lookup_started_at) * 1000
+                )
+                analyze_started_at = time.perf_counter()
+                discrepancies = analyze(
+                    normalized,
+                    event_members=discrepancy_event_members,
+                    event_primary_match_ids=discrepancy_event_primary_match_ids,
+                )
                 opportunities = analyze_outcome_offers(
                     normalized_outcome_offers,
                     event_members=opportunity_event_members,
                     event_primary_match_ids=opportunity_event_primary_match_ids,
                 )
-                await odds_store.insert_opportunities_bulk(
-                    opportunities,
-                    detected_at=cycle_scraped_at,
+                analyze_duration_ms = int(
+                    (time.perf_counter() - analyze_started_at) * 1000
                 )
 
-                await odds_store.insert_discrepancies_bulk(discrepancies)
+                self._scan_phase = "storing"
+                snapshot_store_started_at = time.perf_counter()
+                await odds_store.replace_cycle_outputs_and_activate_snapshot(
+                    odds=normalized,
+                    outcome_offers=normalized_outcome_offers,
+                    unresolved_odds=unresolved_odds,
+                    team_review_cases=team_review_cases,
+                    auto_approved_team_reviews=auto_approved_team_reviews,
+                    opportunities=opportunities,
+                    discrepancies=discrepancies,
+                    detected_at=cycle_scraped_at,
+                    snapshot_at=cycle_scraped_at,
+                )
+                snapshot_store_duration_ms = int(
+                    (time.perf_counter() - snapshot_store_started_at) * 1000
+                )
+                output_store_duration_ms = snapshot_store_duration_ms
+                logger.info(
+                    "Cycle phase durations: initial_normalize=%d ms same_time_auto=%d ms "
+                    "anchored_alias=%d ms apply_merges=%d ms renormalize_or_diagnostics=%d ms "
+                    "prereq_build=%d ms prereq_db=%d ms event_resolve=%d ms "
+                    "prereq_store=%d ms event_lookup=%d ms analyze=%d ms "
+                    "snapshot_store=%d ms output_store=%d ms",
+                    initial_normalize_duration_ms,
+                    same_time_auto_duration_ms,
+                    anchored_alias_duration_ms,
+                    apply_merges_duration_ms,
+                    renormalize_duration_ms,
+                    prerequisite_build_duration_ms,
+                    prerequisite_db_duration_ms,
+                    event_resolve_duration_ms,
+                    prerequisite_store_duration_ms,
+                    event_lookup_duration_ms,
+                    analyze_duration_ms,
+                    snapshot_store_duration_ms,
+                    output_store_duration_ms,
+                )
 
                 self._scan_phase = "notifying"
                 notified = await self._notification_service.notify_discrepancies(
@@ -1062,8 +1125,13 @@ class Scheduler:
 
             try:
                 self._scan_phase = "retaining"
+                retention_started_at = time.perf_counter()
                 cleanup_counts = await odds_store.cleanup_retained_data(cycle_scraped_at)
-                logger.info("Retention cleanup complete: %s", cleanup_counts)
+                logger.info(
+                    "Retention cleanup complete: %s (duration_ms=%d)",
+                    cleanup_counts,
+                    int((time.perf_counter() - retention_started_at) * 1000),
+                )
             except Exception:
                 logger.exception("Retention cleanup failed after a successful scrape cycle")
 

--- a/backend/app/services/team_registry.py
+++ b/backend/app/services/team_registry.py
@@ -499,6 +499,8 @@ def clear_team_registry_cache(*, reset_bootstrap: bool = True) -> None:
     if reset_bootstrap:
         _bootstrap_db_path = None
         _schema_db_path = None
+    _get_canonical_team_cached.cache_clear()
+    _resolve_team_alias_cached.cache_clear()
     _load_team_search_rows.cache_clear()
     _load_canonical_team_list_rows.cache_clear()
 
@@ -516,12 +518,28 @@ def resolve_team_alias(
         return None
 
     _ensure_bootstrapped()
+    return _resolve_team_alias_cached(
+        settings.db_path,
+        raw_key,
+        sport,
+        _normalize_bookmaker_key(bookmaker_id),
+    )
+
+
+@lru_cache(maxsize=65536)
+def _resolve_team_alias_cached(
+    db_path: str,
+    raw_key: str,
+    sport: str,
+    bookmaker_id: str,
+) -> TeamAliasResolution | None:
+    del db_path
     with _connect() as conn:
         return _find_resolution_by_exact_alias(
             conn,
             raw_key=raw_key,
             sport=sport,
-            bookmaker_id=_normalize_bookmaker_key(bookmaker_id),
+            bookmaker_id=bookmaker_id,
         )
 
 
@@ -810,6 +828,16 @@ def get_canonical_team(
     follow_merge: bool = False,
 ) -> CanonicalTeamSummary | None:
     _ensure_bootstrapped()
+    return _get_canonical_team_cached(settings.db_path, team_id, follow_merge)
+
+
+@lru_cache(maxsize=8192)
+def _get_canonical_team_cached(
+    db_path: str,
+    team_id: int,
+    follow_merge: bool,
+) -> CanonicalTeamSummary | None:
+    del db_path
     with _connect() as conn:
         team_row = _query_team_by_id(conn, team_id)
         if team_row is None and follow_merge:

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -811,43 +811,53 @@ def _resolved_event_row(event: ResolvedEventIn) -> tuple:
 async def upsert_resolved_events_bulk(events: list[ResolvedEventIn]) -> int:
     if not events:
         return 0
-    rows = [_resolved_event_row(event) for event in events]
     db = await get_db()
     await db.execute("BEGIN IMMEDIATE")
     try:
-        await db.executemany(
-            """INSERT INTO resolved_events (
-                   id,
-                   sport,
-                   start_time,
-                   primary_match_id,
-                   status,
-                   confidence,
-                   method,
-                   display_home_team,
-                   display_away_team,
-                   display_league_name,
-                   metadata
-               )
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-               ON CONFLICT(id) DO UPDATE SET
-                   sport = excluded.sport,
-                   start_time = excluded.start_time,
-                   primary_match_id = excluded.primary_match_id,
-                   status = excluded.status,
-                   confidence = excluded.confidence,
-                   method = excluded.method,
-                   display_home_team = excluded.display_home_team,
-                   display_away_team = excluded.display_away_team,
-                   display_league_name = excluded.display_league_name,
-                   metadata = excluded.metadata,
-                   updated_at = CURRENT_TIMESTAMP""",
-            rows,
-        )
+        count = await _upsert_resolved_events_bulk_tx(db, events)
         await db.commit()
     except Exception:
         await db.rollback()
         raise
+    return count
+
+
+async def _upsert_resolved_events_bulk_tx(
+    db: aiosqlite.Connection,
+    events: list[ResolvedEventIn],
+) -> int:
+    if not events:
+        return 0
+    rows = [_resolved_event_row(event) for event in events]
+    await db.executemany(
+        """INSERT INTO resolved_events (
+               id,
+               sport,
+               start_time,
+               primary_match_id,
+               status,
+               confidence,
+               method,
+               display_home_team,
+               display_away_team,
+               display_league_name,
+               metadata
+           )
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+               sport = excluded.sport,
+               start_time = excluded.start_time,
+               primary_match_id = excluded.primary_match_id,
+               status = excluded.status,
+               confidence = excluded.confidence,
+               method = excluded.method,
+               display_home_team = excluded.display_home_team,
+               display_away_team = excluded.display_away_team,
+               display_league_name = excluded.display_league_name,
+               metadata = excluded.metadata,
+               updated_at = CURRENT_TIMESTAMP""",
+        rows,
+    )
     return len(rows)
 
 
@@ -977,83 +987,93 @@ async def link_resolved_event_members_bulk(
 ) -> int:
     if not members:
         return 0
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        count = await _link_resolved_event_members_bulk_tx(db, members)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return count
+
+
+async def _link_resolved_event_members_bulk_tx(
+    db: aiosqlite.Connection,
+    members: list[ResolvedEventMemberIn],
+) -> int:
+    if not members:
+        return 0
     rows = [_resolved_event_member_row(member) for member in members]
     source_rows = [
         (member.match_id, member.bookmaker_id, member.source_url)
         for member in members
     ]
-    db = await get_db()
-    await db.execute("BEGIN IMMEDIATE")
-    try:
-        await db.executemany(
-            """INSERT INTO resolved_event_members (
-                   resolved_event_id,
-                   match_id,
-                   bookmaker_id,
-                   orientation,
-                   confidence,
-                   status,
-                   source_url,
-                   source_league_id,
-                   source_league_name,
-                   source_home_team,
-                   source_away_team,
-                   source_start_time,
-                   evidence,
-                   metadata
-               )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
-                    resolved_event_id = excluded.resolved_event_id,
-                    orientation = excluded.orientation,
-                    confidence = excluded.confidence,
-                   status = excluded.status,
-                   source_url = COALESCE(excluded.source_url, resolved_event_members.source_url),
-                   source_league_id = COALESCE(
-                       excluded.source_league_id,
-                       resolved_event_members.source_league_id
-                   ),
-                   source_league_name = COALESCE(
-                       excluded.source_league_name,
-                       resolved_event_members.source_league_name
-                   ),
-                   source_home_team = COALESCE(
-                       excluded.source_home_team,
-                       resolved_event_members.source_home_team
-                   ),
-                   source_away_team = COALESCE(
-                       excluded.source_away_team,
-                       resolved_event_members.source_away_team
-                   ),
-                   source_start_time = COALESCE(
-                       excluded.source_start_time,
-                       resolved_event_members.source_start_time
-                    ),
-                    evidence = excluded.evidence,
-                    metadata = excluded.metadata,
-                    updated_at = CURRENT_TIMESTAMP
-                WHERE NOT (
-                    EXISTS (
-                        SELECT 1
-                        FROM resolved_events existing_event
-                        WHERE existing_event.id = resolved_event_members.resolved_event_id
-                          AND existing_event.status = 'active'
-                          AND existing_event.method IN ('manual', 'manual_review')
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM resolved_events incoming_event
-                        WHERE incoming_event.id = excluded.resolved_event_id
-                          AND incoming_event.method IN ('manual', 'manual_review')
-                    )
-                )""",
-            rows,
-        )
-        await _upsert_match_bookmaker_sources_bulk_tx(db, source_rows)
-        await db.commit()
-    except Exception:
-        await db.rollback()
-        raise
+    await db.executemany(
+        """INSERT INTO resolved_event_members (
+               resolved_event_id,
+               match_id,
+               bookmaker_id,
+               orientation,
+               confidence,
+               status,
+               source_url,
+               source_league_id,
+               source_league_name,
+               source_home_team,
+               source_away_team,
+               source_start_time,
+               evidence,
+               metadata
+           )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
+                resolved_event_id = excluded.resolved_event_id,
+                orientation = excluded.orientation,
+                confidence = excluded.confidence,
+               status = excluded.status,
+               source_url = COALESCE(excluded.source_url, resolved_event_members.source_url),
+               source_league_id = COALESCE(
+                   excluded.source_league_id,
+                   resolved_event_members.source_league_id
+               ),
+               source_league_name = COALESCE(
+                   excluded.source_league_name,
+                   resolved_event_members.source_league_name
+               ),
+               source_home_team = COALESCE(
+                   excluded.source_home_team,
+                   resolved_event_members.source_home_team
+               ),
+               source_away_team = COALESCE(
+                   excluded.source_away_team,
+                   resolved_event_members.source_away_team
+               ),
+               source_start_time = COALESCE(
+                   excluded.source_start_time,
+                   resolved_event_members.source_start_time
+                ),
+                evidence = excluded.evidence,
+                metadata = excluded.metadata,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE NOT (
+                EXISTS (
+                    SELECT 1
+                    FROM resolved_events existing_event
+                    WHERE existing_event.id = resolved_event_members.resolved_event_id
+                      AND existing_event.status = 'active'
+                      AND existing_event.method IN ('manual', 'manual_review')
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM resolved_events incoming_event
+                    WHERE incoming_event.id = excluded.resolved_event_id
+                      AND incoming_event.method IN ('manual', 'manual_review')
+                )
+            )""",
+        rows,
+    )
+    await _upsert_match_bookmaker_sources_bulk_tx(db, source_rows)
     return len(rows)
 
 
@@ -1326,53 +1346,63 @@ def _event_review_case_row(case: EventReviewCaseIn) -> tuple:
 async def upsert_event_review_cases_bulk(cases: list[EventReviewCaseIn]) -> int:
     if not cases:
         return 0
-    rows = [_event_review_case_row(case) for case in cases]
     db = await get_db()
     await db.execute("BEGIN IMMEDIATE")
     try:
-        await db.executemany(
-            """INSERT INTO event_review_cases (
-                   fingerprint,
-                   sport,
-                   start_time,
-                   primary_match_id,
-                   candidate_resolved_event_id,
-                   candidate_match_ids,
-                   reason_code,
-                   confidence,
-                   method,
-                   source_bookmaker_ids,
-                   source_league_labels,
-                   evidence,
-                   metadata,
-                   status
-               )
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-               ON CONFLICT(fingerprint) DO UPDATE SET
-                   sport = excluded.sport,
-                   start_time = excluded.start_time,
-                   primary_match_id = excluded.primary_match_id,
-                   candidate_resolved_event_id = excluded.candidate_resolved_event_id,
-                   candidate_match_ids = excluded.candidate_match_ids,
-                   reason_code = excluded.reason_code,
-                   confidence = excluded.confidence,
-                   method = excluded.method,
-                   source_bookmaker_ids = excluded.source_bookmaker_ids,
-                   source_league_labels = excluded.source_league_labels,
-                   evidence = excluded.evidence,
-                   metadata = excluded.metadata,
-                   status = CASE
-                       WHEN event_review_cases.status IN ('accepted', 'declined')
-                       THEN event_review_cases.status
-                       ELSE excluded.status
-                   END,
-                   updated_at = CURRENT_TIMESTAMP""",
-            rows,
-        )
+        count = await _upsert_event_review_cases_bulk_tx(db, cases)
         await db.commit()
     except Exception:
         await db.rollback()
         raise
+    return count
+
+
+async def _upsert_event_review_cases_bulk_tx(
+    db: aiosqlite.Connection,
+    cases: list[EventReviewCaseIn],
+) -> int:
+    if not cases:
+        return 0
+    rows = [_event_review_case_row(case) for case in cases]
+    await db.executemany(
+        """INSERT INTO event_review_cases (
+               fingerprint,
+               sport,
+               start_time,
+               primary_match_id,
+               candidate_resolved_event_id,
+               candidate_match_ids,
+               reason_code,
+               confidence,
+               method,
+               source_bookmaker_ids,
+               source_league_labels,
+               evidence,
+               metadata,
+               status
+           )
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(fingerprint) DO UPDATE SET
+               sport = excluded.sport,
+               start_time = excluded.start_time,
+               primary_match_id = excluded.primary_match_id,
+               candidate_resolved_event_id = excluded.candidate_resolved_event_id,
+               candidate_match_ids = excluded.candidate_match_ids,
+               reason_code = excluded.reason_code,
+               confidence = excluded.confidence,
+               method = excluded.method,
+               source_bookmaker_ids = excluded.source_bookmaker_ids,
+               source_league_labels = excluded.source_league_labels,
+               evidence = excluded.evidence,
+               metadata = excluded.metadata,
+               status = CASE
+                   WHEN event_review_cases.status IN ('accepted', 'declined')
+                   THEN event_review_cases.status
+                   ELSE excluded.status
+               END,
+               updated_at = CURRENT_TIMESTAMP""",
+        rows,
+    )
     return len(rows)
 
 
@@ -3288,6 +3318,9 @@ async def deactivate_all_discrepancies() -> None:
 
 async def replace_cycle_outputs_and_activate_snapshot(
     *,
+    resolved_events: list[ResolvedEventIn],
+    resolved_event_members: list[ResolvedEventMemberIn],
+    event_review_cases: list[EventReviewCaseIn],
     odds: list[NormalizedOdds],
     outcome_offers: list[NormalizedOutcomeOffer],
     unresolved_odds: list[UnresolvedOddsDiagnostic],
@@ -3338,6 +3371,18 @@ async def replace_cycle_outputs_and_activate_snapshot(
     db = await get_db()
     await db.execute("BEGIN IMMEDIATE")
     try:
+        resolved_event_count = await _upsert_resolved_events_bulk_tx(
+            db,
+            resolved_events,
+        )
+        resolved_event_member_count = await _link_resolved_event_members_bulk_tx(
+            db,
+            resolved_event_members,
+        )
+        event_review_case_count = await _upsert_event_review_cases_bulk_tx(
+            db,
+            event_review_cases,
+        )
         odds_count = await _upsert_odds_bulk_tx(
             db,
             odds,
@@ -3389,6 +3434,9 @@ async def replace_cycle_outputs_and_activate_snapshot(
         await db.rollback()
         raise
     return {
+        "resolved_events": resolved_event_count,
+        "resolved_event_members": resolved_event_member_count,
+        "event_review_cases": event_review_case_count,
         "odds": odds_count,
         "outcome_offers": outcome_offer_count,
         "unresolved_odds": unresolved_count,

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -9,7 +9,7 @@ from typing import Optional
 import aiosqlite
 
 from ..config import settings
-from ..database import get_db
+from ..database import get_db, open_db_connection
 from ..models.schemas import (
     BookmakerOut,
     CanonicalOffer,
@@ -3368,71 +3368,74 @@ async def replace_cycle_outputs_and_activate_snapshot(
         for d in discrepancies
     ]
 
-    db = await get_db()
-    await db.execute("BEGIN IMMEDIATE")
+    db = await open_db_connection()
     try:
-        resolved_event_count = await _upsert_resolved_events_bulk_tx(
-            db,
-            resolved_events,
-        )
-        resolved_event_member_count = await _link_resolved_event_members_bulk_tx(
-            db,
-            resolved_event_members,
-        )
-        event_review_case_count = await _upsert_event_review_cases_bulk_tx(
-            db,
-            event_review_cases,
-        )
-        odds_count = await _upsert_odds_bulk_tx(
-            db,
-            odds,
-            scraped_at=snapshot_at,
-        )
-        outcome_offer_count = await _upsert_outcome_offers_bulk_tx(
-            db,
-            outcome_offers,
-            scraped_at=snapshot_at,
-        )
-        unresolved_count = await _insert_unresolved_odds_bulk_tx(
-            db,
-            unresolved_odds,
-            scraped_at=snapshot_at,
-        )
-        team_review_ids = await _insert_team_review_cases_bulk_tx(
-            db,
-            team_review_cases,
-            scraped_at=snapshot_at,
-        )
-        auto_review_ids = await _insert_team_review_cases_bulk_tx(
-            db,
-            auto_approved_team_reviews,
-            scraped_at=snapshot_at,
-            mark_approved=True,
-        )
-        await db.execute("UPDATE opportunities SET is_active = FALSE")
-        if opportunity_rows:
-            await db.executemany(
-                """INSERT INTO opportunities
-                   (sport, match_id, resolved_event_id, opportunity_type, market_type, line, profit_margin,
-                    middle_profit_margin, legs, detected_at, is_active)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE)""",
-                opportunity_rows,
+        await db.execute("BEGIN IMMEDIATE")
+        try:
+            resolved_event_count = await _upsert_resolved_events_bulk_tx(
+                db,
+                resolved_events,
             )
-        await db.execute("UPDATE discrepancies SET is_active = FALSE")
-        if discrepancy_rows:
-            await db.executemany(
-                """INSERT INTO discrepancies
-                   (match_id, resolved_event_id, market_type, player_name,
-                    bookmaker_a_id, bookmaker_a_match_id, bookmaker_b_id, bookmaker_b_match_id,
-                    threshold_a, threshold_b, odds_a, odds_b, gap, profit_margin, middle_profit_margin)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                discrepancy_rows,
+            resolved_event_member_count = await _link_resolved_event_members_bulk_tx(
+                db,
+                resolved_event_members,
             )
-        await _set_current_snapshot_tx(db, snapshot_at)
-        await db.commit()
-    except Exception:
-        await db.rollback()
-        raise
+            event_review_case_count = await _upsert_event_review_cases_bulk_tx(
+                db,
+                event_review_cases,
+            )
+            odds_count = await _upsert_odds_bulk_tx(
+                db,
+                odds,
+                scraped_at=snapshot_at,
+            )
+            outcome_offer_count = await _upsert_outcome_offers_bulk_tx(
+                db,
+                outcome_offers,
+                scraped_at=snapshot_at,
+            )
+            unresolved_count = await _insert_unresolved_odds_bulk_tx(
+                db,
+                unresolved_odds,
+                scraped_at=snapshot_at,
+            )
+            team_review_ids = await _insert_team_review_cases_bulk_tx(
+                db,
+                team_review_cases,
+                scraped_at=snapshot_at,
+            )
+            auto_review_ids = await _insert_team_review_cases_bulk_tx(
+                db,
+                auto_approved_team_reviews,
+                scraped_at=snapshot_at,
+                mark_approved=True,
+            )
+            await db.execute("UPDATE opportunities SET is_active = FALSE")
+            if opportunity_rows:
+                await db.executemany(
+                    """INSERT INTO opportunities
+                       (sport, match_id, resolved_event_id, opportunity_type, market_type, line, profit_margin,
+                        middle_profit_margin, legs, detected_at, is_active)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE)""",
+                    opportunity_rows,
+                )
+            await db.execute("UPDATE discrepancies SET is_active = FALSE")
+            if discrepancy_rows:
+                await db.executemany(
+                    """INSERT INTO discrepancies
+                       (match_id, resolved_event_id, market_type, player_name,
+                        bookmaker_a_id, bookmaker_a_match_id, bookmaker_b_id, bookmaker_b_match_id,
+                        threshold_a, threshold_b, odds_a, odds_b, gap, profit_margin, middle_profit_margin)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    discrepancy_rows,
+                )
+            await _set_current_snapshot_tx(db, snapshot_at)
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+    finally:
+        await db.close()
     return {
         "resolved_events": resolved_event_count,
         "resolved_event_members": resolved_event_member_count,

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -1804,6 +1804,54 @@ async def insert_opportunity(opportunity, *, detected_at: str) -> int:
     return cursor.lastrowid or 0
 
 
+async def insert_opportunities_bulk(opportunities, *, detected_at: str) -> int:
+    """Insert a batch of opportunities in a single transaction.
+
+    Equivalent to calling :func:`insert_opportunity` once per item but
+    issues a single ``BEGIN IMMEDIATE`` / ``executemany`` / ``commit``
+    instead of one round-trip-and-fsync per row.  A scrape cycle can
+    produce thousands of opportunities (especially after the basketball
+    handicap rollout), so the per-row path serialised the SQLite write
+    transaction for minutes; the bulk path collapses that to one short
+    transaction so the merge endpoints aren't blocked on
+    ``is_cycle_in_progress`` for the whole analyse phase.
+
+    Returns the number of rows inserted.
+    """
+    if not opportunities:
+        return 0
+    db = await get_db()
+    rows = [
+        (
+            opp.sport,
+            opp.match_id,
+            opp.resolved_event_id,
+            opp.opportunity_type,
+            opp.market_type,
+            opp.line,
+            opp.profit_margin,
+            opp.middle_profit_margin,
+            json.dumps([leg.model_dump() for leg in opp.legs]),
+            detected_at,
+        )
+        for opp in opportunities
+    ]
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT INTO opportunities
+               (sport, match_id, resolved_event_id, opportunity_type, market_type, line, profit_margin,
+                middle_profit_margin, legs, detected_at, is_active)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE)""",
+            rows,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
+
+
 def _row_to_opportunity(row: aiosqlite.Row) -> OpportunityOut:
     data = _row_to_dict(row)
     raw_legs = data.get("legs")
@@ -2233,6 +2281,62 @@ async def insert_discrepancy(
     )
     await db.commit()
     return cursor.lastrowid or 0
+
+
+async def insert_discrepancies_bulk(discrepancies) -> int:
+    """Insert a batch of analyzer-emitted discrepancies in one transaction.
+
+    Equivalent to calling :func:`insert_discrepancy` once per item but
+    issues a single ``BEGIN IMMEDIATE`` / ``executemany`` / ``commit``
+    instead of one fsync'd commit per row.  After the basketball
+    handicap rollout the analyzer routinely emits 100k+ rows per cycle,
+    which under the per-row path took 5–7 minutes and held the SQLite
+    write lock for the whole analyse phase — long enough for every
+    merge endpoint to keep returning 409 ``Cycle in progress``.
+
+    Falls back to the same column resolution as :func:`insert_discrepancy`,
+    including the ``bookmaker_*_match_id or match_id`` defaults.
+
+    Returns the number of rows inserted.
+    """
+    if not discrepancies:
+        return 0
+    db = await get_db()
+    rows = [
+        (
+            d.match_id,
+            d.resolved_event_id,
+            d.market_type,
+            d.player_name,
+            d.bookmaker_a_id,
+            d.bookmaker_a_match_id or d.match_id,
+            d.bookmaker_b_id,
+            d.bookmaker_b_match_id or d.match_id,
+            d.threshold_a,
+            d.threshold_b,
+            d.odds_a,
+            d.odds_b,
+            d.gap,
+            d.profit_margin,
+            d.middle_profit_margin,
+        )
+        for d in discrepancies
+    ]
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT INTO discrepancies
+               (match_id, resolved_event_id, market_type, player_name,
+                bookmaker_a_id, bookmaker_a_match_id, bookmaker_b_id, bookmaker_b_match_id,
+                threshold_a, threshold_b, odds_a, odds_b, gap, profit_margin, middle_profit_margin)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
 
 
 async def deactivate_all_discrepancies() -> None:

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -200,10 +200,44 @@ async def rollback_pending_transaction() -> None:
 async def upsert_bookmaker(id: str, name: str, website_url: str | None = None) -> None:
     db = await get_db()
     await db.execute(
-        "INSERT OR REPLACE INTO bookmakers (id, name, website_url) VALUES (?, ?, ?)",
+        """INSERT INTO bookmakers (id, name, website_url)
+           VALUES (?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+               name = excluded.name,
+               website_url = excluded.website_url,
+               is_active = TRUE""",
         (id, name, website_url),
     )
     await db.commit()
+
+
+async def upsert_bookmakers_bulk(
+    bookmakers: list[tuple[str, str, str | None]],
+) -> int:
+    if not bookmakers:
+        return 0
+    by_id: dict[str, tuple[str, str, str | None]] = {}
+    for bookmaker_id, name, website_url in bookmakers:
+        by_id[bookmaker_id] = (bookmaker_id, name, website_url)
+    deduped = list(by_id.values())
+
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT INTO bookmakers (id, name, website_url)
+               VALUES (?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                   name = excluded.name,
+                   website_url = excluded.website_url,
+                   is_active = TRUE""",
+            deduped,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(deduped)
 
 
 async def get_bookmakers(active_only: bool = True) -> list[BookmakerOut]:
@@ -220,10 +254,44 @@ async def get_bookmakers(active_only: bool = True) -> list[BookmakerOut]:
 async def upsert_league(id: str, name: str, sport: str, country: str | None = None) -> None:
     db = await get_db()
     await db.execute(
-        "INSERT OR REPLACE INTO leagues (id, name, sport, country) VALUES (?, ?, ?, ?)",
+        """INSERT INTO leagues (id, name, sport, country)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+               name = excluded.name,
+               sport = excluded.sport,
+               country = excluded.country,
+               is_active = TRUE""",
         (id, name, sport, country),
     )
     await db.commit()
+
+
+async def upsert_leagues_bulk(leagues: list[tuple[str, str, str, str | None]]) -> int:
+    if not leagues:
+        return 0
+    by_id: dict[str, tuple[str, str, str, str | None]] = {}
+    for league_id, name, sport, country in leagues:
+        by_id[league_id] = (league_id, name, sport, country)
+    rows = list(by_id.values())
+
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT INTO leagues (id, name, sport, country)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                   name = excluded.name,
+                   sport = excluded.sport,
+                   country = excluded.country,
+                   is_active = TRUE""",
+            rows,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
 
 
 async def get_leagues(sport: str | None = None) -> list[LeagueOut]:
@@ -242,6 +310,14 @@ async def get_leagues(sport: str | None = None) -> list[LeagueOut]:
 
 async def set_current_snapshot(snapshot_at: str) -> None:
     db = await get_db()
+    await _set_current_snapshot_tx(db, snapshot_at)
+    await db.commit()
+
+
+async def _set_current_snapshot_tx(
+    db: aiosqlite.Connection,
+    snapshot_at: str,
+) -> None:
     await db.execute(
         """INSERT INTO scrape_state (id, current_snapshot_at, updated_at)
            VALUES (1, ?, CURRENT_TIMESTAMP)
@@ -250,7 +326,6 @@ async def set_current_snapshot(snapshot_at: str) -> None:
                updated_at = CURRENT_TIMESTAMP""",
         (snapshot_at,),
     )
-    await db.commit()
 
 
 async def _get_current_snapshot_at(db: aiosqlite.Connection) -> str | None:
@@ -327,7 +402,7 @@ async def upsert_match(
     normalized_home_team_id = home_team_id if home_team_id and home_team_id > 0 else None
     normalized_away_team_id = away_team_id if away_team_id and away_team_id > 0 else None
     await db.execute(
-        """INSERT OR REPLACE INTO matches (
+        """INSERT INTO matches (
                id,
                league_id,
                sport,
@@ -338,7 +413,16 @@ async def upsert_match(
                start_time,
                status
            )
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+               league_id = excluded.league_id,
+               sport = excluded.sport,
+               home_team_id = excluded.home_team_id,
+               away_team_id = excluded.away_team_id,
+               home_team = excluded.home_team,
+               away_team = excluded.away_team,
+               start_time = excluded.start_time,
+               status = excluded.status""",
         (
             id,
             league_id,
@@ -352,6 +436,103 @@ async def upsert_match(
         ),
     )
     await db.commit()
+
+
+async def upsert_matches_bulk(
+    matches: list[
+        tuple[
+            str,
+            str,
+            str,
+            str,
+            str,
+            int | None,
+            int | None,
+            str | None,
+            str,
+        ]
+    ],
+) -> int:
+    if not matches:
+        return 0
+    by_id: dict[
+        str,
+        tuple[
+            str,
+            str,
+            str,
+            int | None,
+            int | None,
+            str,
+            str,
+            str | None,
+            str,
+        ],
+    ] = {}
+    for (
+        match_id,
+        league_id,
+        home_team,
+        away_team,
+        sport,
+        home_team_id,
+        away_team_id,
+        start_time,
+        status,
+    ) in matches:
+        if match_id in by_id:
+            continue
+        normalized_home_team_id = (
+            home_team_id if home_team_id and home_team_id > 0 else None
+        )
+        normalized_away_team_id = (
+            away_team_id if away_team_id and away_team_id > 0 else None
+        )
+        by_id[match_id] = (
+            match_id,
+            league_id,
+            sport,
+            normalized_home_team_id,
+            normalized_away_team_id,
+            home_team,
+            away_team,
+            start_time,
+            status,
+        )
+    rows = list(by_id.values())
+
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT INTO matches (
+                   id,
+                   league_id,
+                   sport,
+                   home_team_id,
+                   away_team_id,
+                   home_team,
+                   away_team,
+                   start_time,
+                   status
+               )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                   league_id = excluded.league_id,
+                   sport = excluded.sport,
+                   home_team_id = excluded.home_team_id,
+                   away_team_id = excluded.away_team_id,
+                   home_team = excluded.home_team,
+                   away_team = excluded.away_team,
+                   start_time = excluded.start_time,
+                   status = excluded.status""",
+            rows,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
 
 
 async def _upsert_match_bookmaker_source_tx(
@@ -369,6 +550,48 @@ async def _upsert_match_bookmaker_source_tx(
                 updated_at = CURRENT_TIMESTAMP""",
         (match_id, bookmaker_id, source_url),
     )
+
+
+async def _upsert_match_bookmaker_sources_bulk_tx(
+    db: aiosqlite.Connection,
+    sources: list[tuple[str, str, str | None]],
+) -> int:
+    if not sources:
+        return 0
+    by_key: dict[tuple[str, str], str | None] = {}
+    for match_id, bookmaker_id, source_url in sources:
+        key = (match_id, bookmaker_id)
+        if key not in by_key or source_url is not None:
+            by_key[key] = source_url
+    rows = [
+        (match_id, bookmaker_id, source_url)
+        for (match_id, bookmaker_id), source_url in by_key.items()
+    ]
+    await db.executemany(
+        """INSERT INTO match_bookmaker_sources (match_id, bookmaker_id, source_url)
+           VALUES (?, ?, ?)
+           ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
+                source_url = COALESCE(excluded.source_url, match_bookmaker_sources.source_url),
+                updated_at = CURRENT_TIMESTAMP""",
+        rows,
+    )
+    return len(rows)
+
+
+async def upsert_match_bookmaker_sources_bulk(
+    sources: list[tuple[str, str, str | None]],
+) -> int:
+    if not sources:
+        return 0
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        inserted = await _upsert_match_bookmaker_sources_bulk_tx(db, sources)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return inserted
 
 
 async def upsert_match_bookmaker_source(
@@ -562,6 +785,66 @@ async def upsert_resolved_event(event: ResolvedEventIn) -> str:
     return event_id
 
 
+def _resolved_event_row(event: ResolvedEventIn) -> tuple:
+    event_id = event.id or f"evt_{uuid.uuid4().hex}"
+    return (
+        event_id,
+        event.sport,
+        event.start_time,
+        event.primary_match_id,
+        event.status,
+        event.confidence,
+        event.method,
+        event.display_home_team,
+        event.display_away_team,
+        event.display_league_name,
+        json.dumps(event.metadata),
+    )
+
+
+async def upsert_resolved_events_bulk(events: list[ResolvedEventIn]) -> int:
+    if not events:
+        return 0
+    rows = [_resolved_event_row(event) for event in events]
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT INTO resolved_events (
+                   id,
+                   sport,
+                   start_time,
+                   primary_match_id,
+                   status,
+                   confidence,
+                   method,
+                   display_home_team,
+                   display_away_team,
+                   display_league_name,
+                   metadata
+               )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                   sport = excluded.sport,
+                   start_time = excluded.start_time,
+                   primary_match_id = excluded.primary_match_id,
+                   status = excluded.status,
+                   confidence = excluded.confidence,
+                   method = excluded.method,
+                   display_home_team = excluded.display_home_team,
+                   display_away_team = excluded.display_away_team,
+                   display_league_name = excluded.display_league_name,
+                   metadata = excluded.metadata,
+                   updated_at = CURRENT_TIMESTAMP""",
+            rows,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
+
+
 async def link_resolved_event_member(member: ResolvedEventMemberIn) -> int:
     db = await get_db()
     await db.execute("BEGIN IMMEDIATE")
@@ -662,6 +945,110 @@ async def link_resolved_event_member(member: ResolvedEventMemberIn) -> int:
         await db.rollback()
         raise
     return int(rows[0]["id"]) if rows else 0
+
+
+def _resolved_event_member_row(member: ResolvedEventMemberIn) -> tuple:
+    return (
+        member.resolved_event_id,
+        member.match_id,
+        member.bookmaker_id,
+        member.orientation,
+        member.confidence,
+        member.status,
+        member.source_url,
+        member.source_league_id,
+        member.source_league_name,
+        member.source_home_team,
+        member.source_away_team,
+        member.source_start_time,
+        json.dumps(member.evidence),
+        json.dumps(member.metadata),
+    )
+
+
+async def link_resolved_event_members_bulk(
+    members: list[ResolvedEventMemberIn],
+) -> int:
+    if not members:
+        return 0
+    rows = [_resolved_event_member_row(member) for member in members]
+    source_rows = [
+        (member.match_id, member.bookmaker_id, member.source_url)
+        for member in members
+    ]
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT INTO resolved_event_members (
+                   resolved_event_id,
+                   match_id,
+                   bookmaker_id,
+                   orientation,
+                   confidence,
+                   status,
+                   source_url,
+                   source_league_id,
+                   source_league_name,
+                   source_home_team,
+                   source_away_team,
+                   source_start_time,
+                   evidence,
+                   metadata
+               )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
+                    resolved_event_id = excluded.resolved_event_id,
+                    orientation = excluded.orientation,
+                    confidence = excluded.confidence,
+                   status = excluded.status,
+                   source_url = COALESCE(excluded.source_url, resolved_event_members.source_url),
+                   source_league_id = COALESCE(
+                       excluded.source_league_id,
+                       resolved_event_members.source_league_id
+                   ),
+                   source_league_name = COALESCE(
+                       excluded.source_league_name,
+                       resolved_event_members.source_league_name
+                   ),
+                   source_home_team = COALESCE(
+                       excluded.source_home_team,
+                       resolved_event_members.source_home_team
+                   ),
+                   source_away_team = COALESCE(
+                       excluded.source_away_team,
+                       resolved_event_members.source_away_team
+                   ),
+                   source_start_time = COALESCE(
+                       excluded.source_start_time,
+                       resolved_event_members.source_start_time
+                    ),
+                    evidence = excluded.evidence,
+                    metadata = excluded.metadata,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE NOT (
+                    EXISTS (
+                        SELECT 1
+                        FROM resolved_events existing_event
+                        WHERE existing_event.id = resolved_event_members.resolved_event_id
+                          AND existing_event.status = 'active'
+                          AND existing_event.method IN ('manual', 'manual_review')
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM resolved_events incoming_event
+                        WHERE incoming_event.id = excluded.resolved_event_id
+                          AND incoming_event.method IN ('manual', 'manual_review')
+                    )
+                )""",
+            rows,
+        )
+        await _upsert_match_bookmaker_sources_bulk_tx(db, source_rows)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
 
 
 async def get_resolved_event_members(
@@ -909,6 +1296,78 @@ async def upsert_event_review_case(case: EventReviewCaseIn) -> int:
         (case.fingerprint,),
     )
     return int(rows[0]["id"]) if rows else 0
+
+
+def _event_review_case_row(case: EventReviewCaseIn) -> tuple:
+    return (
+        case.fingerprint,
+        case.sport,
+        case.start_time,
+        case.primary_match_id,
+        case.candidate_resolved_event_id,
+        json.dumps(case.candidate_match_ids),
+        case.reason_code,
+        case.confidence,
+        case.method,
+        json.dumps(case.source_bookmaker_ids),
+        json.dumps(case.source_league_labels),
+        json.dumps(case.evidence),
+        json.dumps(case.metadata),
+        case.status,
+    )
+
+
+async def upsert_event_review_cases_bulk(cases: list[EventReviewCaseIn]) -> int:
+    if not cases:
+        return 0
+    rows = [_event_review_case_row(case) for case in cases]
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT INTO event_review_cases (
+                   fingerprint,
+                   sport,
+                   start_time,
+                   primary_match_id,
+                   candidate_resolved_event_id,
+                   candidate_match_ids,
+                   reason_code,
+                   confidence,
+                   method,
+                   source_bookmaker_ids,
+                   source_league_labels,
+                   evidence,
+                   metadata,
+                   status
+               )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(fingerprint) DO UPDATE SET
+                   sport = excluded.sport,
+                   start_time = excluded.start_time,
+                   primary_match_id = excluded.primary_match_id,
+                   candidate_resolved_event_id = excluded.candidate_resolved_event_id,
+                   candidate_match_ids = excluded.candidate_match_ids,
+                   reason_code = excluded.reason_code,
+                   confidence = excluded.confidence,
+                   method = excluded.method,
+                   source_bookmaker_ids = excluded.source_bookmaker_ids,
+                   source_league_labels = excluded.source_league_labels,
+                   evidence = excluded.evidence,
+                   metadata = excluded.metadata,
+                   status = CASE
+                       WHEN event_review_cases.status IN ('accepted', 'declined')
+                       THEN event_review_cases.status
+                       ELSE excluded.status
+                   END,
+                   updated_at = CURRENT_TIMESTAMP""",
+            rows,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
 
 
 async def get_event_review_case(
@@ -1606,6 +2065,83 @@ async def upsert_odds(odds: NormalizedOdds, *, scraped_at: str) -> int:
     return row[0] if row else 0
 
 
+def _odds_row(odds: NormalizedOdds, scraped_at: str) -> tuple:
+    return (
+        odds.match_id,
+        odds.bookmaker_id,
+        odds.market_type,
+        odds.player_name,
+        odds.threshold,
+        odds.over_odds,
+        odds.under_odds,
+        scraped_at,
+    )
+
+
+async def upsert_odds_bulk(
+    odds_list: list[NormalizedOdds],
+    *,
+    scraped_at: str,
+) -> int:
+    if not odds_list:
+        return 0
+    rows = [_odds_row(odds, scraped_at) for odds in odds_list]
+    source_rows = [
+        (odds.match_id, odds.bookmaker_id, odds.source_url)
+        for odds in odds_list
+    ]
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT OR REPLACE INTO odds
+               (match_id, bookmaker_id, market_type, player_name, threshold, over_odds, under_odds, scraped_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        await db.executemany(
+            """INSERT INTO odds_history
+               (match_id, bookmaker_id, market_type, player_name, threshold, over_odds, under_odds, scraped_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        await _upsert_match_bookmaker_sources_bulk_tx(db, source_rows)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
+
+
+async def _upsert_odds_bulk_tx(
+    db: aiosqlite.Connection,
+    odds_list: list[NormalizedOdds],
+    *,
+    scraped_at: str,
+) -> int:
+    if not odds_list:
+        return 0
+    rows = [_odds_row(odds, scraped_at) for odds in odds_list]
+    source_rows = [
+        (odds.match_id, odds.bookmaker_id, odds.source_url)
+        for odds in odds_list
+    ]
+    await db.executemany(
+        """INSERT OR REPLACE INTO odds
+           (match_id, bookmaker_id, market_type, player_name, threshold, over_odds, under_odds, scraped_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        rows,
+    )
+    await db.executemany(
+        """INSERT INTO odds_history
+           (match_id, bookmaker_id, market_type, player_name, threshold, over_odds, under_odds, scraped_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        rows,
+    )
+    await _upsert_match_bookmaker_sources_bulk_tx(db, source_rows)
+    return len(rows)
+
+
 async def get_odds_for_match(match_id: str) -> list[OddsOut]:
     db = await get_db()
     current_snapshot_at = await _get_current_snapshot_at(db)
@@ -1693,6 +2229,71 @@ async def upsert_outcome_offer(
         ),
     )
     return int(row[0]["id"]) if row else 0
+
+
+def _outcome_offer_row(offer: NormalizedOutcomeOffer, scraped_at: str) -> tuple:
+    return (
+        offer.match_id,
+        offer.bookmaker_id,
+        offer.market_type,
+        offer.outcome_code,
+        offer.line,
+        offer.odds,
+        offer.raw_label,
+        scraped_at,
+    )
+
+
+async def upsert_outcome_offers_bulk(
+    offers: list[NormalizedOutcomeOffer],
+    *,
+    scraped_at: str,
+) -> int:
+    if not offers:
+        return 0
+    rows = [_outcome_offer_row(offer, scraped_at) for offer in offers]
+    source_rows = [
+        (offer.match_id, offer.bookmaker_id, offer.source_url)
+        for offer in offers
+    ]
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT OR REPLACE INTO outcome_offers
+               (match_id, bookmaker_id, market_type, outcome_code, line, odds, raw_label, scraped_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        await _upsert_match_bookmaker_sources_bulk_tx(db, source_rows)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
+
+
+async def _upsert_outcome_offers_bulk_tx(
+    db: aiosqlite.Connection,
+    offers: list[NormalizedOutcomeOffer],
+    *,
+    scraped_at: str,
+) -> int:
+    if not offers:
+        return 0
+    rows = [_outcome_offer_row(offer, scraped_at) for offer in offers]
+    source_rows = [
+        (offer.match_id, offer.bookmaker_id, offer.source_url)
+        for offer in offers
+    ]
+    await db.executemany(
+        """INSERT OR REPLACE INTO outcome_offers
+           (match_id, bookmaker_id, market_type, outcome_code, line, odds, raw_label, scraped_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        rows,
+    )
+    await _upsert_match_bookmaker_sources_bulk_tx(db, source_rows)
+    return len(rows)
 
 
 async def get_outcome_offers(
@@ -2007,6 +2608,79 @@ async def insert_unresolved_odds(
     return cursor.lastrowid or 0
 
 
+def _unresolved_odds_row(
+    unresolved: UnresolvedOddsDiagnostic,
+    scraped_at: str,
+) -> tuple:
+    return (
+        unresolved.bookmaker_id,
+        unresolved.raw_league_id,
+        unresolved.league_id,
+        unresolved.sport,
+        unresolved.market_type,
+        unresolved.player_name,
+        unresolved.raw_team_name,
+        unresolved.normalized_team_name,
+        unresolved.start_time,
+        unresolved.threshold,
+        unresolved.over_odds,
+        unresolved.under_odds,
+        unresolved.reason_code,
+        unresolved.candidate_count,
+        json.dumps(unresolved.candidate_matchups),
+        json.dumps(unresolved.available_matchups_same_slot),
+        scraped_at,
+    )
+
+
+async def insert_unresolved_odds_bulk(
+    unresolved_odds: list[UnresolvedOddsDiagnostic],
+    *,
+    scraped_at: str,
+) -> int:
+    if not unresolved_odds:
+        return 0
+    rows = [_unresolved_odds_row(unresolved, scraped_at) for unresolved in unresolved_odds]
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        await db.executemany(
+            """INSERT INTO unresolved_odds
+               (bookmaker_id, raw_league_id, league_id, sport, market_type, player_name,
+                raw_team_name, normalized_team_name, start_time, threshold, over_odds,
+                under_odds, reason_code, candidate_count, candidate_matchups,
+                available_matchups_same_slot, scraped_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return len(rows)
+
+
+async def _insert_unresolved_odds_bulk_tx(
+    db: aiosqlite.Connection,
+    unresolved_odds: list[UnresolvedOddsDiagnostic],
+    *,
+    scraped_at: str,
+) -> int:
+    if not unresolved_odds:
+        return 0
+    rows = [_unresolved_odds_row(unresolved, scraped_at) for unresolved in unresolved_odds]
+    await db.executemany(
+        """INSERT INTO unresolved_odds
+           (bookmaker_id, raw_league_id, league_id, sport, market_type, player_name,
+            raw_team_name, normalized_team_name, start_time, threshold, over_odds,
+            under_odds, reason_code, candidate_count, candidate_matchups,
+            available_matchups_same_slot, scraped_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        rows,
+    )
+    return len(rows)
+
+
 async def get_unresolved_odds(
     bookmaker_ids: list[str] | None = None,
     reason_code: str | None = None,
@@ -2114,6 +2788,145 @@ async def insert_team_review_case(
     )
     await db.commit()
     return cursor.lastrowid or 0
+
+
+def _team_review_case_row(
+    case: TeamReviewDiagnostic,
+    scraped_at: str,
+) -> tuple:
+    return (
+        case.bookmaker_id,
+        case.raw_league_id,
+        case.normalized_raw_league_id,
+        case.sport,
+        case.scope_league_id,
+        case.raw_team_name,
+        case.normalized_raw_team_name,
+        case.suggested_team_id,
+        case.suggested_team_name,
+        case.start_time,
+        case.review_kind,
+        case.reason_code,
+        case.confidence,
+        case.similarity_score,
+        json.dumps([candidate.model_dump() for candidate in case.candidate_teams]),
+        case.matched_counterpart_team,
+        case.canonical_home_team,
+        case.canonical_away_team,
+        json.dumps(case.evidence),
+        case.status,
+        scraped_at,
+    )
+
+
+async def insert_team_review_cases_bulk(
+    cases: list[TeamReviewDiagnostic],
+    *,
+    scraped_at: str,
+    mark_approved: bool = False,
+) -> list[int]:
+    if not cases:
+        return []
+    db = await get_db()
+    inserted_ids: list[int] = []
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        for case in cases:
+            cursor = await db.execute(
+                """INSERT INTO team_review_cases
+                   (
+                       bookmaker_id,
+                       raw_league_id,
+                       normalized_raw_league_id,
+                       sport,
+                       scope_league_id,
+                       raw_team_name,
+                       normalized_raw_team_name,
+                       suggested_team_id,
+                       suggested_team_name,
+                       start_time,
+                       review_kind,
+                       reason_code,
+                       confidence,
+                       similarity_score,
+                       candidate_teams,
+                       matched_counterpart_team,
+                       canonical_home_team,
+                       canonical_away_team,
+                       evidence,
+                       status,
+                       scraped_at
+                   )
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                _team_review_case_row(case, scraped_at),
+            )
+            if cursor.lastrowid is not None:
+                inserted_ids.append(int(cursor.lastrowid))
+        if mark_approved and inserted_ids:
+            await db.executemany(
+                """UPDATE team_review_cases
+                   SET status = 'approved',
+                       approved_at = COALESCE(approved_at, CURRENT_TIMESTAMP)
+                   WHERE id = ?""",
+                [(case_id,) for case_id in inserted_ids],
+            )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return inserted_ids
+
+
+async def _insert_team_review_cases_bulk_tx(
+    db: aiosqlite.Connection,
+    cases: list[TeamReviewDiagnostic],
+    *,
+    scraped_at: str,
+    mark_approved: bool = False,
+) -> list[int]:
+    if not cases:
+        return []
+    inserted_ids: list[int] = []
+    for case in cases:
+        cursor = await db.execute(
+            """INSERT INTO team_review_cases
+               (
+                   bookmaker_id,
+                   raw_league_id,
+                   normalized_raw_league_id,
+                   sport,
+                   scope_league_id,
+                   raw_team_name,
+                   normalized_raw_team_name,
+                   suggested_team_id,
+                   suggested_team_name,
+                   start_time,
+                   review_kind,
+                   reason_code,
+                   confidence,
+                   similarity_score,
+                   candidate_teams,
+                   matched_counterpart_team,
+                   canonical_home_team,
+                   canonical_away_team,
+                   evidence,
+                   status,
+                   scraped_at
+               )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            _team_review_case_row(case, scraped_at),
+        )
+        if cursor.lastrowid is not None:
+            inserted_ids.append(int(cursor.lastrowid))
+    if mark_approved and inserted_ids:
+        await db.executemany(
+            """UPDATE team_review_cases
+               SET status = 'approved',
+                   approved_at = COALESCE(approved_at, CURRENT_TIMESTAMP)
+               WHERE id = ?""",
+            [(case_id,) for case_id in inserted_ids],
+        )
+    return inserted_ids
 
 
 async def get_team_review_cases(
@@ -2343,6 +3156,118 @@ async def deactivate_all_discrepancies() -> None:
     db = await get_db()
     await db.execute("UPDATE discrepancies SET is_active = FALSE")
     await db.commit()
+
+
+async def replace_cycle_outputs_and_activate_snapshot(
+    *,
+    odds: list[NormalizedOdds],
+    outcome_offers: list[NormalizedOutcomeOffer],
+    unresolved_odds: list[UnresolvedOddsDiagnostic],
+    team_review_cases: list[TeamReviewDiagnostic],
+    auto_approved_team_reviews: list[TeamReviewDiagnostic],
+    opportunities,
+    discrepancies,
+    detected_at: str,
+    snapshot_at: str,
+) -> dict[str, int]:
+    """Atomically swap active analyzer output and expose the new snapshot."""
+    opportunity_rows = [
+        (
+            opp.sport,
+            opp.match_id,
+            opp.resolved_event_id,
+            opp.opportunity_type,
+            opp.market_type,
+            opp.line,
+            opp.profit_margin,
+            opp.middle_profit_margin,
+            json.dumps([leg.model_dump() for leg in opp.legs]),
+            detected_at,
+        )
+        for opp in opportunities
+    ]
+    discrepancy_rows = [
+        (
+            d.match_id,
+            d.resolved_event_id,
+            d.market_type,
+            d.player_name,
+            d.bookmaker_a_id,
+            d.bookmaker_a_match_id or d.match_id,
+            d.bookmaker_b_id,
+            d.bookmaker_b_match_id or d.match_id,
+            d.threshold_a,
+            d.threshold_b,
+            d.odds_a,
+            d.odds_b,
+            d.gap,
+            d.profit_margin,
+            d.middle_profit_margin,
+        )
+        for d in discrepancies
+    ]
+
+    db = await get_db()
+    await db.execute("BEGIN IMMEDIATE")
+    try:
+        odds_count = await _upsert_odds_bulk_tx(
+            db,
+            odds,
+            scraped_at=snapshot_at,
+        )
+        outcome_offer_count = await _upsert_outcome_offers_bulk_tx(
+            db,
+            outcome_offers,
+            scraped_at=snapshot_at,
+        )
+        unresolved_count = await _insert_unresolved_odds_bulk_tx(
+            db,
+            unresolved_odds,
+            scraped_at=snapshot_at,
+        )
+        team_review_ids = await _insert_team_review_cases_bulk_tx(
+            db,
+            team_review_cases,
+            scraped_at=snapshot_at,
+        )
+        auto_review_ids = await _insert_team_review_cases_bulk_tx(
+            db,
+            auto_approved_team_reviews,
+            scraped_at=snapshot_at,
+            mark_approved=True,
+        )
+        await db.execute("UPDATE opportunities SET is_active = FALSE")
+        if opportunity_rows:
+            await db.executemany(
+                """INSERT INTO opportunities
+                   (sport, match_id, resolved_event_id, opportunity_type, market_type, line, profit_margin,
+                    middle_profit_margin, legs, detected_at, is_active)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE)""",
+                opportunity_rows,
+            )
+        await db.execute("UPDATE discrepancies SET is_active = FALSE")
+        if discrepancy_rows:
+            await db.executemany(
+                """INSERT INTO discrepancies
+                   (match_id, resolved_event_id, market_type, player_name,
+                    bookmaker_a_id, bookmaker_a_match_id, bookmaker_b_id, bookmaker_b_match_id,
+                    threshold_a, threshold_b, odds_a, odds_b, gap, profit_margin, middle_profit_margin)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                discrepancy_rows,
+            )
+        await _set_current_snapshot_tx(db, snapshot_at)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return {
+        "odds": odds_count,
+        "outcome_offers": outcome_offer_count,
+        "unresolved_odds": unresolved_count,
+        "team_review_cases": len(team_review_ids) + len(auto_review_ids),
+        "opportunities": len(opportunity_rows),
+        "discrepancies": len(discrepancy_rows),
+    }
 
 
 async def get_discrepancies(

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -684,17 +684,14 @@ async def test_scheduler_run_cycle_keeps_previous_snapshot_if_store_fails_mid_ba
     )
     await odds_store.set_current_snapshot("2026-04-10T13:39:04.516801")
 
-    original_upsert_odds = odds_store.upsert_odds
-    call_count = 0
+    async def failing_set_current_snapshot_tx(db, snapshot_at):
+        raise RuntimeError("simulated store failure")
 
-    async def failing_upsert_odds(odds, *, scraped_at):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 2:
-            raise RuntimeError("simulated store failure")
-        return await original_upsert_odds(odds, scraped_at=scraped_at)
-
-    monkeypatch.setattr(odds_store, "upsert_odds", failing_upsert_odds)
+    monkeypatch.setattr(
+        odds_store,
+        "_set_current_snapshot_tx",
+        failing_set_current_snapshot_tx,
+    )
 
     _register_test_scrapers(
         StubScraper(
@@ -733,11 +730,12 @@ async def test_scheduler_run_cycle_keeps_previous_snapshot_if_store_fails_mid_ba
     with pytest.raises(RuntimeError, match="simulated store failure"):
         await Scheduler(interval_minutes=1).run_cycle()
 
-    matches = await odds_store.get_matches(limit=10)
     status = await odds_store.get_system_status()
+    current = await odds_store.get_odds_for_match("old")
 
-    assert [match.id for match in matches] == ["old"]
     assert status.last_scrape_at == "2026-04-10T13:39:04.516801"
+    assert len(current) == 1
+    assert current[0].over_odds == 1.8
 
 
 @pytest.mark.asyncio
@@ -1493,17 +1491,14 @@ async def test_scheduler_run_cycle_rolls_back_auto_saved_alias_if_store_fails(
         ),
     )
 
-    original_upsert_odds = odds_store.upsert_odds
-    call_count = 0
+    async def failing_replace_cycle_outputs_and_activate_snapshot(**kwargs):
+        raise RuntimeError("simulated store failure")
 
-    async def failing_upsert_odds(odds, *, scraped_at):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 2:
-            raise RuntimeError("simulated store failure")
-        return await original_upsert_odds(odds, scraped_at=scraped_at)
-
-    monkeypatch.setattr(odds_store, "upsert_odds", failing_upsert_odds)
+    monkeypatch.setattr(
+        odds_store,
+        "replace_cycle_outputs_and_activate_snapshot",
+        failing_replace_cycle_outputs_and_activate_snapshot,
+    )
 
     with pytest.raises(RuntimeError, match="simulated store failure"):
         await Scheduler(interval_minutes=1).run_cycle()
@@ -1570,17 +1565,14 @@ async def test_scheduler_run_cycle_rolls_back_auto_merge_if_store_fails(
         ),
     )
 
-    original_upsert_odds = odds_store.upsert_odds
-    call_count = 0
+    async def failing_replace_cycle_outputs_and_activate_snapshot(**kwargs):
+        raise RuntimeError("simulated store failure")
 
-    async def failing_upsert_odds(odds, *, scraped_at):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 2:
-            raise RuntimeError("simulated store failure")
-        return await original_upsert_odds(odds, scraped_at=scraped_at)
-
-    monkeypatch.setattr(odds_store, "upsert_odds", failing_upsert_odds)
+    monkeypatch.setattr(
+        odds_store,
+        "replace_cycle_outputs_and_activate_snapshot",
+        failing_replace_cycle_outputs_and_activate_snapshot,
+    )
 
     with pytest.raises(RuntimeError, match="simulated store failure"):
         await Scheduler(interval_minutes=1).run_cycle()
@@ -1607,17 +1599,17 @@ async def test_scheduler_run_cycle_ignores_unsnapshotted_review_history_for_auto
     )
     await odds_store.set_current_snapshot("2020-01-01T00:00:00+00:00")
 
-    original_set_current_snapshot = odds_store.set_current_snapshot
+    original_set_current_snapshot_tx = odds_store._set_current_snapshot_tx
     call_count = 0
 
-    async def flaky_set_current_snapshot(snapshot_at: str) -> None:
+    async def flaky_set_current_snapshot_tx(db, snapshot_at: str) -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             raise RuntimeError("simulated snapshot failure")
-        await original_set_current_snapshot(snapshot_at)
+        await original_set_current_snapshot_tx(db, snapshot_at)
 
-    monkeypatch.setattr(odds_store, "set_current_snapshot", flaky_set_current_snapshot)
+    monkeypatch.setattr(odds_store, "_set_current_snapshot_tx", flaky_set_current_snapshot_tx)
 
     with pytest.raises(RuntimeError, match="simulated snapshot failure"):
         await Scheduler(interval_minutes=1).run_cycle()

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -739,6 +739,36 @@ async def test_scheduler_run_cycle_keeps_previous_snapshot_if_store_fails_mid_ba
 
 
 @pytest.mark.asyncio
+async def test_scheduler_run_cycle_rolls_back_event_resolution_if_snapshot_fails(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _register_test_scrapers(
+        StubScraper(
+            "mozzart",
+            payload_by_league={"euroleague": [_raw_odds("mozzart", 10.5)]},
+        ),
+        StubScraper(
+            "maxbet",
+            payload_by_league={"euroleague": [_raw_odds("maxbet", 12.5)]},
+        ),
+    )
+
+    async def failing_set_current_snapshot_tx(db, snapshot_at):
+        raise RuntimeError("simulated snapshot failure")
+
+    monkeypatch.setattr(
+        odds_store,
+        "_set_current_snapshot_tx",
+        failing_set_current_snapshot_tx,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated snapshot failure"):
+        await Scheduler(interval_minutes=1).run_cycle()
+
+    assert await odds_store.list_resolved_events() == []
+
+
+@pytest.mark.asyncio
 async def test_scheduler_run_cycle_auto_saves_anchored_alias_same_scrape():
     _register_test_scrapers(
         StubScraper(

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -1781,6 +1781,36 @@ async def test_replace_cycle_outputs_and_snapshot_rolls_back_atomically_on_failu
 
     with pytest.raises(Exception):
         await odds_store.replace_cycle_outputs_and_activate_snapshot(
+            resolved_events=[
+                ResolvedEventIn(
+                    id="evt-new",
+                    sport="basketball",
+                    start_time="2030-01-01T20:00:00+00:00",
+                    primary_match_id="new",
+                    confidence=0.99,
+                    method="exact",
+                )
+            ],
+            resolved_event_members=[
+                ResolvedEventMemberIn(
+                    resolved_event_id="evt-new",
+                    match_id="new",
+                    bookmaker_id="maxbet",
+                    confidence=0.99,
+                )
+            ],
+            event_review_cases=[
+                EventReviewCaseIn(
+                    fingerprint="event-review-new",
+                    sport="basketball",
+                    start_time="2030-01-01T20:00:00+00:00",
+                    primary_match_id="new",
+                    candidate_resolved_event_id="evt-new",
+                    candidate_match_ids=["new"],
+                    reason_code="candidate_event_equivalence",
+                    source_bookmaker_ids=["maxbet"],
+                )
+            ],
             odds=[
                 NormalizedOdds(
                     match_id="old",
@@ -1852,6 +1882,8 @@ async def test_replace_cycle_outputs_and_snapshot_rolls_back_atomically_on_failu
     current = await odds_store.get_odds_for_match("old")
     assert len(current) == 1
     assert current[0].over_odds == 1.8
+    assert await odds_store.get_resolved_event("evt-new") is None
+    assert await odds_store.get_event_review_case_by_fingerprint("event-review-new") is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -11,6 +11,9 @@ from app.database import close_db, get_db, init_db
 from app.models.schemas import (
     EventReviewCaseIn,
     NormalizedOdds,
+    NormalizedOutcomeOffer,
+    ResolvedEventIn,
+    ResolvedEventMemberIn,
     TeamReviewDiagnostic,
     UnresolvedOddsDiagnostic,
 )
@@ -1465,3 +1468,392 @@ async def test_insert_opportunities_bulk_handles_empty_input():
         [], detected_at="2026-05-02T16:00:00+00:00"
     )
     assert inserted == 0
+
+
+@pytest.mark.asyncio
+async def test_replace_cycle_outputs_and_snapshot_rolls_back_atomically_on_failure():
+    from dataclasses import dataclass
+
+    from app.models.schemas import OpportunityLeg
+    from app.services.opportunity_analyzer import Opportunity
+
+    @dataclass
+    class _DiscrepancyRow:
+        match_id: str
+        resolved_event_id: str | None
+        market_type: str
+        player_name: str | None
+        bookmaker_a_id: str
+        bookmaker_a_match_id: str | None
+        bookmaker_b_id: str
+        bookmaker_b_match_id: str | None
+        threshold_a: float
+        threshold_b: float
+        odds_a: float | None
+        odds_b: float | None
+        gap: float
+        profit_margin: float | None
+        middle_profit_margin: float | None
+
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_match("old", "euroleague", "Partizan", "Crvena Zvezda")
+    await odds_store.upsert_match("new", "euroleague", "Bayern", "Real Madrid")
+    await odds_store.upsert_odds(
+        NormalizedOdds(
+            match_id="old",
+            bookmaker_id="mozzart",
+            league_id="euroleague",
+            home_team="Partizan",
+            away_team="Crvena Zvezda",
+            market_type="player_points",
+            player_name="Old Player",
+            threshold=10.5,
+            over_odds=1.8,
+            under_odds=2.0,
+        ),
+        scraped_at="old-snapshot",
+    )
+    await odds_store.set_current_snapshot("old-snapshot")
+    await odds_store.insert_discrepancy(
+        "old",
+        "player_points",
+        "Old Player",
+        "mozzart",
+        "maxbet",
+        10.5,
+        12.5,
+        1.8,
+        1.9,
+        2.0,
+        0.02,
+    )
+    await odds_store.insert_opportunity(
+        Opportunity(
+            sport="basketball",
+            match_id="old",
+            opportunity_type="test",
+            market_type="player_points",
+            line=10.5,
+            profit_margin=0.02,
+            middle_profit_margin=None,
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="mozzart",
+                    market_type="player_points",
+                    outcome_code="over",
+                    odds=1.8,
+                    line=10.5,
+                )
+            ],
+        ),
+        detected_at="old-snapshot",
+    )
+
+    with pytest.raises(Exception):
+        await odds_store.replace_cycle_outputs_and_activate_snapshot(
+            odds=[
+                NormalizedOdds(
+                    match_id="old",
+                    bookmaker_id="mozzart",
+                    league_id="euroleague",
+                    home_team="Partizan",
+                    away_team="Crvena Zvezda",
+                    market_type="player_points",
+                    player_name="Old Player",
+                    threshold=10.5,
+                    over_odds=1.7,
+                    under_odds=2.1,
+                )
+            ],
+            outcome_offers=[],
+            unresolved_odds=[],
+            team_review_cases=[],
+            auto_approved_team_reviews=[],
+            opportunities=[
+                Opportunity(
+                    sport="basketball",
+                    match_id="new",
+                    opportunity_type="test",
+                    market_type="player_points",
+                    line=12.5,
+                    profit_margin=0.03,
+                    middle_profit_margin=None,
+                    legs=[
+                        OpportunityLeg(
+                            bookmaker_id="maxbet",
+                            market_type="player_points",
+                            outcome_code="under",
+                            odds=1.9,
+                            line=12.5,
+                        )
+                    ],
+                )
+            ],
+            discrepancies=[
+                _DiscrepancyRow(
+                    match_id="missing-match",
+                    resolved_event_id=None,
+                    market_type="player_points",
+                    player_name="Broken",
+                    bookmaker_a_id="mozzart",
+                    bookmaker_a_match_id=None,
+                    bookmaker_b_id="maxbet",
+                    bookmaker_b_match_id=None,
+                    threshold_a=10.5,
+                    threshold_b=12.5,
+                    odds_a=1.8,
+                    odds_b=1.9,
+                    gap=2.0,
+                    profit_margin=0.03,
+                    middle_profit_margin=None,
+                )
+            ],
+            detected_at="new-snapshot",
+            snapshot_at="new-snapshot",
+        )
+
+    status = await odds_store.get_system_status()
+    discrepancies = await odds_store.get_discrepancies()
+    opportunities = await odds_store.get_opportunities()
+
+    assert status.last_scrape_at == "old-snapshot"
+    assert [d.match_id for d in discrepancies] == ["old"]
+    assert [o.match_id for o in opportunities] == ["old"]
+    current = await odds_store.get_odds_for_match("old")
+    assert len(current) == 1
+    assert current[0].over_odds == 1.8
+
+
+@pytest.mark.asyncio
+async def test_upsert_odds_bulk_writes_current_history_and_sources():
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_match("m1", "euroleague", "Partizan", "Crvena Zvezda")
+    await odds_store.upsert_odds(
+        NormalizedOdds(
+            match_id="m1",
+            bookmaker_id="mozzart",
+            league_id="euroleague",
+            home_team="Partizan",
+            away_team="Crvena Zvezda",
+            source_url="https://example.com/original",
+            market_type="player_points",
+            player_name="Iffe Lundberg",
+            threshold=16.5,
+            over_odds=1.85,
+            under_odds=1.95,
+        ),
+        scraped_at="2026-05-02T15:00:00+00:00",
+    )
+
+    inserted = await odds_store.upsert_odds_bulk(
+        [
+            NormalizedOdds(
+                match_id="m1",
+                bookmaker_id="mozzart",
+                league_id="euroleague",
+                home_team="Partizan",
+                away_team="Crvena Zvezda",
+                source_url=None,
+                market_type="player_points",
+                player_name="Iffe Lundberg",
+                threshold=16.5,
+                over_odds=1.90,
+                under_odds=1.90,
+            ),
+            NormalizedOdds(
+                match_id="m1",
+                bookmaker_id="mozzart",
+                league_id="euroleague",
+                home_team="Partizan",
+                away_team="Crvena Zvezda",
+                source_url="https://example.com/handicap",
+                market_type="home_handicap_ot",
+                threshold=-4.5,
+                over_odds=1.85,
+                under_odds=1.95,
+            ),
+        ],
+        scraped_at="2026-05-02T16:00:00+00:00",
+    )
+    await odds_store.set_current_snapshot("2026-05-02T16:00:00+00:00")
+
+    assert inserted == 2
+    current = await odds_store.get_odds_for_match("m1")
+    assert {(row.market_type, row.player_name, row.threshold) for row in current} == {
+        ("player_points", "Iffe Lundberg", 16.5),
+        ("home_handicap_ot", None, -4.5),
+    }
+    player_row = next(row for row in current if row.market_type == "player_points")
+    assert player_row.over_odds == 1.90
+    assert player_row.source_url == "https://example.com/handicap"
+
+    db = await get_db()
+    history_count = await db.execute_fetchall(
+        "SELECT COUNT(*) AS count FROM odds_history WHERE match_id = ?",
+        ("m1",),
+    )
+    assert history_count[0]["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_upsert_outcome_offers_bulk_preserves_nullable_line_uniqueness():
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_league("premier_league", "Premier League", "football")
+    await odds_store.upsert_match("f1", "premier_league", "Arsenal", "Chelsea", sport="football")
+
+    inserted = await odds_store.upsert_outcome_offers_bulk(
+        [
+            NormalizedOutcomeOffer(
+                match_id="f1",
+                bookmaker_id="mozzart",
+                league_id="premier_league",
+                sport="football",
+                home_team="Arsenal",
+                away_team="Chelsea",
+                source_url="https://example.com/f1",
+                market_type="football_result",
+                outcome_code="home",
+                odds=2.05,
+                line=None,
+                raw_label="1",
+            ),
+            NormalizedOutcomeOffer(
+                match_id="f1",
+                bookmaker_id="mozzart",
+                league_id="premier_league",
+                sport="football",
+                home_team="Arsenal",
+                away_team="Chelsea",
+                source_url="https://example.com/f1",
+                market_type="football_total",
+                outcome_code="over",
+                odds=1.95,
+                line=2.5,
+                raw_label="2.5+",
+            ),
+        ],
+        scraped_at="2026-05-02T16:00:00+00:00",
+    )
+    await odds_store.set_current_snapshot("2026-05-02T16:00:00+00:00")
+
+    assert inserted == 2
+    offers = await odds_store.get_outcome_offers(match_id="f1")
+    assert {(offer.market_type, offer.outcome_code, offer.line) for offer in offers} == {
+        ("football_result", "home", None),
+        ("football_total", "over", 2.5),
+    }
+    assert {offer.source_url for offer in offers} == {"https://example.com/f1"}
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_bulk_inserts_match_per_row_visibility():
+    await odds_store.upsert_bookmaker("admiralbet", "AdmiralBet")
+    await odds_store.upsert_league("aba_liga", "ABA Liga", "basketball")
+    scraped_at = "2026-05-02T16:00:00+00:00"
+
+    unresolved_inserted = await odds_store.insert_unresolved_odds_bulk(
+        [
+            UnresolvedOddsDiagnostic(
+                bookmaker_id="admiralbet",
+                raw_league_id="AdmiralBet ABA Liga",
+                league_id="aba_liga",
+                market_type="player_points",
+                player_name="P. Nikolic",
+                raw_team_name="Borac Cacak",
+                normalized_team_name="Borac Cacak",
+                start_time="2026-05-02T16:00:00+00:00",
+                threshold=10.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                reason_code="no_canonical_matchup_for_team_at_slot",
+                candidate_count=0,
+                available_matchups_same_slot=["Dubai vs Buducnost"],
+            )
+        ],
+        scraped_at=scraped_at,
+    )
+    approved_ids = await odds_store.insert_team_review_cases_bulk(
+        [
+            TeamReviewDiagnostic(
+                bookmaker_id="admiralbet",
+                raw_league_id="aba_liga",
+                normalized_raw_league_id="aba_liga",
+                scope_league_id="aba_liga",
+                raw_team_name="Borac",
+                normalized_raw_team_name="borac",
+                start_time="2026-05-02T16:00:00+00:00",
+                reason_code="candidate_team_match_same_start_time",
+                matched_counterpart_team="Dubai",
+                canonical_home_team="Borac",
+                canonical_away_team="Dubai",
+            )
+        ],
+        scraped_at=scraped_at,
+        mark_approved=True,
+    )
+    await odds_store.set_current_snapshot(scraped_at)
+
+    assert unresolved_inserted == 1
+    assert len(approved_ids) == 1
+    unresolved = await odds_store.get_unresolved_odds()
+    assert len(unresolved) == 1
+    assert unresolved[0].available_matchups_same_slot == ["Dubai vs Buducnost"]
+    reviews = await odds_store.get_team_review_cases(status="approved")
+    assert len(reviews) == 1
+    assert reviews[0].raw_team_name == "Borac"
+
+
+@pytest.mark.asyncio
+async def test_link_resolved_event_members_bulk_preserves_manual_member():
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_match("m1", "euroleague", "Partizan", "Crvena Zvezda")
+    await odds_store.upsert_match("m2", "euroleague", "Partizan", "Crvena Zvezda")
+    await odds_store.upsert_resolved_event(
+        ResolvedEventIn(
+            id="evt_manual",
+            sport="basketball",
+            start_time="2026-05-02T16:00:00+00:00",
+            primary_match_id="m1",
+            method="manual",
+        )
+    )
+    await odds_store.link_resolved_event_member(
+        ResolvedEventMemberIn(
+            resolved_event_id="evt_manual",
+            match_id="m1",
+            bookmaker_id="mozzart",
+            source_url="https://example.com/manual",
+        )
+    )
+
+    await odds_store.upsert_resolved_events_bulk(
+        [
+            ResolvedEventIn(
+                id="evt_auto",
+                sport="basketball",
+                start_time="2026-05-02T16:00:00+00:00",
+                primary_match_id="m2",
+                method="exact",
+            )
+        ]
+    )
+    linked = await odds_store.link_resolved_event_members_bulk(
+        [
+            ResolvedEventMemberIn(
+                resolved_event_id="evt_auto",
+                match_id="m1",
+                bookmaker_id="mozzart",
+                source_url="https://example.com/auto",
+            )
+        ]
+    )
+
+    assert linked == 1
+    member = await odds_store.get_resolved_event_member(match_id="m1", bookmaker_id="mozzart")
+    assert member is not None
+    assert member.resolved_event_id == "evt_manual"
+    assert member.source_url == "https://example.com/manual"

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -1887,6 +1887,258 @@ async def test_replace_cycle_outputs_and_snapshot_rolls_back_atomically_on_failu
 
 
 @pytest.mark.asyncio
+async def test_replace_cycle_outputs_hides_uncommitted_writer_changes_from_shared_reads(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from dataclasses import dataclass
+
+    @dataclass
+    class _DiscrepancyRow:
+        match_id: str
+        resolved_event_id: str | None
+        market_type: str
+        player_name: str | None
+        bookmaker_a_id: str
+        bookmaker_a_match_id: str | None
+        bookmaker_b_id: str
+        bookmaker_b_match_id: str | None
+        threshold_a: float
+        threshold_b: float
+        odds_a: float | None
+        odds_b: float | None
+        gap: float
+        profit_margin: float | None
+        middle_profit_margin: float | None
+
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_match("old", "euroleague", "Partizan", "Crvena Zvezda")
+    await odds_store.upsert_match("new", "euroleague", "Bayern", "Real Madrid")
+    await odds_store.upsert_odds(
+        NormalizedOdds(
+            match_id="old",
+            bookmaker_id="mozzart",
+            league_id="euroleague",
+            home_team="Partizan",
+            away_team="Crvena Zvezda",
+            market_type="player_points",
+            player_name="Old Player",
+            threshold=10.5,
+            over_odds=1.8,
+            under_odds=2.0,
+        ),
+        scraped_at="old-snapshot",
+    )
+    await odds_store.set_current_snapshot("old-snapshot")
+    await odds_store.insert_discrepancy(
+        "old",
+        "player_points",
+        "Old Player",
+        "mozzart",
+        "maxbet",
+        10.5,
+        12.5,
+        1.8,
+        1.9,
+        2.0,
+        0.02,
+    )
+
+    original_set_current_snapshot_tx = odds_store._set_current_snapshot_tx
+    writer_paused = asyncio.Event()
+    allow_commit = asyncio.Event()
+
+    async def pausing_set_current_snapshot_tx(db, snapshot_at):
+        writer_paused.set()
+        await allow_commit.wait()
+        await original_set_current_snapshot_tx(db, snapshot_at)
+
+    monkeypatch.setattr(
+        odds_store,
+        "_set_current_snapshot_tx",
+        pausing_set_current_snapshot_tx,
+    )
+
+    writer_task = asyncio.create_task(
+        odds_store.replace_cycle_outputs_and_activate_snapshot(
+            resolved_events=[
+                ResolvedEventIn(
+                    id="evt-new",
+                    sport="basketball",
+                    start_time="2030-01-01T20:00:00+00:00",
+                    primary_match_id="new",
+                    confidence=0.99,
+                    method="exact",
+                )
+            ],
+            resolved_event_members=[
+                ResolvedEventMemberIn(
+                    resolved_event_id="evt-new",
+                    match_id="new",
+                    bookmaker_id="maxbet",
+                    confidence=0.99,
+                )
+            ],
+            event_review_cases=[],
+            odds=[],
+            outcome_offers=[],
+            unresolved_odds=[],
+            team_review_cases=[],
+            auto_approved_team_reviews=[],
+            opportunities=[],
+            discrepancies=[
+                _DiscrepancyRow(
+                    match_id="new",
+                    resolved_event_id="evt-new",
+                    market_type="player_points",
+                    player_name="New Player",
+                    bookmaker_a_id="mozzart",
+                    bookmaker_a_match_id=None,
+                    bookmaker_b_id="maxbet",
+                    bookmaker_b_match_id=None,
+                    threshold_a=10.5,
+                    threshold_b=12.5,
+                    odds_a=1.8,
+                    odds_b=1.9,
+                    gap=2.0,
+                    profit_margin=0.03,
+                    middle_profit_margin=None,
+                )
+            ],
+            detected_at="new-snapshot",
+            snapshot_at="new-snapshot",
+        )
+    )
+    await asyncio.wait_for(writer_paused.wait(), timeout=1)
+
+    try:
+        status_during = await odds_store.get_system_status()
+        discrepancies_during = await odds_store.get_discrepancies()
+        assert status_during.last_scrape_at == "old-snapshot"
+        assert [d.match_id for d in discrepancies_during] == ["old"]
+        assert await odds_store.get_resolved_event("evt-new") is None
+    finally:
+        allow_commit.set()
+
+    await writer_task
+    status_after = await odds_store.get_system_status()
+    discrepancies_after = await odds_store.get_discrepancies()
+    assert status_after.last_scrape_at == "new-snapshot"
+    assert [d.match_id for d in discrepancies_after] == ["new"]
+    assert await odds_store.get_resolved_event("evt-new") is not None
+
+
+@pytest.mark.asyncio
+async def test_replace_cycle_outputs_supports_default_memory_database():
+    await close_db()
+    await init_db()
+    try:
+        result = await odds_store.replace_cycle_outputs_and_activate_snapshot(
+            resolved_events=[],
+            resolved_event_members=[],
+            event_review_cases=[],
+            odds=[],
+            outcome_offers=[],
+            unresolved_odds=[],
+            team_review_cases=[],
+            auto_approved_team_reviews=[],
+            opportunities=[],
+            discrepancies=[],
+            detected_at="memory-snapshot",
+            snapshot_at="memory-snapshot",
+        )
+        status = await odds_store.get_system_status()
+
+        assert result["discrepancies"] == 0
+        assert status.last_scrape_at == "memory-snapshot"
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+async def test_default_memory_database_hides_uncommitted_writer_changes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    await close_db()
+    await init_db()
+    try:
+        await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+        await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+        await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+        await odds_store.upsert_match(
+            "old",
+            "euroleague",
+            "Partizan",
+            "Crvena Zvezda",
+        )
+        await odds_store.upsert_match("new", "euroleague", "Bayern", "Real Madrid")
+        await odds_store.set_current_snapshot("old-snapshot")
+        await odds_store.insert_discrepancy(
+            "old",
+            "player_points",
+            "Old Player",
+            "mozzart",
+            "maxbet",
+            10.5,
+            12.5,
+            1.8,
+            1.9,
+            2.0,
+            0.02,
+        )
+
+        original_set_current_snapshot_tx = odds_store._set_current_snapshot_tx
+        writer_paused = asyncio.Event()
+        allow_commit = asyncio.Event()
+
+        async def pausing_set_current_snapshot_tx(db, snapshot_at):
+            writer_paused.set()
+            await allow_commit.wait()
+            await original_set_current_snapshot_tx(db, snapshot_at)
+
+        monkeypatch.setattr(
+            odds_store,
+            "_set_current_snapshot_tx",
+            pausing_set_current_snapshot_tx,
+        )
+
+        writer_task = asyncio.create_task(
+            odds_store.replace_cycle_outputs_and_activate_snapshot(
+                resolved_events=[],
+                resolved_event_members=[],
+                event_review_cases=[],
+                odds=[],
+                outcome_offers=[],
+                unresolved_odds=[],
+                team_review_cases=[],
+                auto_approved_team_reviews=[],
+                opportunities=[],
+                discrepancies=[],
+                detected_at="new-snapshot",
+                snapshot_at="new-snapshot",
+            )
+        )
+        await asyncio.wait_for(writer_paused.wait(), timeout=1)
+
+        try:
+            status_during = await odds_store.get_system_status()
+            discrepancies_during = await odds_store.get_discrepancies()
+            assert status_during.last_scrape_at == "old-snapshot"
+            assert [d.match_id for d in discrepancies_during] == ["old"]
+        finally:
+            allow_commit.set()
+
+        await writer_task
+        status_after = await odds_store.get_system_status()
+        discrepancies_after = await odds_store.get_discrepancies()
+        assert status_after.last_scrape_at == "new-snapshot"
+        assert discrepancies_after == []
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
 async def test_upsert_odds_bulk_writes_current_history_and_sources():
     await odds_store.upsert_bookmaker("mozzart", "Mozzart")
     await odds_store.upsert_league("euroleague", "Euroleague", "basketball")

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -1268,3 +1268,200 @@ async def test_legacy_fallback_groups_recent_rows_before_snapshot_exists():
     assert status.total_matches == 2
     assert status.total_odds == 2
     assert status.last_scrape_at == "2026-04-11T20:05:00.000001"
+
+
+@pytest.mark.asyncio
+async def test_insert_discrepancies_bulk_matches_per_row_path():
+    """Bulk insert path produces the same DB rows as the per-row path.
+
+    Regression for the analyzer-phase slowness that surfaced after the
+    basketball handicap rollout: per-row commits made a single cycle hold
+    the SQLite write transaction for 5–7 minutes (≈ ``insert_discrepancy``
+    × 100k+).  ``insert_discrepancies_bulk`` collapses that to a single
+    transaction.  This test verifies semantic equivalence.
+    """
+    from dataclasses import dataclass
+
+    @dataclass
+    class _Row:
+        match_id: str
+        market_type: str
+        player_name: str | None
+        bookmaker_a_id: str
+        bookmaker_b_id: str
+        threshold_a: float
+        threshold_b: float
+        odds_a: float | None
+        odds_b: float | None
+        gap: float
+        profit_margin: float | None
+        middle_profit_margin: float | None = None
+        resolved_event_id: str | None = None
+        bookmaker_a_match_id: str | None = None
+        bookmaker_b_match_id: str | None = None
+
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_match("mPB", "euroleague", "Partizan", "Crvena Zvezda")
+    await odds_store.upsert_match("mAB", "euroleague", "Atlas", "Bayern")
+    # Per-bookmaker match-id columns FK to matches.id, so the alternate
+    # IDs the bulk test uses below must exist.
+    await odds_store.upsert_match("mPB-mozz", "euroleague", "Partizan", "Crvena Zvezda")
+    await odds_store.upsert_match("mPB-maxbet", "euroleague", "Partizan", "Crvena Zvezda")
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+
+    rows = [
+        _Row(
+            match_id="mPB",
+            market_type="player_points",
+            player_name="Mike James",
+            bookmaker_a_id="mozzart",
+            bookmaker_b_id="meridian",
+            threshold_a=18.5,
+            threshold_b=20.5,
+            odds_a=1.85,
+            odds_b=1.90,
+            gap=2.0,
+            profit_margin=0.025,
+            middle_profit_margin=0.85,
+        ),
+        _Row(
+            match_id="mPB",
+            market_type="home_handicap_ot",
+            player_name=None,
+            bookmaker_a_id="mozzart",
+            bookmaker_b_id="maxbet",
+            threshold_a=-3.5,
+            threshold_b=-2.5,
+            odds_a=1.95,
+            odds_b=1.85,
+            gap=1.0,
+            profit_margin=0.012,
+            middle_profit_margin=None,  # exercise the NULL path
+            bookmaker_a_match_id="mPB-mozz",
+            bookmaker_b_match_id="mPB-maxbet",
+        ),
+        _Row(
+            match_id="mAB",
+            market_type="game_total_ot",
+            player_name=None,
+            bookmaker_a_id="meridian",
+            bookmaker_b_id="maxbet",
+            threshold_a=205.5,
+            threshold_b=205.5,
+            odds_a=1.92,
+            odds_b=1.92,
+            gap=0.0,
+            profit_margin=None,  # exercise the NULL profit path
+            middle_profit_margin=0.40,
+        ),
+    ]
+
+    inserted = await odds_store.insert_discrepancies_bulk(rows)
+    assert inserted == 3
+
+    discs = await odds_store.get_discrepancies()
+    by_market = {(d.match_id, d.market_type, d.player_name): d for d in discs}
+    assert len(discs) == 3
+
+    pb_player = by_market[("mPB", "player_points", "Mike James")]
+    assert pb_player.threshold_a == 18.5
+    assert pb_player.threshold_b == 20.5
+    assert pb_player.odds_a == 1.85
+    assert pb_player.middle_profit_margin == 0.85
+    # Default fallback: bookmaker_*_match_id should equal match_id when
+    # the dataclass leaves them as None.
+    assert pb_player.bookmaker_a_match_id == "mPB"
+    assert pb_player.bookmaker_b_match_id == "mPB"
+
+    pb_handicap = by_market[("mPB", "home_handicap_ot", None)]
+    # Signed threshold preserved through the bulk path.
+    assert pb_handicap.threshold_a == -3.5
+    assert pb_handicap.threshold_b == -2.5
+    # NULL middle_profit_margin should round-trip as None, not 0.0.
+    assert pb_handicap.middle_profit_margin is None
+    # Explicit per-bookmaker match-ids are preserved.
+    assert pb_handicap.bookmaker_a_match_id == "mPB-mozz"
+    assert pb_handicap.bookmaker_b_match_id == "mPB-maxbet"
+
+    ab = by_market[("mAB", "game_total_ot", None)]
+    assert ab.profit_margin is None
+    assert ab.middle_profit_margin == 0.40
+    assert ab.gap == 0.0
+
+
+@pytest.mark.asyncio
+async def test_insert_discrepancies_bulk_handles_empty_input():
+    """Empty input is a no-op and must not start a transaction."""
+    inserted = await odds_store.insert_discrepancies_bulk([])
+    assert inserted == 0
+    discs = await odds_store.get_discrepancies()
+    assert discs == []
+
+
+@pytest.mark.asyncio
+async def test_insert_opportunities_bulk_matches_per_row_path():
+    """Bulk-insert opportunities produce the same DB rows as per-row inserts."""
+    from app.models.schemas import OpportunityLeg
+    from app.services.opportunity_analyzer import Opportunity
+
+    await odds_store.upsert_league("uefa", "UEFA", "football")
+    await odds_store.upsert_match("f-m1", "uefa", "Bayern", "Real Madrid")
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+
+    opportunities = [
+        Opportunity(
+            sport="football",
+            match_id="f-m1",
+            opportunity_type="football_result_double_chance",
+            market_type="football_double_chance",
+            line=None,
+            profit_margin=0.012,
+            middle_profit_margin=None,
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="mozzart",
+                    bookmaker_name="Mozzart",
+                    market_type="football_result",
+                    outcome_code="home",
+                    odds=2.5,
+                    line=None,
+                    raw_label="1",
+                ),
+                OpportunityLeg(
+                    bookmaker_id="maxbet",
+                    bookmaker_name="MaxBet",
+                    market_type="football_double_chance",
+                    outcome_code="draw_or_away",
+                    odds=1.42,
+                    line=None,
+                    raw_label="X2",
+                ),
+            ],
+        ),
+    ]
+
+    inserted = await odds_store.insert_opportunities_bulk(
+        opportunities, detected_at="2026-05-02T16:00:00+00:00"
+    )
+    assert inserted == 1
+
+    opps = await odds_store.get_opportunities()
+    assert len(opps) == 1
+    assert opps[0].profit_margin == 0.012
+    assert opps[0].middle_profit_margin is None
+    assert opps[0].sport == "football"
+    assert len(opps[0].legs) == 2
+    assert opps[0].legs[0].outcome_code == "home"
+    assert opps[0].legs[1].outcome_code == "draw_or_away"
+
+
+@pytest.mark.asyncio
+async def test_insert_opportunities_bulk_handles_empty_input():
+    """Empty input is a no-op."""
+    inserted = await odds_store.insert_opportunities_bulk(
+        [], detected_at="2026-05-02T16:00:00+00:00"
+    )
+    assert inserted == 0


### PR DESCRIPTION
## Summary
- Bulk-persist scrape-cycle database writes instead of committing odds/analyzer output row-by-row.
- Batch resolved-event persistence and keep manual/manual-review member protections intact.
- Cache hot team-registry lookups and skip expensive hot-cycle unresolved diagnostics.
- Atomically persist current odds, odds history, outcome offers, diagnostics, review cases, active analyzer outputs, and `current_snapshot_at` so failed cycles cannot expose mixed snapshots.

## Performance
Copied production DB benchmark after merging latest `origin/main`:
- Before: ~416s average full cycle, with scrape around ~61s.
- After: 93.894s full cycle, with 40.992s scrape.
- Atomic snapshot/output transaction: 2.979s.

## Verification
- `cd backend && ./venv/bin/pytest -q` → `809 passed in 16.25s` before merging latest `origin/main`.
- After merging latest `origin/main`: `cd backend && ./venv/bin/python -m py_compile app/store/odds_store.py app/services/event_resolver.py app/services/scheduler.py app/services/team_registry.py app/services/canonical_offers.py tests/test_store.py tests/test_scheduler.py tests/test_canonical_offers.py && ./venv/bin/pytest -q` → `820 passed in 16.33s`.
- Copied-DB real cycle: `cycle_duration_ms=93894`, `scrape_duration_ms=40992`, `discrepancies_found=255848`, `odds_scraped=14874`.
- Three adversarial reviews completed; reviewers found snapshot/output atomicity issues, which were fixed and re-reviewed clean.
