### PR TITLE
Persist canonical analyzer opportunities

### DIFF
--- a/backend/app/api/opportunities.py
+++ b/backend/app/api/opportunities.py
@@ -16,6 +16,7 @@ async def list_opportunities(
     sport: Optional[str] = Query(None),
     bookmaker_ids: Optional[str] = Query(None),
     market_type: Optional[str] = Query(None),
+    include_legacy_discrepancy_overlap: bool = Query(False),
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
@@ -23,6 +24,7 @@ async def list_opportunities(
         sport=sport,
         bookmaker_ids=parse_csv_query_values(bookmaker_ids),
         market_type=market_type,
+        include_legacy_discrepancy_overlap=include_legacy_discrepancy_overlap,
         limit=limit,
         offset=offset,
     )
@@ -45,4 +47,3 @@ async def list_market_offers(
         limit=limit,
         offset=offset,
     )
-

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -65,6 +65,12 @@ class _CanonicalShadowResult:
     warnings: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class _CanonicalAnalysisResult:
+    offers: tuple = ()
+    opportunities: tuple = ()
+
+
 def _is_auto_alias_candidate(case) -> bool:
     return (
         case.review_kind in {"alias_suggestion", "candidate_search"}
@@ -89,12 +95,7 @@ def _enabled_threshold_league_ids(scraper: BaseScraper, enabled_sports: set[str]
     return list(dict.fromkeys(league_ids))
 
 
-async def _run_canonical_shadow_analysis(
-    *,
-    match_ids: set[str],
-    legacy_discrepancy_count: int,
-    legacy_opportunity_count: int,
-) -> _CanonicalShadowResult:
+async def _load_current_canonical_analysis(match_ids: set[str]) -> _CanonicalAnalysisResult:
     canonical_offers = await odds_store.get_current_canonical_offers_for_matches(
         sorted(match_ids)
     )
@@ -114,10 +115,22 @@ async def _run_canonical_shadow_analysis(
         canonical_offers,
         event_primary_match_ids=event_primary_match_ids,
     )
+    return _CanonicalAnalysisResult(
+        offers=tuple(canonical_offers),
+        opportunities=tuple(canonical_opportunities),
+    )
+
+
+def _canonical_shadow_result(
+    canonical_analysis: _CanonicalAnalysisResult,
+    *,
+    legacy_discrepancy_count: int,
+    legacy_opportunity_count: int,
+) -> _CanonicalShadowResult:
     expected_count = legacy_discrepancy_count + legacy_opportunity_count
     legacy_equivalent_count = _legacy_equivalent_shadow_count(
-        canonical_opportunities,
-        canonical_offers,
+        canonical_analysis.opportunities,
+        canonical_analysis.offers,
     )
     warnings: tuple[str, ...] = ()
     if legacy_equivalent_count != expected_count:
@@ -125,11 +138,11 @@ async def _run_canonical_shadow_analysis(
             "canonical_shadow_count_mismatch "
             f"legacy={expected_count} "
             f"canonical_legacy_equivalent={legacy_equivalent_count} "
-            f"canonical_total={len(canonical_opportunities)}",
+            f"canonical_total={len(canonical_analysis.opportunities)}",
         )
     return _CanonicalShadowResult(
-        offers_analyzed=len(canonical_offers),
-        opportunities_found=len(canonical_opportunities),
+        offers_analyzed=len(canonical_analysis.offers),
+        opportunities_found=len(canonical_analysis.opportunities),
         warnings=warnings,
     )
 
@@ -961,6 +974,7 @@ class Scheduler:
             seen_matches: set[str] = set()
             discrepancies = []
             opportunities = []
+            legacy_outcome_opportunities = []
             canonical_shadow = _CanonicalShadowResult()
             notified = 0
             pending_auto_merges: list[tuple[int, int]] = []
@@ -1108,7 +1122,6 @@ class Scheduler:
                     event_members=discrepancy_event_members,
                     event_primary_match_ids=discrepancy_event_primary_match_ids,
                 )
-                await odds_store.deactivate_opportunities()
                 opportunity_event_members = (
                     await odds_store.get_eligible_resolved_event_members_for_outcome_offers(
                         normalized_outcome_offers
@@ -1122,16 +1135,29 @@ class Scheduler:
                         ]
                     )
                 )
-                opportunities = analyze_outcome_offers(
+                legacy_outcome_opportunities = analyze_outcome_offers(
                     normalized_outcome_offers,
                     event_members=opportunity_event_members,
                     event_primary_match_ids=opportunity_event_primary_match_ids,
                 )
-                for opportunity in opportunities:
-                    await odds_store.insert_opportunity(
-                        opportunity,
-                        detected_at=cycle_scraped_at,
+                canonical_analysis = _CanonicalAnalysisResult()
+                canonical_analysis_failed = False
+                try:
+                    canonical_analysis = await _load_current_canonical_analysis(
+                        match_ids=seen_matches,
                     )
+                except Exception:
+                    canonical_analysis_failed = True
+                    logger.exception("Canonical opportunity analysis failed")
+                opportunities = list(canonical_analysis.opportunities)
+
+                if not canonical_analysis_failed:
+                    await odds_store.deactivate_opportunities()
+                    for opportunity in opportunities:
+                        await odds_store.insert_opportunity(
+                            opportunity,
+                            detected_at=cycle_scraped_at,
+                        )
 
                 for d in discrepancies:
                     await odds_store.insert_discrepancy(
@@ -1152,21 +1178,20 @@ class Scheduler:
                         bookmaker_b_match_id=d.bookmaker_b_match_id,
                     )
 
-                try:
-                    canonical_shadow = await _run_canonical_shadow_analysis(
-                        match_ids=seen_matches,
-                        legacy_discrepancy_count=len(discrepancies),
-                        legacy_opportunity_count=len(opportunities),
-                    )
-                    if canonical_shadow.warnings:
-                        logger.warning(
-                            "Canonical shadow analysis warnings: %s",
-                            ", ".join(canonical_shadow.warnings),
-                        )
-                except Exception:
-                    logger.exception("Canonical shadow analysis failed")
+                if canonical_analysis_failed:
                     canonical_shadow = _CanonicalShadowResult(
-                        warnings=("canonical_shadow_failed",)
+                        warnings=("canonical_analysis_failed",)
+                    )
+                else:
+                    canonical_shadow = _canonical_shadow_result(
+                        canonical_analysis,
+                        legacy_discrepancy_count=len(discrepancies),
+                        legacy_opportunity_count=len(legacy_outcome_opportunities),
+                    )
+                if canonical_shadow.warnings:
+                    logger.warning(
+                        "Canonical shadow analysis warnings: %s",
+                        ", ".join(canonical_shadow.warnings),
                     )
 
                 self._scan_phase = "notifying"

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1151,8 +1151,8 @@ class Scheduler:
                     logger.exception("Canonical opportunity analysis failed")
                 opportunities = list(canonical_analysis.opportunities)
 
+                await odds_store.deactivate_opportunities()
                 if not canonical_analysis_failed:
-                    await odds_store.deactivate_opportunities()
                     for opportunity in opportunities:
                         await odds_store.insert_opportunity(
                             opportunity,

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -1948,6 +1948,7 @@ async def get_opportunities(
     sport: str | None = None,
     bookmaker_ids: list[str] | None = None,
     market_type: str | None = None,
+    include_legacy_discrepancy_overlap: bool = True,
     limit: int = 100,
     offset: int = 0,
 ) -> list[OpportunityOut]:
@@ -1961,6 +1962,9 @@ async def get_opportunities(
     if sport:
         conditions.append("op.sport = ?")
         params.append(sport)
+    if not include_legacy_discrepancy_overlap:
+        conditions.append("op.sport != ?")
+        params.append("basketball")
     if market_type:
         conditions.append("op.market_type = ?")
         params.append(market_type)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -12,6 +12,7 @@ from app.main import app
 from app.models.schemas import (
     NormalizedOdds,
     NormalizedOutcomeOffer,
+    OpportunityLeg,
     RawOddsData,
     TeamReviewDiagnostic,
     UnresolvedOddsDiagnostic,
@@ -21,7 +22,7 @@ from app.scrapers.mock_scraper import MockScraper
 from app.scrapers.registry import registry
 from app.services.scheduler import scheduler
 from app.services.normalizer import normalize_team_name
-from app.services.opportunity_analyzer import analyze_outcome_offers
+from app.services.opportunity_analyzer import Opportunity, analyze_outcome_offers
 from app.services.team_registry import create_canonical_team, remember_team_alias
 from app.store import odds_store
 
@@ -295,6 +296,69 @@ async def test_football_market_offers_and_opportunities_api(client: AsyncClient)
     )
     assert no_match_resp.status_code == 200
     assert no_match_resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_opportunities_api_hides_basketball_overlap_by_default(client: AsyncClient):
+    await odds_store.upsert_league("euroleague", "EuroLeague", "basketball")
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.upsert_match(
+        id="basketball-match",
+        league_id="euroleague",
+        sport="basketball",
+        home_team="Olympiacos",
+        away_team="Real Madrid",
+        start_time="2030-01-01T20:00:00+00:00",
+    )
+    await odds_store.insert_opportunity(
+        Opportunity(
+            sport="basketball",
+            match_id="basketball-match",
+            opportunity_type="middle",
+            market_type="player_points",
+            line=18.5,
+            profit_margin=0.02,
+            middle_profit_margin=0.50,
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="mozzart",
+                    market_type="player_points",
+                    outcome_code="over",
+                    line=18.5,
+                    odds=1.90,
+                ),
+                OpportunityLeg(
+                    bookmaker_id="meridian",
+                    market_type="player_points",
+                    outcome_code="under",
+                    line=20.5,
+                    odds=2.10,
+                ),
+            ],
+        ),
+        detected_at="2030-01-01T20:00:00",
+    )
+
+    default_resp = await client.get("/api/v1/opportunities")
+    basketball_resp = await client.get(
+        "/api/v1/opportunities",
+        params={"sport": "basketball"},
+    )
+    opt_in_resp = await client.get(
+        "/api/v1/opportunities",
+        params={
+            "sport": "basketball",
+            "include_legacy_discrepancy_overlap": "true",
+        },
+    )
+
+    assert default_resp.status_code == 200
+    assert basketball_resp.status_code == 200
+    assert opt_in_resp.status_code == 200
+    assert default_resp.json() == []
+    assert basketball_resp.json() == []
+    assert [row["sport"] for row in opt_in_resp.json()] == ["basketball"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -698,6 +698,45 @@ async def test_scheduler_canonical_analysis_failure_preserves_discrepancies(
         "app.services.scheduler._load_current_canonical_analysis",
         fail_canonical_analysis,
     )
+    await odds_store.upsert_league("premier-league", "Premier League", "football")
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+    await odds_store.upsert_bookmaker("balkanbet", "BalkanBet")
+    await odds_store.upsert_match(
+        id="stale-football-match",
+        league_id="premier-league",
+        sport="football",
+        home_team="Arsenal",
+        away_team="Chelsea",
+        start_time="2030-01-01T20:00:00+00:00",
+    )
+    await odds_store.insert_opportunity(
+        Opportunity(
+            sport="football",
+            match_id="stale-football-match",
+            opportunity_type="same_line_arbitrage",
+            market_type="football_total_goals",
+            line=2.5,
+            profit_margin=0.02,
+            middle_profit_margin=None,
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="maxbet",
+                    market_type="football_total_goals",
+                    outcome_code="under",
+                    line=2.5,
+                    odds=1.95,
+                ),
+                OpportunityLeg(
+                    bookmaker_id="balkanbet",
+                    market_type="football_total_goals",
+                    outcome_code="over",
+                    line=2.5,
+                    odds=2.10,
+                ),
+            ],
+        ),
+        detected_at="2029-01-01T00:00:00",
+    )
     _register_test_scrapers(
         StubScraper(
             "alpha",
@@ -715,6 +754,7 @@ async def test_scheduler_canonical_analysis_failure_preserves_discrepancies(
     assert result["opportunities_found"] == 0
     assert result["canonical_shadow_warnings"] == ["canonical_analysis_failed"]
     assert len(await odds_store.get_discrepancies(market_type="player_points")) == 1
+    assert await odds_store.get_opportunities(sport="football") == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -38,14 +38,15 @@ def _raw_odds(
     *,
     over_odds: float = 1.9,
     under_odds: float = 1.9,
-    player_name: str = "Sasha Vezenkov",
+    player_name: str | None = "Sasha Vezenkov",
+    market_type: str = "player_points",
 ) -> RawOddsData:
     return RawOddsData(
         bookmaker_id=bookmaker_id,
         league_id="euroleague",
         home_team="Olympiacos",
         away_team="Real Madrid",
-        market_type="player_points",
+        market_type=market_type,
         player_name=player_name,
         threshold=threshold,
         over_odds=over_odds,
@@ -61,6 +62,7 @@ def _raw_outcome_offer(
     sport: str = "tennis",
     market_type: str = "tennis_match_winner",
     odds: float = 2.1,
+    line: float | None = None,
 ) -> RawOutcomeOffer:
     return RawOutcomeOffer(
         bookmaker_id=bookmaker_id,
@@ -71,6 +73,7 @@ def _raw_outcome_offer(
         market_type=market_type,
         outcome_code=outcome_code,
         odds=odds,
+        line=line,
         raw_label=outcome_code,
         start_time="2030-01-01T20:00:00+00:00",
     )
@@ -317,10 +320,63 @@ async def test_scheduler_runs_canonical_shadow_analysis_for_current_snapshot():
     result = await Scheduler(interval_minutes=1).run_cycle()
 
     assert result["discrepancies_found"] == 1
-    assert result["opportunities_found"] == 0
+    assert result["opportunities_found"] == 1
     assert result["canonical_offers_analyzed"] == 4
     assert result["canonical_opportunities_found"] == 1
     assert result["canonical_shadow_warnings"] == []
+    opportunities = await odds_store.get_opportunities(sport="basketball")
+    assert [(item.opportunity_type, item.market_type) for item in opportunities] == [
+        ("middle", "player_points")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_persists_canonical_basketball_total_opportunity():
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds(
+                        "alpha",
+                        160.5,
+                        over_odds=1.90,
+                        under_odds=1.80,
+                        player_name=None,
+                        market_type="game_total",
+                    )
+                ]
+            },
+        ),
+        StubScraper(
+            "beta",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds(
+                        "beta",
+                        162.5,
+                        over_odds=1.70,
+                        under_odds=2.10,
+                        player_name=None,
+                        market_type="game_total",
+                    )
+                ]
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["discrepancies_found"] == 1
+    assert result["opportunities_found"] == 1
+    opportunities = await odds_store.get_opportunities(sport="basketball")
+    assert len(opportunities) == 1
+    assert opportunities[0].opportunity_type == "middle"
+    assert opportunities[0].market_type == "game_total"
+    assert [(leg.bookmaker_id, leg.outcome_code, leg.line) for leg in opportunities[0].legs] == [
+        ("alpha", "over", 160.5),
+        ("beta", "under", 162.5),
+    ]
 
 
 @pytest.mark.asyncio
@@ -343,6 +399,7 @@ async def test_scheduler_shadow_ignores_canonical_only_basketball_same_line_arbi
     result = await Scheduler(interval_minutes=1).run_cycle()
 
     assert result["discrepancies_found"] == 0
+    assert result["opportunities_found"] == 2
     assert result["canonical_opportunities_found"] == 2
     assert result["canonical_shadow_warnings"] == []
 
@@ -397,6 +454,7 @@ async def test_scheduler_shadow_matches_same_line_player_markets_with_shared_leg
     result = await Scheduler(interval_minutes=1).run_cycle()
 
     assert result["discrepancies_found"] == 2
+    assert result["opportunities_found"] == 2
     assert result["canonical_opportunities_found"] == 2
     assert result["canonical_shadow_warnings"] == []
 
@@ -425,6 +483,7 @@ async def test_scheduler_shadow_counts_same_line_best_direction_once():
     result = await Scheduler(interval_minutes=1).run_cycle()
 
     assert result["discrepancies_found"] == 1
+    assert result["opportunities_found"] == 2
     assert result["canonical_opportunities_found"] == 2
     assert result["canonical_shadow_warnings"] == []
 
@@ -479,8 +538,115 @@ async def test_scheduler_shadow_preserves_same_line_player_market_identity():
     result = await Scheduler(interval_minutes=1).run_cycle()
 
     assert result["discrepancies_found"] == 2
+    assert result["opportunities_found"] == 2
     assert result["canonical_opportunities_found"] == 2
     assert result["canonical_shadow_warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_persists_canonical_football_total_opportunity(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "enabled_sports", "football")
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            leagues=(),
+            outcome_sports=("football",),
+            outcome_payload_by_sport={
+                "football": [
+                    _raw_outcome_offer(
+                        "alpha",
+                        "over",
+                        sport="football",
+                        market_type="football_total_goals",
+                        odds=1.90,
+                        line=2.5,
+                    )
+                ],
+            },
+        ),
+        StubScraper(
+            "beta",
+            leagues=(),
+            outcome_sports=("football",),
+            outcome_payload_by_sport={
+                "football": [
+                    _raw_outcome_offer(
+                        "beta",
+                        "under",
+                        sport="football",
+                        market_type="football_total_goals",
+                        odds=2.10,
+                        line=3.5,
+                    )
+                ],
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["opportunities_found"] == 1
+    assert result["canonical_opportunities_found"] == 1
+    opportunities = await odds_store.get_opportunities(sport="football")
+    assert [(item.opportunity_type, item.market_type) for item in opportunities] == [
+        ("middle", "football_total_goals")
+    ]
+    assert [(leg.bookmaker_id, leg.outcome_code, leg.line) for leg in opportunities[0].legs] == [
+        ("alpha", "over", 2.5),
+        ("beta", "under", 3.5),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_persists_canonical_football_complementary_opportunity(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "enabled_sports", "football")
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            leagues=(),
+            outcome_sports=("football",),
+            outcome_payload_by_sport={
+                "football": [
+                    _raw_outcome_offer(
+                        "alpha",
+                        "home",
+                        sport="football",
+                        market_type="football_result",
+                        odds=2.10,
+                    )
+                ],
+            },
+        ),
+        StubScraper(
+            "beta",
+            leagues=(),
+            outcome_sports=("football",),
+            outcome_payload_by_sport={
+                "football": [
+                    _raw_outcome_offer(
+                        "beta",
+                        "draw_or_away",
+                        sport="football",
+                        market_type="football_double_chance",
+                        odds=2.10,
+                    )
+                ],
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["opportunities_found"] == 1
+    assert result["canonical_opportunities_found"] == 1
+    opportunities = await odds_store.get_opportunities(sport="football")
+    assert [(item.opportunity_type, item.market_type) for item in opportunities] == [
+        ("complementary_outcomes", "football_result_double_chance")
+    ]
 
 
 @pytest.mark.asyncio
@@ -511,10 +677,44 @@ async def test_scheduler_shadow_analysis_handles_tennis_outcome_offers(
 
     assert result["odds_scraped"] == 0
     assert result["outcome_offers_scraped"] == 2
-    assert result["opportunities_found"] == 0
+    assert result["opportunities_found"] == 1
     assert result["canonical_offers_analyzed"] == 2
     assert result["canonical_opportunities_found"] == 1
     assert result["canonical_shadow_warnings"] == []
+    opportunities = await odds_store.get_opportunities(sport="tennis")
+    assert [(item.opportunity_type, item.market_type) for item in opportunities] == [
+        ("same_line_arbitrage", "match_winner")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_canonical_analysis_failure_preserves_discrepancies(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fail_canonical_analysis(match_ids: set[str]):
+        raise RuntimeError("canonical boom")
+
+    monkeypatch.setattr(
+        "app.services.scheduler._load_current_canonical_analysis",
+        fail_canonical_analysis,
+    )
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            payload_by_league={"euroleague": [_raw_odds("alpha", 18.5)]},
+        ),
+        StubScraper(
+            "beta",
+            payload_by_league={"euroleague": [_raw_odds("beta", 20.5)]},
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["discrepancies_found"] == 1
+    assert result["opportunities_found"] == 0
+    assert result["canonical_shadow_warnings"] == ["canonical_analysis_failed"]
+    assert len(await odds_store.get_discrepancies(market_type="player_points")) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist canonical analyzer output to the existing `opportunities` table as the primary generic opportunities source
- keep legacy basketball discrepancy writes active and use legacy outcome analysis only for parity diagnostics
- preserve canonical counters/warnings and isolate canonical analysis failures so discrepancy persistence and notifications still proceed
- add scheduler coverage for basketball player props/totals, football totals/complementary outcomes, tennis winner persistence, and canonical failure degradation

## Validation
- cd backend && ./venv/bin/pytest tests/test_scheduler.py -q
- cd backend && ./venv/bin/pytest tests/test_scheduler.py tests/test_canonical_analyzer.py tests/test_store.py tests/test_api.py tests/test_resolved_event_analysis.py tests/test_match_merge.py -q
- cd backend && ./venv/bin/python -m compileall -q app tests && ./venv/bin/pytest -q
- three-reviewer adversarial pass after failure-isolation fix: no significant issues found

Closes #60