### PR TITLE
Add canonical offer analyzer

### DIFF
--- a/backend/app/services/canonical_analyzer.py
+++ b/backend/app/services/canonical_analyzer.py
@@ -4,7 +4,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from itertools import combinations
 
-from ..models.schemas import CanonicalOffer, OpportunityLeg
+from ..models.schemas import CanonicalMarket, CanonicalOffer, OpportunityLeg
+from .canonical_offers import _clean_part
 from .opportunity_analyzer import Opportunity, _middle_profit_margin, _profit_margin
 
 
@@ -73,6 +74,8 @@ def _analyze_two_way_arbitrage(
             continue
         if not _is_two_way_pair(first, second):
             continue
+        if not _has_positive_odds(first, second):
+            continue
         margin = _profit_margin(first.odds, second.odds)
         if margin is None or margin <= 0:
             continue
@@ -110,6 +113,8 @@ def _analyze_line_middle(
 
         low, high = (first, second) if first.market.line < second.market.line else (second, first)
         if low.outcome_code != "over" or high.outcome_code != "under":
+            continue
+        if not _has_positive_odds(low, high):
             continue
 
         gap = high.market.line - low.market.line
@@ -158,6 +163,8 @@ def _analyze_complementary_outcomes(
             for double_chance_offer in by_key.get(double_chance_key, []):
                 if result_offer.bookmaker_id == double_chance_offer.bookmaker_id:
                     continue
+                if not _has_positive_odds(result_offer, double_chance_offer):
+                    continue
                 margin = _profit_margin(result_offer.odds, double_chance_offer.odds)
                 if margin is None or margin <= 0:
                     continue
@@ -183,6 +190,10 @@ def _is_two_way_pair(first: CanonicalOffer, second: CanonicalOffer) -> bool:
     if first.market.line is not None:
         return outcomes == _LINE_OUTCOME_PAIR
     return outcomes == _TWO_WAY_MARKET_OUTCOMES.get(market_type)
+
+
+def _has_positive_odds(*offers: CanonicalOffer) -> bool:
+    return all(offer.odds > 0 for offer in offers)
 
 
 def _passes_line_middle_margin_filter(
@@ -243,8 +254,7 @@ def _market_family_key(
         market.sport,
         _event_identity(offer),
         market.subject_type,
-        market.subject_key,
-        market.subject_name,
+        _subject_identity(market),
         market.period,
         market.scope,
     ]
@@ -257,6 +267,10 @@ def _event_identity(offer: CanonicalOffer) -> str:
     if offer.market.event_id:
         return f"event:{offer.market.event_id}"
     return f"match:{offer.market.match_id}"
+
+
+def _subject_identity(market: CanonicalMarket) -> str | None:
+    return _clean_part(market.subject_key) or _clean_part(market.subject_name)
 
 
 def _context(

--- a/backend/app/services/canonical_analyzer.py
+++ b/backend/app/services/canonical_analyzer.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from itertools import combinations
+
+from ..models.schemas import CanonicalOffer, OpportunityLeg
+from .opportunity_analyzer import Opportunity, _middle_profit_margin, _profit_margin
+
+
+_COMPLEMENTARY_OUTCOME_PAIRS = {
+    ("result", "home"): ("double_chance", "draw_or_away"),
+    ("result", "away"): ("double_chance", "home_or_draw"),
+    ("result", "draw"): ("double_chance", "home_or_away"),
+}
+_LINE_OUTCOME_PAIR = {"over", "under"}
+_TWO_WAY_MARKET_OUTCOMES = {
+    "match_winner": {"home", "away"},
+}
+_LINE_MIDDLE_OUTSIDE_MARGIN_FLOORS = {
+    "football_total_goals": -0.05,
+}
+
+
+@dataclass(frozen=True)
+class _RuleContext:
+    match_id: str
+    resolved_event_id: str | None
+
+
+def analyze_canonical_offers(
+    offers: Sequence[CanonicalOffer],
+    *,
+    min_gap: float = 0.0,
+    event_primary_match_ids: Mapping[str, str] | None = None,
+) -> list[Opportunity]:
+    """Find two-leg opportunities from canonical bookmaker offers."""
+    deduped: dict[tuple, Opportunity] = {}
+
+    for group in _same_market_groups(offers).values():
+        context = _context(group, event_primary_match_ids=event_primary_match_ids)
+        for opportunity in _analyze_two_way_arbitrage(group, context):
+            deduped[_dedupe_key(opportunity)] = opportunity
+
+    for group in _line_market_groups(offers).values():
+        context = _context(group, event_primary_match_ids=event_primary_match_ids)
+        for opportunity in _analyze_line_middle(group, context, min_gap=min_gap):
+            deduped[_dedupe_key(opportunity)] = opportunity
+
+    for group in _event_market_family_groups(offers).values():
+        context = _context(group, event_primary_match_ids=event_primary_match_ids)
+        for opportunity in _analyze_complementary_outcomes(group, context):
+            deduped[_dedupe_key(opportunity)] = opportunity
+
+    return sorted(
+        deduped.values(),
+        key=lambda item: (
+            -(item.profit_margin or -999),
+            item.match_id,
+            item.opportunity_type,
+            item.market_type,
+        ),
+    )
+
+
+def _analyze_two_way_arbitrage(
+    group: Sequence[CanonicalOffer],
+    context: _RuleContext,
+) -> list[Opportunity]:
+    opportunities: list[Opportunity] = []
+    for first, second in combinations(group, 2):
+        if first.bookmaker_id == second.bookmaker_id:
+            continue
+        if not _is_two_way_pair(first, second):
+            continue
+        margin = _profit_margin(first.odds, second.odds)
+        if margin is None or margin <= 0:
+            continue
+        market = first.market
+        opportunities.append(
+            Opportunity(
+                sport=market.sport,
+                match_id=context.match_id,
+                opportunity_type="same_line_arbitrage",
+                market_type=market.market_type,
+                line=market.line,
+                profit_margin=margin,
+                middle_profit_margin=None,
+                legs=[_leg(first), _leg(second)],
+                resolved_event_id=context.resolved_event_id,
+            )
+        )
+    return opportunities
+
+
+def _analyze_line_middle(
+    group: Sequence[CanonicalOffer],
+    context: _RuleContext,
+    *,
+    min_gap: float,
+) -> list[Opportunity]:
+    opportunities: list[Opportunity] = []
+    for first, second in combinations(group, 2):
+        if first.bookmaker_id == second.bookmaker_id:
+            continue
+        if first.market.line is None or second.market.line is None:
+            continue
+        if first.market.line == second.market.line:
+            continue
+
+        low, high = (first, second) if first.market.line < second.market.line else (second, first)
+        if low.outcome_code != "over" or high.outcome_code != "under":
+            continue
+
+        gap = high.market.line - low.market.line
+        if gap < min_gap:
+            continue
+
+        margin = _profit_margin(low.odds, high.odds)
+        middle_margin = _middle_profit_margin(low.odds, high.odds)
+        if not _passes_line_middle_margin_filter(
+            low.market.market_type,
+            margin=margin,
+            middle_margin=middle_margin,
+        ):
+            continue
+
+        opportunities.append(
+            Opportunity(
+                sport=low.market.sport,
+                match_id=context.match_id,
+                opportunity_type="middle",
+                market_type=low.market.market_type,
+                line=low.market.line,
+                profit_margin=margin,
+                middle_profit_margin=middle_margin,
+                legs=[_leg(low), _leg(high)],
+                resolved_event_id=context.resolved_event_id,
+            )
+        )
+    return opportunities
+
+
+def _analyze_complementary_outcomes(
+    group: Sequence[CanonicalOffer],
+    context: _RuleContext,
+) -> list[Opportunity]:
+    by_key: dict[tuple[str, str], list[CanonicalOffer]] = {}
+    for offer in group:
+        by_key.setdefault(
+            (offer.market.market_type, offer.outcome_code),
+            [],
+        ).append(offer)
+
+    opportunities: list[Opportunity] = []
+    for result_key, double_chance_key in _COMPLEMENTARY_OUTCOME_PAIRS.items():
+        for result_offer in by_key.get(result_key, []):
+            for double_chance_offer in by_key.get(double_chance_key, []):
+                if result_offer.bookmaker_id == double_chance_offer.bookmaker_id:
+                    continue
+                margin = _profit_margin(result_offer.odds, double_chance_offer.odds)
+                if margin is None or margin <= 0:
+                    continue
+                opportunities.append(
+                    Opportunity(
+                        sport=result_offer.market.sport,
+                        match_id=context.match_id,
+                        opportunity_type="complementary_outcomes",
+                        market_type="football_result_double_chance",
+                        line=None,
+                        profit_margin=margin,
+                        middle_profit_margin=None,
+                        legs=[_leg(result_offer), _leg(double_chance_offer)],
+                        resolved_event_id=context.resolved_event_id,
+                    )
+                )
+    return opportunities
+
+
+def _is_two_way_pair(first: CanonicalOffer, second: CanonicalOffer) -> bool:
+    outcomes = {first.outcome_code, second.outcome_code}
+    market_type = first.market.market_type
+    if first.market.line is not None:
+        return outcomes == _LINE_OUTCOME_PAIR
+    return outcomes == _TWO_WAY_MARKET_OUTCOMES.get(market_type)
+
+
+def _passes_line_middle_margin_filter(
+    market_type: str,
+    *,
+    margin: float | None,
+    middle_margin: float | None,
+) -> bool:
+    floor = _LINE_MIDDLE_OUTSIDE_MARGIN_FLOORS.get(market_type)
+    if floor is None:
+        return margin is not None and middle_margin is not None
+    return (
+        margin is not None
+        and middle_margin is not None
+        and middle_margin > 0
+        and margin >= floor
+    )
+
+
+def _same_market_groups(
+    offers: Sequence[CanonicalOffer],
+) -> dict[str, list[CanonicalOffer]]:
+    groups: dict[str, list[CanonicalOffer]] = {}
+    for offer in offers:
+        groups.setdefault(offer.market_key, []).append(offer)
+    return groups
+
+
+def _line_market_groups(
+    offers: Sequence[CanonicalOffer],
+) -> dict[tuple, list[CanonicalOffer]]:
+    groups: dict[tuple, list[CanonicalOffer]] = {}
+    for offer in offers:
+        if offer.market.line is None:
+            continue
+        if offer.outcome_code not in _LINE_OUTCOME_PAIR:
+            continue
+        groups.setdefault(_market_family_key(offer, include_market_type=True), []).append(offer)
+    return groups
+
+
+def _event_market_family_groups(
+    offers: Sequence[CanonicalOffer],
+) -> dict[tuple, list[CanonicalOffer]]:
+    groups: dict[tuple, list[CanonicalOffer]] = {}
+    for offer in offers:
+        groups.setdefault(_market_family_key(offer, include_market_type=False), []).append(offer)
+    return groups
+
+
+def _market_family_key(
+    offer: CanonicalOffer,
+    *,
+    include_market_type: bool,
+) -> tuple:
+    market = offer.market
+    key = [
+        market.sport,
+        _event_identity(offer),
+        market.subject_type,
+        market.subject_key,
+        market.subject_name,
+        market.period,
+        market.scope,
+    ]
+    if include_market_type:
+        key.insert(2, market.market_type)
+    return tuple(key)
+
+
+def _event_identity(offer: CanonicalOffer) -> str:
+    if offer.market.event_id:
+        return f"event:{offer.market.event_id}"
+    return f"match:{offer.market.match_id}"
+
+
+def _context(
+    group: Sequence[CanonicalOffer],
+    *,
+    event_primary_match_ids: Mapping[str, str] | None,
+) -> _RuleContext:
+    resolved_event_id = _resolved_event_id(group)
+    if resolved_event_id and event_primary_match_ids and resolved_event_id in event_primary_match_ids:
+        match_id = event_primary_match_ids[resolved_event_id]
+    else:
+        match_id = min(offer.market.match_id for offer in group)
+    return _RuleContext(match_id=match_id, resolved_event_id=resolved_event_id)
+
+
+def _resolved_event_id(group: Sequence[CanonicalOffer]) -> str | None:
+    event_ids = {offer.market.event_id for offer in group if offer.market.event_id}
+    if len(event_ids) == 1:
+        return next(iter(event_ids))
+    return None
+
+
+def _leg(offer: CanonicalOffer) -> OpportunityLeg:
+    market = offer.market
+    return OpportunityLeg(
+        match_id=market.bookmaker_match_id or market.match_id,
+        bookmaker_id=offer.bookmaker_id,
+        source_url=offer.source_url,
+        market_type=market.source_market_type,
+        outcome_code=offer.outcome_code,
+        odds=offer.odds,
+        line=market.line,
+        raw_label=offer.raw_label,
+    )
+
+
+def _dedupe_key(opportunity: Opportunity) -> tuple:
+    leg_keys = tuple(
+        sorted(
+            (
+                leg.bookmaker_id,
+                leg.match_id,
+                leg.market_type,
+                leg.outcome_code,
+                leg.line,
+                leg.odds,
+            )
+            for leg in opportunity.legs
+        )
+    )
+    return (
+        opportunity.resolved_event_id,
+        opportunity.match_id,
+        opportunity.opportunity_type,
+        opportunity.market_type,
+        opportunity.line,
+        leg_keys,
+    )

--- a/backend/app/services/canonical_offers.py
+++ b/backend/app/services/canonical_offers.py
@@ -14,6 +14,7 @@ from ..models.schemas import (
 _CANONICAL_MARKET_TYPES = {
     "football_result": "result",
     "football_double_chance": "double_chance",
+    "player_points_milestones": "player_points",
     "tennis_match_winner": "match_winner",
 }
 

--- a/backend/tests/test_canonical_analyzer.py
+++ b/backend/tests/test_canonical_analyzer.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import pytest
+
+from app.models.schemas import NormalizedOdds, NormalizedOutcomeOffer
+from app.services.analyzer import find_threshold_gaps
+from app.services.canonical_analyzer import analyze_canonical_offers
+from app.services.canonical_offers import (
+    canonical_offer_from_normalized_outcome_offer,
+    canonical_offers_from_normalized_odds,
+)
+from app.services.opportunity_analyzer import analyze_outcome_offers
+
+
+def _odds(
+    bookmaker: str,
+    player: str | None,
+    threshold: float,
+    *,
+    over: float | None = 1.85,
+    under: float | None = 1.95,
+    match_id: str = "basketball-match-1",
+    market_type: str = "player_points",
+    event_id: str | None = None,
+) -> list:
+    odds = NormalizedOdds(
+        match_id=match_id,
+        bookmaker_id=bookmaker,
+        league_id="euroleague",
+        sport="basketball",
+        home_team="Partizan",
+        away_team="Crvena Zvezda",
+        market_type=market_type,
+        player_name=player,
+        threshold=threshold,
+        over_odds=over,
+        under_odds=under,
+    )
+    return canonical_offers_from_normalized_odds(odds, event_id=event_id)
+
+
+def _legacy_odds(
+    bookmaker: str,
+    player: str | None,
+    threshold: float,
+    *,
+    over: float | None = 1.85,
+    under: float | None = 1.95,
+    match_id: str = "basketball-match-1",
+    market_type: str = "player_points",
+) -> NormalizedOdds:
+    return NormalizedOdds(
+        match_id=match_id,
+        bookmaker_id=bookmaker,
+        league_id="euroleague",
+        sport="basketball",
+        home_team="Partizan",
+        away_team="Crvena Zvezda",
+        market_type=market_type,
+        player_name=player,
+        threshold=threshold,
+        over_odds=over,
+        under_odds=under,
+    )
+
+
+def _outcome_offer(
+    bookmaker_id: str,
+    market_type: str,
+    outcome_code: str,
+    odds: float,
+    *,
+    line: float | None = None,
+    match_id: str = "football-match-1",
+    sport: str = "football",
+    event_id: str | None = None,
+):
+    offer = NormalizedOutcomeOffer(
+        match_id=match_id,
+        bookmaker_id=bookmaker_id,
+        league_id=f"{sport}_league",
+        sport=sport,
+        home_team_id=1,
+        away_team_id=2,
+        home_team="Team Alpha",
+        away_team="Team Beta",
+        market_type=market_type,
+        outcome_code=outcome_code,
+        odds=odds,
+        line=line,
+        raw_label=outcome_code,
+        start_time="2030-01-01T20:00:00+00:00",
+    )
+    return canonical_offer_from_normalized_outcome_offer(offer, event_id=event_id)
+
+
+def _legacy_outcome_offer(
+    bookmaker_id: str,
+    market_type: str,
+    outcome_code: str,
+    odds: float,
+    *,
+    line: float | None = None,
+    match_id: str = "football-match-1",
+) -> NormalizedOutcomeOffer:
+    return NormalizedOutcomeOffer(
+        match_id=match_id,
+        bookmaker_id=bookmaker_id,
+        league_id="football_league",
+        sport="football",
+        home_team_id=1,
+        away_team_id=2,
+        home_team="Team Alpha",
+        away_team="Team Beta",
+        market_type=market_type,
+        outcome_code=outcome_code,
+        odds=odds,
+        line=line,
+        raw_label=outcome_code,
+        start_time="2030-01-01T20:00:00+00:00",
+    )
+
+
+def test_canonical_line_middle_matches_basketball_threshold_gap():
+    legacy_odds = [
+        _legacy_odds("mozzart", "Lundberg", 16.5, over=1.85, under=1.95),
+        _legacy_odds("meridian", "Lundberg", 18.5, over=1.80, under=2.00),
+    ]
+    legacy = find_threshold_gaps(legacy_odds)
+    opportunities = analyze_canonical_offers(
+        [
+            *_odds("mozzart", "Lundberg", 16.5, over=1.85, under=1.95),
+            *_odds("meridian", "Lundberg", 18.5, over=1.80, under=2.00),
+        ]
+    )
+
+    assert len(legacy) == 1
+    assert len(opportunities) == 1
+    opportunity = opportunities[0]
+    assert opportunity.opportunity_type == "middle"
+    assert opportunity.market_type == legacy[0].market_type
+    assert opportunity.line == legacy[0].threshold_a
+    assert opportunity.profit_margin == legacy[0].profit_margin
+    assert opportunity.middle_profit_margin == legacy[0].middle_profit_margin
+    assert {(leg.bookmaker_id, leg.outcome_code, leg.line) for leg in opportunity.legs} == {
+        ("mozzart", "over", 16.5),
+        ("meridian", "under", 18.5),
+    }
+
+
+def test_canonical_line_middle_honors_min_gap():
+    offers = [
+        *_odds("mozzart", "Lundberg", 16.5),
+        *_odds("meridian", "Lundberg", 17.5),
+    ]
+
+    assert analyze_canonical_offers(offers, min_gap=2.0) == []
+    assert len(analyze_canonical_offers(offers, min_gap=0.5)) == 1
+
+
+def test_canonical_player_points_milestones_compare_as_player_points():
+    opportunities = analyze_canonical_offers(
+        [
+            *_odds(
+                "oktagonbet",
+                "Lundberg",
+                9.5,
+                over=1.90,
+                under=None,
+                market_type="player_points_milestones",
+            ),
+            *_odds("mozzart", "Lundberg", 12.5, over=1.80, under=1.90),
+        ]
+    )
+
+    assert len(opportunities) == 1
+    opportunity = opportunities[0]
+    assert opportunity.market_type == "player_points"
+    assert {(leg.market_type, leg.outcome_code, leg.line) for leg in opportunity.legs} == {
+        ("player_points_milestones", "over", 9.5),
+        ("player_points", "under", 12.5),
+    }
+
+
+def test_canonical_same_line_arbitrage_matches_basketball_positive_margin():
+    legacy = find_threshold_gaps(
+        [
+            _legacy_odds("a", "Lundberg", -4.5, over=2.05, under=1.85, market_type="home_handicap_ot"),
+            _legacy_odds("b", "Lundberg", -4.5, over=1.85, under=2.00, market_type="home_handicap_ot"),
+        ]
+    )
+    opportunities = analyze_canonical_offers(
+        [
+            *_odds("a", "Lundberg", -4.5, over=2.05, under=1.85, market_type="home_handicap_ot"),
+            *_odds("b", "Lundberg", -4.5, over=1.85, under=2.00, market_type="home_handicap_ot"),
+        ]
+    )
+
+    assert len(legacy) == 1
+    assert len(opportunities) == 1
+    opportunity = opportunities[0]
+    assert opportunity.opportunity_type == "same_line_arbitrage"
+    assert opportunity.market_type == "home_handicap_ot"
+    assert opportunity.line == -4.5
+    assert opportunity.profit_margin == legacy[0].profit_margin
+    assert opportunity.middle_profit_margin == legacy[0].middle_profit_margin
+    assert {(leg.bookmaker_id, leg.outcome_code, leg.odds) for leg in opportunity.legs} == {
+        ("a", "over", 2.05),
+        ("b", "under", 2.00),
+    }
+
+
+def test_canonical_same_bookmaker_alternate_lines_are_ignored():
+    assert (
+        analyze_canonical_offers(
+            [
+                *_odds("mozzart", None, 216.5, market_type="game_total"),
+                *_odds("mozzart", None, 217.5, market_type="game_total"),
+            ]
+        )
+        == []
+    )
+
+
+def test_canonical_total_goals_same_line_arbitrage_matches_legacy():
+    legacy = analyze_outcome_offers(
+        [
+            _legacy_outcome_offer("maxbet", "football_total_goals", "under", 2.15, line=2.5),
+            _legacy_outcome_offer("balkanbet", "football_total_goals", "over", 2.85, line=2.5),
+        ]
+    )
+    opportunities = analyze_canonical_offers(
+        [
+            _outcome_offer("maxbet", "football_total_goals", "under", 2.15, line=2.5),
+            _outcome_offer("balkanbet", "football_total_goals", "over", 2.85, line=2.5),
+        ]
+    )
+
+    assert len(legacy) == 1
+    assert len(opportunities) == 1
+    assert opportunities[0].opportunity_type == legacy[0].opportunity_type
+    assert opportunities[0].market_type == legacy[0].market_type
+    assert opportunities[0].line == legacy[0].line
+    assert opportunities[0].profit_margin == legacy[0].profit_margin
+
+
+def test_canonical_result_double_chance_complement_matches_legacy():
+    legacy = analyze_outcome_offers(
+        [
+            _legacy_outcome_offer("maxbet", "football_result", "home", 2.5),
+            _legacy_outcome_offer("balkanbet", "football_double_chance", "draw_or_away", 1.75),
+        ]
+    )
+    opportunities = analyze_canonical_offers(
+        [
+            _outcome_offer("maxbet", "football_result", "home", 2.5),
+            _outcome_offer("balkanbet", "football_double_chance", "draw_or_away", 1.75),
+        ]
+    )
+
+    assert len(legacy) == 1
+    assert len(opportunities) == 1
+    assert opportunities[0].opportunity_type == legacy[0].opportunity_type
+    assert opportunities[0].market_type == legacy[0].market_type
+    assert opportunities[0].profit_margin == legacy[0].profit_margin
+    assert {leg.market_type for leg in opportunities[0].legs} == {
+        "football_result",
+        "football_double_chance",
+    }
+
+
+def test_canonical_total_goals_middle_matches_legacy_floor():
+    legacy = analyze_outcome_offers(
+        [
+            _legacy_outcome_offer("balkanbet", "football_total_goals", "over", 2.0, line=1.5),
+            _legacy_outcome_offer("maxbet", "football_total_goals", "under", 2.0, line=2.5),
+        ]
+    )
+    opportunities = analyze_canonical_offers(
+        [
+            _outcome_offer("balkanbet", "football_total_goals", "over", 2.0, line=1.5),
+            _outcome_offer("maxbet", "football_total_goals", "under", 2.0, line=2.5),
+        ]
+    )
+
+    assert len(legacy) == 1
+    assert len(opportunities) == 1
+    assert opportunities[0].opportunity_type == "middle"
+    assert opportunities[0].profit_margin == legacy[0].profit_margin
+    assert opportunities[0].middle_profit_margin == legacy[0].middle_profit_margin
+
+
+def test_canonical_total_goals_middle_filters_large_outside_loss():
+    opportunities = analyze_canonical_offers(
+        [
+            _outcome_offer("balkanbet", "football_total_goals", "over", 1.65, line=1.5),
+            _outcome_offer("maxbet", "football_total_goals", "under", 1.65, line=2.5),
+        ]
+    )
+
+    assert opportunities == []
+
+
+def test_canonical_tennis_match_winner_arbitrage_needs_no_tennis_pipeline():
+    opportunities = analyze_canonical_offers(
+        [
+            _outcome_offer(
+                "book-a",
+                "tennis_match_winner",
+                "home",
+                2.10,
+                sport="tennis",
+            ),
+            _outcome_offer(
+                "book-b",
+                "tennis_match_winner",
+                "away",
+                2.10,
+                sport="tennis",
+            ),
+        ]
+    )
+
+    assert len(opportunities) == 1
+    opportunity = opportunities[0]
+    assert opportunity.sport == "tennis"
+    assert opportunity.market_type == "match_winner"
+    assert opportunity.opportunity_type == "same_line_arbitrage"
+    assert opportunity.profit_margin == pytest.approx(0.05, abs=1e-4)
+    assert {leg.market_type for leg in opportunity.legs} == {"tennis_match_winner"}
+
+
+def test_canonical_resolved_event_uses_primary_match_and_source_leg_matches():
+    opportunities = analyze_canonical_offers(
+        [
+            *_odds(
+                "mozzart",
+                "Lundberg",
+                16.5,
+                match_id="match-mozzart",
+                event_id="evt-partizan-zvezda",
+            ),
+            *_odds(
+                "meridian",
+                "Lundberg",
+                18.5,
+                match_id="match-meridian",
+                event_id="evt-partizan-zvezda",
+            ),
+        ],
+        event_primary_match_ids={"evt-partizan-zvezda": "match-mozzart"},
+    )
+
+    assert len(opportunities) == 1
+    opportunity = opportunities[0]
+    assert opportunity.resolved_event_id == "evt-partizan-zvezda"
+    assert opportunity.match_id == "match-mozzart"
+    assert {leg.match_id for leg in opportunity.legs} == {
+        "match-mozzart",
+        "match-meridian",
+    }

--- a/backend/tests/test_canonical_analyzer.py
+++ b/backend/tests/test_canonical_analyzer.py
@@ -22,6 +22,8 @@ def _odds(
     match_id: str = "basketball-match-1",
     market_type: str = "player_points",
     event_id: str | None = None,
+    subject_key: str | None = None,
+    subject_name: str | None = None,
 ) -> list:
     odds = NormalizedOdds(
         match_id=match_id,
@@ -36,7 +38,12 @@ def _odds(
         over_odds=over,
         under_odds=under,
     )
-    return canonical_offers_from_normalized_odds(odds, event_id=event_id)
+    return canonical_offers_from_normalized_odds(
+        odds,
+        event_id=event_id,
+        subject_key_override=subject_key,
+        subject_name_override=subject_name,
+    )
 
 
 def _legacy_odds(
@@ -156,6 +163,70 @@ def test_canonical_line_middle_honors_min_gap():
 
     assert analyze_canonical_offers(offers, min_gap=2.0) == []
     assert len(analyze_canonical_offers(offers, min_gap=0.5)) == 1
+
+
+def test_canonical_line_middle_uses_subject_key_before_display_name():
+    opportunities = analyze_canonical_offers(
+        [
+            *_odds(
+                "mozzart",
+                "Nikola Jokić",
+                16.5,
+                over=1.90,
+                under=1.80,
+                subject_key="ply_lundberg",
+                subject_name="Nikola Jokić",
+            ),
+            *_odds(
+                "meridian",
+                "N. Jokic",
+                18.5,
+                over=1.80,
+                under=1.95,
+                subject_key="ply_lundberg",
+                subject_name="N. Jokic",
+            ),
+        ]
+    )
+
+    assert len(opportunities) == 1
+    assert {(leg.bookmaker_id, leg.outcome_code, leg.line) for leg in opportunities[0].legs} == {
+        ("mozzart", "over", 16.5),
+        ("meridian", "under", 18.5),
+    }
+
+
+def test_canonical_line_middle_rejects_invalid_odds():
+    opportunities = analyze_canonical_offers(
+        [
+            *_odds("mozzart", "Lundberg", 16.5, over=0.0, under=None),
+            *_odds("meridian", "Lundberg", 18.5, over=None, under=2.00),
+        ]
+    )
+
+    assert opportunities == []
+
+
+def test_canonical_same_line_arbitrage_rejects_invalid_odds():
+    opportunities = analyze_canonical_offers(
+        [
+            *_odds("mozzart", "Lundberg", 16.5, over=0.0, under=None),
+            *_odds("meridian", "Lundberg", 16.5, over=None, under=2.00),
+        ]
+    )
+
+    assert opportunities == []
+
+
+def test_canonical_complementary_outcomes_reject_invalid_odds():
+    opportunities = analyze_canonical_offers(
+        [
+            _outcome_offer("maxbet", "football_result", "home", 0.0),
+            _outcome_offer("balkanbet", "football_double_chance", "draw_or_away", 2.0),
+        ]
+    )
+
+    assert opportunities == []
 
 
 def test_canonical_player_points_milestones_compare_as_player_points():


### PR DESCRIPTION
## Summary
- add a canonical-offer analyzer that emits existing Opportunity results
- implement canonical rules for same-line two-way arbitrage, line middles, and complementary outcomes
- map player_points_milestones to player_points for canonical parity
- add parity coverage for basketball discrepancies, football opportunities, and synthetic tennis match-winner arbitrage

## Validation
- cd backend && ./venv/bin/python -m compileall -q app tests
- cd backend && ./venv/bin/pytest tests/test_canonical_analyzer.py tests/test_canonical_offers.py tests/test_analyzer.py tests/test_opportunity_analyzer.py -q
- cd backend && ./venv/bin/pytest -q

Refs #53