### PR TITLE
Add canonical shadow pipeline analysis

### DIFF
--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -22,6 +22,15 @@ class BaseScraper(abc.ABC):
         """Return list of league IDs this scraper supports."""
         ...
 
+    def get_supported_odds_sports(self) -> list[str]:
+        """Return sports supported by the threshold-odds scraper lane."""
+        return list(self.get_supported_odds_leagues())
+
+    def get_supported_odds_leagues(self) -> dict[str, list[str]]:
+        """Return threshold-odds league IDs grouped by sport."""
+        leagues = self.get_supported_leagues()
+        return {"basketball": leagues} if leagues else {}
+
     @abc.abstractmethod
     async def scrape_odds(self, league_id: str) -> list[RawOddsData]:
         """Scrape odds for a given league and return raw data."""

--- a/backend/app/services/canonical_analyzer.py
+++ b/backend/app/services/canonical_analyzer.py
@@ -91,6 +91,7 @@ def _analyze_two_way_arbitrage(
                 middle_profit_margin=None,
                 legs=[_leg(first), _leg(second)],
                 resolved_event_id=context.resolved_event_id,
+                market_keys=(market.market_key,),
             )
         )
     return opportunities
@@ -141,6 +142,7 @@ def _analyze_line_middle(
                 middle_profit_margin=middle_margin,
                 legs=[_leg(low), _leg(high)],
                 resolved_event_id=context.resolved_event_id,
+                market_keys=tuple(sorted({low.market_key, high.market_key})),
             )
         )
     return opportunities
@@ -179,6 +181,14 @@ def _analyze_complementary_outcomes(
                         middle_profit_margin=None,
                         legs=[_leg(result_offer), _leg(double_chance_offer)],
                         resolved_event_id=context.resolved_event_id,
+                        market_keys=tuple(
+                            sorted(
+                                {
+                                    result_offer.market_key,
+                                    double_chance_offer.market_key,
+                                }
+                            )
+                        ),
                     )
                 )
     return opportunities
@@ -327,5 +337,6 @@ def _dedupe_key(opportunity: Opportunity) -> tuple:
         opportunity.opportunity_type,
         opportunity.market_type,
         opportunity.line,
+        opportunity.market_keys,
         leg_keys,
     )

--- a/backend/app/services/opportunity_analyzer.py
+++ b/backend/app/services/opportunity_analyzer.py
@@ -18,6 +18,7 @@ class Opportunity:
     middle_profit_margin: float | None
     legs: list[OpportunityLeg]
     resolved_event_id: str | None = None
+    market_keys: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import time
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 
 from ..config import settings
@@ -19,6 +20,7 @@ from ..services.normalizer import (
     resolve_team_name,
 )
 from ..services.analyzer import analyze
+from ..services.canonical_analyzer import analyze_canonical_offers
 from ..services.event_resolver import (
     CANONICAL_TEAM_AUTO_MERGE_THRESHOLD,
     SameTimeCanonicalMergeProposal as _SameTimeMergeProposal,
@@ -56,6 +58,13 @@ AUTO_CANONICAL_MERGE_REVIEW_KIND = "auto_canonical_merge_suggestion"
 SAME_TIME_MIN_TARGET_SUPPORT = 2
 
 
+@dataclass(frozen=True)
+class _CanonicalShadowResult:
+    offers_analyzed: int = 0
+    opportunities_found: int = 0
+    warnings: tuple[str, ...] = ()
+
+
 def _is_auto_alias_candidate(case) -> bool:
     return (
         case.review_kind in {"alias_suggestion", "candidate_search"}
@@ -68,6 +77,140 @@ def _is_auto_alias_candidate(case) -> bool:
         and case.canonical_away_team is not None
         and case.similarity_score is not None
         and case.similarity_score >= ANCHORED_AUTO_APPLY_THRESHOLD
+    )
+
+
+def _enabled_threshold_league_ids(scraper: BaseScraper, enabled_sports: set[str]) -> list[str]:
+    league_ids: list[str] = []
+    for sport, sport_leagues in scraper.get_supported_odds_leagues().items():
+        if sport not in enabled_sports:
+            continue
+        league_ids.extend(sport_leagues)
+    return list(dict.fromkeys(league_ids))
+
+
+async def _run_canonical_shadow_analysis(
+    *,
+    match_ids: set[str],
+    legacy_discrepancy_count: int,
+    legacy_opportunity_count: int,
+) -> _CanonicalShadowResult:
+    canonical_offers = await odds_store.get_current_canonical_offers_for_matches(
+        sorted(match_ids)
+    )
+    event_ids = sorted(
+        {
+            offer.market.event_id
+            for offer in canonical_offers
+            if offer.market.event_id
+        }
+    )
+    event_primary_match_ids = (
+        await odds_store.get_resolved_event_primary_match_ids(event_ids)
+        if event_ids
+        else {}
+    )
+    canonical_opportunities = analyze_canonical_offers(
+        canonical_offers,
+        event_primary_match_ids=event_primary_match_ids,
+    )
+    expected_count = legacy_discrepancy_count + legacy_opportunity_count
+    legacy_equivalent_count = _legacy_equivalent_shadow_count(
+        canonical_opportunities,
+        canonical_offers,
+    )
+    warnings: tuple[str, ...] = ()
+    if legacy_equivalent_count != expected_count:
+        warnings = (
+            "canonical_shadow_count_mismatch "
+            f"legacy={expected_count} "
+            f"canonical_legacy_equivalent={legacy_equivalent_count} "
+            f"canonical_total={len(canonical_opportunities)}",
+        )
+    return _CanonicalShadowResult(
+        offers_analyzed=len(canonical_offers),
+        opportunities_found=len(canonical_opportunities),
+        warnings=warnings,
+    )
+
+
+def _legacy_equivalent_shadow_count(opportunities, canonical_offers) -> int:
+    count = 0
+    basketball_same_line_keys: set[tuple[str, tuple[str, str]]] = set()
+
+    for opportunity in opportunities:
+        if opportunity.sport == "basketball":
+            if opportunity.opportunity_type == "same_line_arbitrage":
+                key = _basketball_same_line_shadow_legacy_key(
+                    opportunity,
+                    canonical_offers,
+                )
+                if key is not None:
+                    basketball_same_line_keys.add(key)
+                continue
+            count += 1
+            continue
+        if _is_legacy_equivalent_shadow_opportunity(opportunity):
+            count += 1
+
+    return count + len(basketball_same_line_keys)
+
+
+def _is_legacy_equivalent_shadow_opportunity(opportunity) -> bool:
+    if opportunity.sport == "basketball":
+        return True
+    if opportunity.sport == "football":
+        return opportunity.market_type in {
+            "football_total_goals",
+            "football_result_double_chance",
+        }
+    return False
+
+
+def _basketball_same_line_shadow_legacy_key(
+    opportunity,
+    canonical_offers,
+) -> tuple[str, tuple[str, str]] | None:
+    market_key = _opportunity_market_key(opportunity, canonical_offers)
+    if market_key is None:
+        return None
+    over_offers = {
+        offer.bookmaker_id: offer
+        for offer in canonical_offers
+        if offer.market_key == market_key and offer.outcome_code == "over"
+    }
+    leg_bookmakers = [leg.bookmaker_id for leg in opportunity.legs]
+    if len(leg_bookmakers) != 2:
+        return None
+    first = over_offers.get(leg_bookmakers[0])
+    second = over_offers.get(leg_bookmakers[1])
+    if first is None or second is None:
+        return None
+    if abs(first.odds - second.odds) < 0.05:
+        return None
+    return market_key, tuple(sorted((first.bookmaker_id, second.bookmaker_id)))
+
+
+def _opportunity_market_key(opportunity, canonical_offers) -> str | None:
+    candidate_keys: set[str] | None = None
+    for leg in opportunity.legs:
+        leg_keys = {
+            offer.market_key for offer in canonical_offers if _offer_matches_leg(offer, leg)
+        }
+        candidate_keys = leg_keys if candidate_keys is None else candidate_keys & leg_keys
+    if candidate_keys is not None and len(candidate_keys) == 1:
+        return next(iter(candidate_keys))
+    return None
+
+
+def _offer_matches_leg(offer, leg) -> bool:
+    return (
+        offer.bookmaker_id == leg.bookmaker_id
+        and offer.outcome_code == leg.outcome_code
+        and offer.odds == leg.odds
+        and offer.market.line == leg.line
+        and offer.market.source_market_type == leg.market_type
+        and (offer.market.bookmaker_match_id or offer.market.match_id) == leg.match_id
     )
 
 
@@ -795,15 +938,11 @@ class Scheduler:
             scrapers = registry.get_all()
             enabled_sports = set(settings.enabled_sport_list)
             scrape_started_at = time.perf_counter()
-            scrape_tasks = (
-                [
-                    self._scrape_one(scraper, league_id)
-                    for scraper in scrapers
-                    for league_id in scraper.get_supported_leagues()
-                ]
-                if "basketball" in enabled_sports
-                else []
-            )
+            scrape_tasks = [
+                self._scrape_one(scraper, league_id)
+                for scraper in scrapers
+                for league_id in _enabled_threshold_league_ids(scraper, enabled_sports)
+            ]
             outcome_scrape_tasks = [
                 self._scrape_outcome_one(scraper, sport)
                 for scraper in scrapers
@@ -845,6 +984,7 @@ class Scheduler:
             seen_matches: set[str] = set()
             discrepancies = []
             opportunities = []
+            canonical_shadow = _CanonicalShadowResult()
             notified = 0
             pending_auto_merges: list[tuple[int, int]] = []
             (
@@ -1035,6 +1175,23 @@ class Scheduler:
                         bookmaker_b_match_id=d.bookmaker_b_match_id,
                     )
 
+                try:
+                    canonical_shadow = await _run_canonical_shadow_analysis(
+                        match_ids=seen_matches,
+                        legacy_discrepancy_count=len(discrepancies),
+                        legacy_opportunity_count=len(opportunities),
+                    )
+                    if canonical_shadow.warnings:
+                        logger.warning(
+                            "Canonical shadow analysis warnings: %s",
+                            ", ".join(canonical_shadow.warnings),
+                        )
+                except Exception:
+                    logger.exception("Canonical shadow analysis failed")
+                    canonical_shadow = _CanonicalShadowResult(
+                        warnings=("canonical_shadow_failed",)
+                    )
+
                 self._scan_phase = "notifying"
                 notified = await self._notification_service.notify_discrepancies(
                     discrepancies
@@ -1091,6 +1248,9 @@ class Scheduler:
                 "outcome_offers_scraped": len(normalized_outcome_offers),
                 "discrepancies_found": len(discrepancies),
                 "opportunities_found": len(opportunities),
+                "canonical_offers_analyzed": canonical_shadow.offers_analyzed,
+                "canonical_opportunities_found": canonical_shadow.opportunities_found,
+                "canonical_shadow_warnings": list(canonical_shadow.warnings),
                 "notifications_sent": notified,
                 "scrape_duration_ms": scrape_duration_ms,
                 "cycle_duration_ms": int((time.perf_counter() - cycle_started_at) * 1000),

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -171,9 +171,9 @@ def _basketball_same_line_shadow_legacy_key(
     opportunity,
     canonical_offers,
 ) -> tuple[str, tuple[str, str]] | None:
-    market_key = _opportunity_market_key(opportunity, canonical_offers)
-    if market_key is None:
+    if len(opportunity.market_keys) != 1:
         return None
+    market_key = opportunity.market_keys[0]
     over_offers = {
         offer.bookmaker_id: offer
         for offer in canonical_offers
@@ -189,29 +189,6 @@ def _basketball_same_line_shadow_legacy_key(
     if abs(first.odds - second.odds) < 0.05:
         return None
     return market_key, tuple(sorted((first.bookmaker_id, second.bookmaker_id)))
-
-
-def _opportunity_market_key(opportunity, canonical_offers) -> str | None:
-    candidate_keys: set[str] | None = None
-    for leg in opportunity.legs:
-        leg_keys = {
-            offer.market_key for offer in canonical_offers if _offer_matches_leg(offer, leg)
-        }
-        candidate_keys = leg_keys if candidate_keys is None else candidate_keys & leg_keys
-    if candidate_keys is not None and len(candidate_keys) == 1:
-        return next(iter(candidate_keys))
-    return None
-
-
-def _offer_matches_leg(offer, leg) -> bool:
-    return (
-        offer.bookmaker_id == leg.bookmaker_id
-        and offer.outcome_code == leg.outcome_code
-        and offer.odds == leg.odds
-        and offer.market.line == leg.line
-        and offer.market.source_market_type == leg.market_type
-        and (offer.market.bookmaker_match_id or offer.market.match_id) == leg.match_id
-    )
 
 
 def _candidate_merge_source_ids(case) -> set[int]:

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -430,6 +430,60 @@ async def test_scheduler_shadow_counts_same_line_best_direction_once():
 
 
 @pytest.mark.asyncio
+async def test_scheduler_shadow_preserves_same_line_player_market_identity():
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds(
+                        "alpha",
+                        18.5,
+                        over_odds=2.10,
+                        under_odds=1.50,
+                        player_name="Sasha Vezenkov",
+                    ),
+                    _raw_odds(
+                        "alpha",
+                        18.5,
+                        over_odds=2.10,
+                        under_odds=1.50,
+                        player_name="Facundo Campazzo",
+                    ),
+                ]
+            },
+        ),
+        StubScraper(
+            "beta",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds(
+                        "beta",
+                        18.5,
+                        over_odds=2.00,
+                        under_odds=2.10,
+                        player_name="Sasha Vezenkov",
+                    ),
+                    _raw_odds(
+                        "beta",
+                        18.5,
+                        over_odds=2.00,
+                        under_odds=2.10,
+                        player_name="Facundo Campazzo",
+                    ),
+                ]
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["discrepancies_found"] == 2
+    assert result["canonical_opportunities_found"] == 2
+    assert result["canonical_shadow_warnings"] == []
+
+
+@pytest.mark.asyncio
 async def test_scheduler_shadow_analysis_handles_tennis_outcome_offers(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -6,7 +6,13 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from app.config import settings
-from app.models.schemas import NormalizedOdds, OpportunityLeg, RawOddsData, TeamReviewDiagnostic
+from app.models.schemas import (
+    NormalizedOdds,
+    OpportunityLeg,
+    RawOddsData,
+    RawOutcomeOffer,
+    TeamReviewDiagnostic,
+)
 from app.scrapers.base import BaseScraper
 from app.services.opportunity_analyzer import Opportunity
 from app.services.scheduler import Scheduler, _normalize_merge_pairings
@@ -32,6 +38,7 @@ def _raw_odds(
     *,
     over_odds: float = 1.9,
     under_odds: float = 1.9,
+    player_name: str = "Sasha Vezenkov",
 ) -> RawOddsData:
     return RawOddsData(
         bookmaker_id=bookmaker_id,
@@ -39,11 +46,33 @@ def _raw_odds(
         home_team="Olympiacos",
         away_team="Real Madrid",
         market_type="player_points",
-        player_name="Sasha Vezenkov",
+        player_name=player_name,
         threshold=threshold,
         over_odds=over_odds,
         under_odds=under_odds,
         start_time="2030-01-01T20:00:00",
+    )
+
+
+def _raw_outcome_offer(
+    bookmaker_id: str,
+    outcome_code: str,
+    *,
+    sport: str = "tennis",
+    market_type: str = "tennis_match_winner",
+    odds: float = 2.1,
+) -> RawOutcomeOffer:
+    return RawOutcomeOffer(
+        bookmaker_id=bookmaker_id,
+        league_id=f"{sport}_test_league",
+        sport=sport,
+        home_team="Novak Djokovic",
+        away_team="Carlos Alcaraz",
+        market_type=market_type,
+        outcome_code=outcome_code,
+        odds=odds,
+        raw_label=outcome_code,
+        start_time="2030-01-01T20:00:00+00:00",
     )
 
 
@@ -85,6 +114,10 @@ class StubScraper(BaseScraper):
         malformed_return: object = _UNSET,
         recorder: dict | None = None,
         payload_by_league: dict[str, list[RawOddsData]] | None = None,
+        odds_sports: tuple[str, ...] | None = None,
+        odds_leagues_by_sport: dict[str, list[str]] | None = None,
+        outcome_sports: tuple[str, ...] = (),
+        outcome_payload_by_sport: dict[str, list[RawOutcomeOffer]] | None = None,
     ) -> None:
         self._bookmaker_id = bookmaker_id
         self._bookmaker_name = bookmaker_name or bookmaker_id.title()
@@ -94,6 +127,10 @@ class StubScraper(BaseScraper):
         self._malformed_return = malformed_return
         self._recorder = recorder
         self._payload_by_league = payload_by_league or {}
+        self._odds_sports = odds_sports
+        self._odds_leagues_by_sport = odds_leagues_by_sport
+        self._outcome_sports = list(outcome_sports)
+        self._outcome_payload_by_sport = outcome_payload_by_sport or {}
 
     def get_bookmaker_id(self) -> str:
         return self._bookmaker_id
@@ -103,6 +140,24 @@ class StubScraper(BaseScraper):
 
     def get_supported_leagues(self) -> list[str]:
         return list(self._leagues)
+
+    def get_supported_odds_sports(self) -> list[str]:
+        if self._odds_sports is not None:
+            return list(self._odds_sports)
+        return super().get_supported_odds_sports()
+
+    def get_supported_odds_leagues(self) -> dict[str, list[str]]:
+        if self._odds_leagues_by_sport is not None:
+            return {
+                sport: list(league_ids)
+                for sport, league_ids in self._odds_leagues_by_sport.items()
+            }
+        if self._odds_sports is not None:
+            return {sport: list(self._leagues) for sport in self._odds_sports}
+        return super().get_supported_odds_leagues()
+
+    def get_supported_outcome_sports(self) -> list[str]:
+        return list(self._outcome_sports)
 
     async def scrape_odds(self, league_id: str) -> list[RawOddsData]:
         if self._recorder is not None:
@@ -124,6 +179,9 @@ class StubScraper(BaseScraper):
             if self._recorder is not None:
                 self._recorder["active"] -= 1
                 self._recorder["finishes"].append((self._bookmaker_id, league_id))
+
+    async def scrape_outcome_offers(self, sport: str) -> list[RawOutcomeOffer]:
+        return list(self._outcome_payload_by_sport.get(sport, []))
 
 
 def test_normalize_merge_pairings_flattens_valid_chains():
@@ -187,6 +245,222 @@ async def test_scheduler_run_cycle_overlaps_scraper_tasks():
     assert result["matches_scraped"] == 0
     assert result["odds_scraped"] == 0
     assert result["discrepancies_found"] == 0
+
+
+@pytest.mark.asyncio
+async def test_scheduler_threshold_scrape_uses_explicit_sport_capability(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    recorder = {"active": 0, "max_active": 0, "starts": [], "finishes": []}
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            recorder=recorder,
+            payload_by_league={"euroleague": [_raw_odds("alpha", 18.5)]},
+        )
+    )
+    monkeypatch.setattr(settings, "enabled_sports", "football")
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert recorder["starts"] == []
+    assert result["odds_scraped"] == 0
+    assert result["canonical_offers_analyzed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_scheduler_threshold_scrape_runs_only_enabled_sport_leagues(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    recorder = {"active": 0, "max_active": 0, "starts": [], "finishes": []}
+    _register_test_scrapers(
+        StubScraper(
+            "multi",
+            leagues=("euroleague", "football_league"),
+            odds_leagues_by_sport={
+                "basketball": ["euroleague"],
+                "football": ["football_league"],
+            },
+            recorder=recorder,
+            payload_by_league={
+                "euroleague": [_raw_odds("multi", 18.5)],
+                "football_league": [
+                    _raw_odds("multi", 20.5).model_copy(
+                        update={"sport": "football", "league_id": "football_league"}
+                    )
+                ],
+            },
+        )
+    )
+    monkeypatch.setattr(settings, "enabled_sports", "football")
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert recorder["starts"] == [("multi", "football_league")]
+    assert recorder["finishes"] == [("multi", "football_league")]
+    assert result["matches_scraped"] == 0
+
+
+@pytest.mark.asyncio
+async def test_scheduler_runs_canonical_shadow_analysis_for_current_snapshot():
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            payload_by_league={"euroleague": [_raw_odds("alpha", 18.5)]},
+        ),
+        StubScraper(
+            "beta",
+            payload_by_league={"euroleague": [_raw_odds("beta", 20.5)]},
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["discrepancies_found"] == 1
+    assert result["opportunities_found"] == 0
+    assert result["canonical_offers_analyzed"] == 4
+    assert result["canonical_opportunities_found"] == 1
+    assert result["canonical_shadow_warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_shadow_ignores_canonical_only_basketball_same_line_arbitrage():
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            payload_by_league={
+                "euroleague": [_raw_odds("alpha", 18.5, over_odds=2.10, under_odds=2.10)]
+            },
+        ),
+        StubScraper(
+            "beta",
+            payload_by_league={
+                "euroleague": [_raw_odds("beta", 18.5, over_odds=2.10, under_odds=2.10)]
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["discrepancies_found"] == 0
+    assert result["canonical_opportunities_found"] == 2
+    assert result["canonical_shadow_warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_shadow_matches_same_line_player_markets_with_shared_leg_fields():
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds(
+                        "alpha",
+                        18.5,
+                        over_odds=2.10,
+                        under_odds=1.50,
+                        player_name="Sasha Vezenkov",
+                    ),
+                    _raw_odds(
+                        "alpha",
+                        18.5,
+                        over_odds=2.10,
+                        under_odds=1.50,
+                        player_name="Facundo Campazzo",
+                    ),
+                ]
+            },
+        ),
+        StubScraper(
+            "beta",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds(
+                        "beta",
+                        18.5,
+                        over_odds=2.00,
+                        under_odds=2.10,
+                        player_name="Sasha Vezenkov",
+                    ),
+                    _raw_odds(
+                        "beta",
+                        18.5,
+                        over_odds=2.00,
+                        under_odds=2.20,
+                        player_name="Facundo Campazzo",
+                    ),
+                ]
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["discrepancies_found"] == 2
+    assert result["canonical_opportunities_found"] == 2
+    assert result["canonical_shadow_warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_shadow_counts_same_line_best_direction_once():
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds("alpha", 18.5, over_odds=2.10, under_odds=2.10)
+                ]
+            },
+        ),
+        StubScraper(
+            "beta",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds("beta", 18.5, over_odds=2.00, under_odds=2.10)
+                ]
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["discrepancies_found"] == 1
+    assert result["canonical_opportunities_found"] == 2
+    assert result["canonical_shadow_warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_shadow_analysis_handles_tennis_outcome_offers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "enabled_sports", "tennis")
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            leagues=(),
+            outcome_sports=("tennis",),
+            outcome_payload_by_sport={
+                "tennis": [_raw_outcome_offer("alpha", "home")],
+            },
+        ),
+        StubScraper(
+            "beta",
+            leagues=(),
+            outcome_sports=("tennis",),
+            outcome_payload_by_sport={
+                "tennis": [_raw_outcome_offer("beta", "away")],
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["odds_scraped"] == 0
+    assert result["outcome_offers_scraped"] == 2
+    assert result["opportunities_found"] == 0
+    assert result["canonical_offers_analyzed"] == 2
+    assert result["canonical_opportunities_found"] == 1
+    assert result["canonical_shadow_warnings"] == []
 
 
 @pytest.mark.asyncio
@@ -432,17 +706,27 @@ async def test_scheduler_run_cycle_returns_expected_output_shape():
     assert {
         "matches_scraped",
         "odds_scraped",
+        "outcome_offers_scraped",
         "discrepancies_found",
+        "opportunities_found",
+        "canonical_offers_analyzed",
+        "canonical_opportunities_found",
+        "canonical_shadow_warnings",
         "notifications_sent",
     } <= result.keys()
     for key in (
         "matches_scraped",
         "odds_scraped",
+        "outcome_offers_scraped",
         "discrepancies_found",
+        "opportunities_found",
+        "canonical_offers_analyzed",
+        "canonical_opportunities_found",
         "notifications_sent",
     ):
         assert isinstance(result[key], int)
         assert result[key] >= 0
+    assert isinstance(result["canonical_shadow_warnings"], list)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add explicit threshold-odds scraper capability mapping so scheduler threshold scraping is gated by enabled sport leagues
- run canonical offer analysis in scheduler shadow mode after legacy persistence, exposing additive cycle counts and warnings while leaving existing writes/API unchanged
- cover basketball parity, canonical-only same-line noise, non-basketball capability scheduling, and synthetic tennis outcome shadow analysis

## Validation
- cd backend && ./venv/bin/python -m compileall -q app tests && ./venv/bin/pytest -q
- cd backend && ./venv/bin/pytest tests/test_scheduler.py tests/test_canonical_offers.py tests/test_canonical_analyzer.py -q
- final focused code review found no significant issues after fixes

Refs #54