### PR TITLE
Add generic opportunities API shape

### DIFF
--- a/backend/app/api/opportunities.py
+++ b/backend/app/api/opportunities.py
@@ -16,10 +16,17 @@ async def list_opportunities(
     sport: Optional[str] = Query(None),
     bookmaker_ids: Optional[str] = Query(None),
     market_type: Optional[str] = Query(None),
-    include_legacy_discrepancy_overlap: bool = Query(False),
+    include_legacy_discrepancy_overlap: bool = Query(
+        False,
+        description=(
+            "Compatibility guard for the current Dashboard: basketball canonical "
+            "opportunities overlap legacy discrepancies unless explicitly included."
+        ),
+    ),
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
+    """Return the generic canonical opportunity shape across supported sports."""
     return await odds_store.get_opportunities(
         sport=sport,
         bookmaker_ids=parse_csv_query_values(bookmaker_ids),

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -179,9 +179,13 @@ CREATE TABLE IF NOT EXISTS opportunities (
     resolved_event_id TEXT REFERENCES resolved_events(id),
     opportunity_type TEXT NOT NULL,
     market_type TEXT NOT NULL,
+    subject_type TEXT,
+    subject_key TEXT,
+    subject_name TEXT,
     line REAL,
     profit_margin REAL,
     middle_profit_margin REAL,
+    market_keys TEXT NOT NULL DEFAULT '[]',
     legs TEXT NOT NULL DEFAULT '[]',
     detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     is_active BOOLEAN DEFAULT TRUE
@@ -488,9 +492,13 @@ async def _rebuild_opportunities(conn: aiosqlite.Connection) -> None:
             resolved_event_id TEXT REFERENCES resolved_events(id),
             opportunity_type TEXT NOT NULL,
             market_type TEXT NOT NULL,
+            subject_type TEXT,
+            subject_key TEXT,
+            subject_name TEXT,
             line REAL,
             profit_margin REAL,
             middle_profit_margin REAL,
+            market_keys TEXT NOT NULL DEFAULT '[]',
             legs TEXT NOT NULL DEFAULT '[]',
             detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             is_active BOOLEAN DEFAULT TRUE
@@ -506,9 +514,13 @@ async def _rebuild_opportunities(conn: aiosqlite.Connection) -> None:
             resolved_event_id,
             opportunity_type,
             market_type,
+            subject_type,
+            subject_key,
+            subject_name,
             line,
             profit_margin,
             middle_profit_margin,
+            market_keys,
             legs,
             detected_at,
             is_active
@@ -528,9 +540,13 @@ async def _rebuild_opportunities(conn: aiosqlite.Connection) -> None:
             END,
             opportunity_type,
             market_type,
+            subject_type,
+            subject_key,
+            subject_name,
             line,
             profit_margin,
             middle_profit_margin,
+            market_keys,
             legs,
             detected_at,
             is_active
@@ -751,9 +767,13 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
                resolved_event_id TEXT REFERENCES resolved_events(id),
                opportunity_type TEXT NOT NULL,
                market_type TEXT NOT NULL,
+               subject_type TEXT,
+               subject_key TEXT,
+               subject_name TEXT,
                line REAL,
                profit_margin REAL,
                middle_profit_margin REAL,
+               market_keys TEXT NOT NULL DEFAULT '[]',
                legs TEXT NOT NULL DEFAULT '[]',
                detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                is_active BOOLEAN DEFAULT TRUE
@@ -770,6 +790,16 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
     if opportunity_columns and "resolved_event_id" not in existing_opportunities:
         await conn.execute(
             "ALTER TABLE opportunities ADD COLUMN resolved_event_id TEXT REFERENCES resolved_events(id)"
+        )
+    if opportunity_columns and "subject_type" not in existing_opportunities:
+        await conn.execute("ALTER TABLE opportunities ADD COLUMN subject_type TEXT")
+    if opportunity_columns and "subject_key" not in existing_opportunities:
+        await conn.execute("ALTER TABLE opportunities ADD COLUMN subject_key TEXT")
+    if opportunity_columns and "subject_name" not in existing_opportunities:
+        await conn.execute("ALTER TABLE opportunities ADD COLUMN subject_name TEXT")
+    if opportunity_columns and "market_keys" not in existing_opportunities:
+        await conn.execute(
+            "ALTER TABLE opportunities ADD COLUMN market_keys TEXT NOT NULL DEFAULT '[]'"
         )
     if opportunity_columns and not await _table_has_foreign_key(
         conn,

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -379,6 +379,7 @@ class OpportunityLeg(BaseModel):
 class OpportunityOut(BaseModel):
     id: int
     sport: str
+    event_id: Optional[str] = None
     match_id: str
     resolved_event_id: Optional[str] = None
     home_team: Optional[str] = None
@@ -387,9 +388,13 @@ class OpportunityOut(BaseModel):
     start_time: Optional[str] = None
     opportunity_type: str
     market_type: str
+    subject_type: Optional[str] = None
+    subject_key: Optional[str] = None
+    subject_name: Optional[str] = None
     line: Optional[float] = None
     profit_margin: Optional[float] = None
     middle_profit_margin: Optional[float] = None
+    market_keys: list[str] = Field(default_factory=list)
     legs: list[OpportunityLeg] = Field(default_factory=list)
     detected_at: Optional[str] = None
     is_active: bool = True

--- a/backend/app/services/canonical_analyzer.py
+++ b/backend/app/services/canonical_analyzer.py
@@ -91,6 +91,9 @@ def _analyze_two_way_arbitrage(
                 middle_profit_margin=None,
                 legs=[_leg(first), _leg(second)],
                 resolved_event_id=context.resolved_event_id,
+                subject_type=market.subject_type,
+                subject_key=market.subject_key,
+                subject_name=market.subject_name,
                 market_keys=(market.market_key,),
             )
         )
@@ -131,6 +134,10 @@ def _analyze_line_middle(
         ):
             continue
 
+        subject_type, subject_key, subject_name = _subject_metadata(
+            low.market,
+            high.market,
+        )
         opportunities.append(
             Opportunity(
                 sport=low.market.sport,
@@ -142,6 +149,9 @@ def _analyze_line_middle(
                 middle_profit_margin=middle_margin,
                 legs=[_leg(low), _leg(high)],
                 resolved_event_id=context.resolved_event_id,
+                subject_type=subject_type,
+                subject_key=subject_key,
+                subject_name=subject_name,
                 market_keys=tuple(sorted({low.market_key, high.market_key})),
             )
         )
@@ -170,6 +180,10 @@ def _analyze_complementary_outcomes(
                 margin = _profit_margin(result_offer.odds, double_chance_offer.odds)
                 if margin is None or margin <= 0:
                     continue
+                subject_type, subject_key, subject_name = _subject_metadata(
+                    result_offer.market,
+                    double_chance_offer.market,
+                )
                 opportunities.append(
                     Opportunity(
                         sport=result_offer.market.sport,
@@ -181,6 +195,9 @@ def _analyze_complementary_outcomes(
                         middle_profit_margin=None,
                         legs=[_leg(result_offer), _leg(double_chance_offer)],
                         resolved_event_id=context.resolved_event_id,
+                        subject_type=subject_type,
+                        subject_key=subject_key,
+                        subject_name=subject_name,
                         market_keys=tuple(
                             sorted(
                                 {
@@ -271,6 +288,24 @@ def _market_family_key(
     if include_market_type:
         key.insert(2, market.market_type)
     return tuple(key)
+
+
+def _subject_metadata(
+    first: CanonicalMarket,
+    second: CanonicalMarket | None = None,
+) -> tuple[str | None, str | None, str | None]:
+    markets = [market for market in (first, second) if market is not None]
+    subject_types = {market.subject_type for market in markets if market.subject_type}
+    subject_type = sorted(subject_types)[0] if len(subject_types) == 1 else None
+    subject_key = next(
+        (market.subject_key for market in markets if market.subject_key),
+        None,
+    )
+    subject_name = next(
+        (market.subject_name for market in markets if market.subject_name),
+        None,
+    )
+    return subject_type, subject_key, subject_name
 
 
 def _event_identity(offer: CanonicalOffer) -> str:

--- a/backend/app/services/opportunity_analyzer.py
+++ b/backend/app/services/opportunity_analyzer.py
@@ -18,6 +18,9 @@ class Opportunity:
     middle_profit_margin: float | None
     legs: list[OpportunityLeg]
     resolved_event_id: str | None = None
+    subject_type: str | None = None
+    subject_key: str | None = None
+    subject_name: str | None = None
     market_keys: tuple[str, ...] = ()
 
 

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -1975,7 +1975,55 @@ async def get_opportunities(
         conditions.append("op.sport = ?")
         params.append(sport)
     if not include_legacy_discrepancy_overlap:
-        conditions.append("op.sport != ?")
+        conditions.append(
+            """NOT (
+                   op.sport = ?
+                   AND EXISTS (
+                       SELECT 1
+                       FROM discrepancies d
+                       WHERE d.is_active = TRUE
+                         AND d.market_type = op.market_type
+                         AND (
+                             d.match_id = op.match_id
+                             OR (
+                                 d.resolved_event_id IS NOT NULL
+                                 AND d.resolved_event_id = op.resolved_event_id
+                             )
+                         )
+                         AND (
+                             (op.subject_type = 'player' AND d.player_name = op.subject_name)
+                             OR (
+                                 COALESCE(op.subject_type, 'event') != 'player'
+                                 AND d.player_name IS NULL
+                             )
+                         )
+                         AND EXISTS (
+                             SELECT 1
+                             FROM json_each(op.legs) AS over_leg
+                             WHERE json_extract(over_leg.value, '$.bookmaker_id') = d.bookmaker_a_id
+                               AND json_extract(over_leg.value, '$.outcome_code') = 'over'
+                               AND CAST(json_extract(over_leg.value, '$.line') AS REAL) = d.threshold_a
+                               AND (
+                                   json_extract(over_leg.value, '$.match_id') IS NULL
+                                   OR json_extract(over_leg.value, '$.match_id') =
+                                      COALESCE(d.bookmaker_a_match_id, d.match_id)
+                               )
+                         )
+                         AND EXISTS (
+                             SELECT 1
+                             FROM json_each(op.legs) AS under_leg
+                             WHERE json_extract(under_leg.value, '$.bookmaker_id') = d.bookmaker_b_id
+                               AND json_extract(under_leg.value, '$.outcome_code') = 'under'
+                               AND CAST(json_extract(under_leg.value, '$.line') AS REAL) = d.threshold_b
+                               AND (
+                                   json_extract(under_leg.value, '$.match_id') IS NULL
+                                   OR json_extract(under_leg.value, '$.match_id') =
+                                      COALESCE(d.bookmaker_b_match_id, d.match_id)
+                               )
+                         )
+                   )
+               )"""
+        )
         params.append("basketball")
     if market_type:
         conditions.append("op.market_type = ?")

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -1912,18 +1912,23 @@ async def insert_opportunity(opportunity, *, detected_at: str) -> int:
     db = await get_db()
     cursor = await db.execute(
         """INSERT INTO opportunities
-           (sport, match_id, resolved_event_id, opportunity_type, market_type, line, profit_margin,
-            middle_profit_margin, legs, detected_at, is_active)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE)""",
+           (sport, match_id, resolved_event_id, opportunity_type, market_type, subject_type,
+            subject_key, subject_name, line, profit_margin, middle_profit_margin, market_keys,
+            legs, detected_at, is_active)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE)""",
         (
             opportunity.sport,
             opportunity.match_id,
             opportunity.resolved_event_id,
             opportunity.opportunity_type,
             opportunity.market_type,
+            opportunity.subject_type,
+            opportunity.subject_key,
+            opportunity.subject_name,
             opportunity.line,
             opportunity.profit_margin,
             opportunity.middle_profit_margin,
+            json.dumps(list(opportunity.market_keys)),
             json.dumps([leg.model_dump() for leg in opportunity.legs]),
             detected_at,
         ),
@@ -1940,6 +1945,13 @@ def _row_to_opportunity(row: aiosqlite.Row) -> OpportunityOut:
     for leg_data in legs_payload:
         legs.append(OpportunityLeg(**leg_data))
     data["legs"] = legs
+    data["event_id"] = data.get("resolved_event_id")
+    raw_market_keys = data.get("market_keys")
+    data["market_keys"] = (
+        json.loads(raw_market_keys)
+        if isinstance(raw_market_keys, str) and raw_market_keys
+        else []
+    )
     return OpportunityOut(**data)
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -359,6 +359,241 @@ async def test_opportunities_api_hides_basketball_overlap_by_default(client: Asy
     assert default_resp.json() == []
     assert basketball_resp.json() == []
     assert [row["sport"] for row in opt_in_resp.json()] == ["basketball"]
+    assert opt_in_resp.json()[0]["event_id"] is None
+    assert "subject_type" in opt_in_resp.json()[0]
+    assert "market_keys" in opt_in_resp.json()[0]
+
+
+@pytest.mark.asyncio
+async def test_opportunities_api_returns_generic_shape_across_sports(client: AsyncClient):
+    await odds_store.upsert_league("euroleague", "EuroLeague", "basketball")
+    await odds_store.upsert_league("premier_league", "Premier League", "football")
+    await odds_store.upsert_league("atp", "ATP", "tennis")
+    for bookmaker_id, bookmaker_name in (
+        ("mozzart", "Mozzart"),
+        ("meridian", "Meridian"),
+        ("maxbet", "MaxBet"),
+        ("balkanbet", "BalkanBet"),
+        ("alpha", "Alpha"),
+        ("beta", "Beta"),
+    ):
+        await odds_store.upsert_bookmaker(bookmaker_id, bookmaker_name)
+
+    await odds_store.upsert_match(
+        id="basketball-match",
+        league_id="euroleague",
+        sport="basketball",
+        home_team="Partizan",
+        away_team="Crvena Zvezda",
+        start_time="2030-01-01T20:00:00+00:00",
+    )
+    await odds_store.upsert_match(
+        id="football-match",
+        league_id="premier_league",
+        sport="football",
+        home_team="Team Alpha",
+        away_team="Team Beta",
+        start_time="2030-01-01T18:00:00+00:00",
+    )
+    await odds_store.upsert_match(
+        id="tennis-match",
+        league_id="atp",
+        sport="tennis",
+        home_team="Novak Djokovic",
+        away_team="Carlos Alcaraz",
+        start_time="2030-01-01T16:00:00+00:00",
+    )
+
+    seeded_opportunities = [
+        Opportunity(
+            sport="basketball",
+            match_id="basketball-match",
+            opportunity_type="middle",
+            market_type="player_points",
+            subject_type="player",
+            subject_key="ply_jokic",
+            subject_name="Nikola Jokić",
+            line=18.5,
+            profit_margin=0.02,
+            middle_profit_margin=0.50,
+            market_keys=("mk-player-points-18.5", "mk-player-points-20.5"),
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="mozzart",
+                    market_type="player_points",
+                    outcome_code="over",
+                    line=18.5,
+                    odds=1.90,
+                ),
+                OpportunityLeg(
+                    bookmaker_id="meridian",
+                    market_type="player_points",
+                    outcome_code="under",
+                    line=20.5,
+                    odds=2.10,
+                ),
+            ],
+        ),
+        Opportunity(
+            sport="basketball",
+            match_id="basketball-match",
+            opportunity_type="same_line_arbitrage",
+            market_type="player_rebounds",
+            subject_type="player",
+            subject_key="ply_micic",
+            subject_name="Vasilije Micić",
+            line=7.5,
+            profit_margin=0.03,
+            middle_profit_margin=None,
+            market_keys=("mk-player-rebounds-7.5",),
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="mozzart",
+                    market_type="player_rebounds",
+                    outcome_code="over",
+                    line=7.5,
+                    odds=2.10,
+                ),
+                OpportunityLeg(
+                    bookmaker_id="meridian",
+                    market_type="player_rebounds",
+                    outcome_code="under",
+                    line=7.5,
+                    odds=2.10,
+                ),
+            ],
+        ),
+        Opportunity(
+            sport="football",
+            match_id="football-match",
+            opportunity_type="middle",
+            market_type="football_total_goals",
+            subject_type="event",
+            line=2.5,
+            profit_margin=-0.01,
+            middle_profit_margin=0.08,
+            market_keys=("mk-football-total-2.5", "mk-football-total-3.5"),
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="maxbet",
+                    market_type="football_total_goals",
+                    outcome_code="over",
+                    line=2.5,
+                    odds=1.90,
+                ),
+                OpportunityLeg(
+                    bookmaker_id="balkanbet",
+                    market_type="football_total_goals",
+                    outcome_code="under",
+                    line=3.5,
+                    odds=2.10,
+                ),
+            ],
+        ),
+        Opportunity(
+            sport="football",
+            match_id="football-match",
+            opportunity_type="complementary_outcomes",
+            market_type="football_result_double_chance",
+            subject_type="event",
+            line=None,
+            profit_margin=0.04,
+            middle_profit_margin=None,
+            market_keys=("mk-football-result-home", "mk-football-dc-draw-away"),
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="maxbet",
+                    market_type="football_result",
+                    outcome_code="home",
+                    odds=2.10,
+                ),
+                OpportunityLeg(
+                    bookmaker_id="balkanbet",
+                    market_type="football_double_chance",
+                    outcome_code="draw_or_away",
+                    odds=2.10,
+                ),
+            ],
+        ),
+        Opportunity(
+            sport="tennis",
+            match_id="tennis-match",
+            opportunity_type="same_line_arbitrage",
+            market_type="match_winner",
+            subject_type="event",
+            line=None,
+            profit_margin=0.05,
+            middle_profit_margin=None,
+            market_keys=("mk-tennis-winner",),
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="alpha",
+                    market_type="tennis_match_winner",
+                    outcome_code="home",
+                    odds=2.10,
+                ),
+                OpportunityLeg(
+                    bookmaker_id="beta",
+                    market_type="tennis_match_winner",
+                    outcome_code="away",
+                    odds=2.10,
+                ),
+            ],
+        ),
+    ]
+    for opportunity in seeded_opportunities:
+        await odds_store.insert_opportunity(
+            opportunity,
+            detected_at="2030-01-01T20:00:00",
+        )
+
+    resp = await client.get(
+        "/api/v1/opportunities",
+        params={"include_legacy_discrepancy_overlap": "true", "limit": 10},
+    )
+
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 5
+    assert {
+        (row["sport"], row["opportunity_type"], row["market_type"])
+        for row in rows
+    } == {
+        ("basketball", "middle", "player_points"),
+        ("basketball", "same_line_arbitrage", "player_rebounds"),
+        ("football", "middle", "football_total_goals"),
+        ("football", "complementary_outcomes", "football_result_double_chance"),
+        ("tennis", "same_line_arbitrage", "match_winner"),
+    }
+
+    player_middle = next(row for row in rows if row["subject_key"] == "ply_jokic")
+    assert player_middle["event_id"] is None
+    assert player_middle["resolved_event_id"] is None
+    assert player_middle["subject_type"] == "player"
+    assert player_middle["subject_name"] == "Nikola Jokić"
+    assert player_middle["market_keys"] == [
+        "mk-player-points-18.5",
+        "mk-player-points-20.5",
+    ]
+    assert [leg["bookmaker_name"] for leg in player_middle["legs"]] == [
+        "Mozzart",
+        "Meridian",
+    ]
+
+    football_complement = next(
+        row for row in rows if row["opportunity_type"] == "complementary_outcomes"
+    )
+    assert football_complement["subject_type"] == "event"
+    assert {leg["market_type"] for leg in football_complement["legs"]} == {
+        "football_result",
+        "football_double_chance",
+    }
+
+    tennis_winner = next(row for row in rows if row["sport"] == "tennis")
+    assert tennis_winner["market_type"] == "match_winner"
+    assert {leg["market_type"] for leg in tennis_winner["legs"]} == {
+        "tennis_match_winner"
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -299,7 +299,9 @@ async def test_football_market_offers_and_opportunities_api(client: AsyncClient)
 
 
 @pytest.mark.asyncio
-async def test_opportunities_api_hides_basketball_overlap_by_default(client: AsyncClient):
+async def test_opportunities_api_hides_only_basketball_rows_that_overlap_discrepancies(
+    client: AsyncClient,
+):
     await odds_store.upsert_league("euroleague", "EuroLeague", "basketball")
     await odds_store.upsert_bookmaker("mozzart", "Mozzart")
     await odds_store.upsert_bookmaker("meridian", "Meridian")
@@ -311,12 +313,15 @@ async def test_opportunities_api_hides_basketball_overlap_by_default(client: Asy
         away_team="Real Madrid",
         start_time="2030-01-01T20:00:00+00:00",
     )
-    await odds_store.insert_opportunity(
+    overlapping_id = await odds_store.insert_opportunity(
         Opportunity(
             sport="basketball",
             match_id="basketball-match",
             opportunity_type="middle",
             market_type="player_points",
+            subject_type="player",
+            subject_key="player:nikola jokic",
+            subject_name="Nikola Jokic",
             line=18.5,
             profit_margin=0.02,
             middle_profit_margin=0.50,
@@ -339,6 +344,51 @@ async def test_opportunities_api_hides_basketball_overlap_by_default(client: Asy
         ),
         detected_at="2030-01-01T20:00:00",
     )
+    canonical_only_id = await odds_store.insert_opportunity(
+        Opportunity(
+            sport="basketball",
+            match_id="basketball-match",
+            opportunity_type="same_line_arbitrage",
+            market_type="player_points",
+            subject_type="player",
+            subject_key="player:nikola jokic",
+            subject_name="Nikola Jokic",
+            line=22.5,
+            profit_margin=0.04,
+            middle_profit_margin=None,
+            legs=[
+                OpportunityLeg(
+                    bookmaker_id="mozzart",
+                    market_type="player_points",
+                    outcome_code="over",
+                    line=22.5,
+                    odds=2.10,
+                ),
+                OpportunityLeg(
+                    bookmaker_id="meridian",
+                    market_type="player_points",
+                    outcome_code="under",
+                    line=22.5,
+                    odds=2.10,
+                ),
+            ],
+        ),
+        detected_at="2030-01-01T20:01:00",
+    )
+    await odds_store.insert_discrepancy(
+        match_id="basketball-match",
+        market_type="player_points",
+        player_name="Nikola Jokic",
+        bookmaker_a_id="mozzart",
+        bookmaker_b_id="meridian",
+        threshold_a=18.5,
+        threshold_b=20.5,
+        odds_a=1.90,
+        odds_b=2.10,
+        gap=2.0,
+        profit_margin=0.02,
+        middle_profit_margin=0.50,
+    )
 
     default_resp = await client.get("/api/v1/opportunities")
     basketball_resp = await client.get(
@@ -356,12 +406,17 @@ async def test_opportunities_api_hides_basketball_overlap_by_default(client: Asy
     assert default_resp.status_code == 200
     assert basketball_resp.status_code == 200
     assert opt_in_resp.status_code == 200
-    assert default_resp.json() == []
-    assert basketball_resp.json() == []
-    assert [row["sport"] for row in opt_in_resp.json()] == ["basketball"]
-    assert opt_in_resp.json()[0]["event_id"] is None
-    assert "subject_type" in opt_in_resp.json()[0]
-    assert "market_keys" in opt_in_resp.json()[0]
+    assert [row["id"] for row in default_resp.json()] == [canonical_only_id]
+    assert [row["id"] for row in basketball_resp.json()] == [canonical_only_id]
+    assert {row["id"] for row in opt_in_resp.json()} == {
+        overlapping_id,
+        canonical_only_id,
+    }
+    default_row = default_resp.json()[0]
+    assert default_row["opportunity_type"] == "same_line_arbitrage"
+    assert default_row["event_id"] is None
+    assert "subject_type" in default_row
+    assert "market_keys" in default_row
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_canonical_analyzer.py
+++ b/backend/tests/test_canonical_analyzer.py
@@ -190,6 +190,9 @@ def test_canonical_line_middle_uses_subject_key_before_display_name():
     )
 
     assert len(opportunities) == 1
+    assert opportunities[0].subject_type == "player"
+    assert opportunities[0].subject_key == "ply_lundberg"
+    assert opportunities[0].subject_name == "Nikola Jokić"
     assert {(leg.bookmaker_id, leg.outcome_code, leg.line) for leg in opportunities[0].legs} == {
         ("mozzart", "over", 16.5),
         ("meridian", "under", 18.5),

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -328,6 +328,11 @@ async def test_scheduler_runs_canonical_shadow_analysis_for_current_snapshot():
     assert [(item.opportunity_type, item.market_type) for item in opportunities] == [
         ("middle", "player_points")
     ]
+    assert opportunities[0].subject_type == "player"
+    assert opportunities[0].subject_key is not None
+    assert opportunities[0].subject_key.startswith("ply_")
+    assert opportunities[0].subject_name == "Sasha Vezenkov"
+    assert len(opportunities[0].market_keys) == 2
 
 
 @pytest.mark.asyncio
@@ -373,6 +378,9 @@ async def test_scheduler_persists_canonical_basketball_total_opportunity():
     assert len(opportunities) == 1
     assert opportunities[0].opportunity_type == "middle"
     assert opportunities[0].market_type == "game_total"
+    assert opportunities[0].subject_type == "event"
+    assert opportunities[0].subject_key is None
+    assert opportunities[0].subject_name is None
     assert [(leg.bookmaker_id, leg.outcome_code, leg.line) for leg in opportunities[0].legs] == [
         ("alpha", "over", 160.5),
         ("beta", "under", 162.5),
@@ -593,6 +601,8 @@ async def test_scheduler_persists_canonical_football_total_opportunity(
     assert [(item.opportunity_type, item.market_type) for item in opportunities] == [
         ("middle", "football_total_goals")
     ]
+    assert opportunities[0].subject_type == "event"
+    assert opportunities[0].market_keys
     assert [(leg.bookmaker_id, leg.outcome_code, leg.line) for leg in opportunities[0].legs] == [
         ("alpha", "over", 2.5),
         ("beta", "under", 3.5),
@@ -647,6 +657,8 @@ async def test_scheduler_persists_canonical_football_complementary_opportunity(
     assert [(item.opportunity_type, item.market_type) for item in opportunities] == [
         ("complementary_outcomes", "football_result_double_chance")
     ]
+    assert opportunities[0].subject_type == "event"
+    assert len(opportunities[0].market_keys) == 2
 
 
 @pytest.mark.asyncio
@@ -685,6 +697,8 @@ async def test_scheduler_shadow_analysis_handles_tennis_outcome_offers(
     assert [(item.opportunity_type, item.market_type) for item in opportunities] == [
         ("same_line_arbitrage", "match_winner")
     ]
+    assert opportunities[0].subject_type == "event"
+    assert len(opportunities[0].market_keys) == 1
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/mockData.ts
+++ b/frontend/src/api/mockData.ts
@@ -214,9 +214,11 @@ export const mockFootballOpportunities: Opportunity[] = [
     start_time: hours(2.5),
     opportunity_type: 'same_line_arbitrage',
     market_type: 'football_total_goals',
+    subject_type: 'event',
     line: 2.5,
     profit_margin: 0.1277,
     middle_profit_margin: null,
+    market_keys: ['mock-football-total-2.5'],
     legs: [
       { bookmaker_id: 'maxbet', bookmaker_name: 'MaxBet', market_type: 'football_total_goals', outcome_code: 'under', odds: 2.15, line: 2.5, raw_label: '0-2' },
       { bookmaker_id: 'balkanbet', bookmaker_name: 'BalkanBet', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.85, line: 2.5, raw_label: '3+' },
@@ -234,9 +236,11 @@ export const mockFootballOpportunities: Opportunity[] = [
     start_time: hours(2.25),
     opportunity_type: 'complementary_outcomes',
     market_type: 'football_result_double_chance',
+    subject_type: 'event',
     line: null,
     profit_margin: 0.0253,
     middle_profit_margin: null,
+    market_keys: ['mock-football-result-home', 'mock-football-double-chance-draw-away'],
     legs: [
       { bookmaker_id: 'maxbet', bookmaker_name: 'MaxBet', market_type: 'football_result', outcome_code: 'home', odds: 2.5, line: null, raw_label: '1' },
       { bookmaker_id: 'balkanbet', bookmaker_name: 'BalkanBet', market_type: 'football_double_chance', outcome_code: 'draw_or_away', odds: 1.42, line: null, raw_label: 'X2' },

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -52,9 +52,12 @@ export type MarketType =
   | 'football_total_goals'
   | 'football_result'
   | 'football_double_chance'
-  | 'football_result_double_chance';
+  | 'football_result_double_chance'
+  | 'match_winner'
+  | 'tennis_match_winner';
 
 export type OutcomeMarketType =
+  | MarketType
   | 'football_total_goals'
   | 'football_result'
   | 'football_double_chance'
@@ -122,7 +125,7 @@ export interface OpportunityLeg {
   bookmaker_id: string;
   bookmaker_name?: string | null;
   source_url?: string | null;
-  market_type: OutcomeMarketType;
+  market_type: string;
   outcome_code: string;
   odds: number;
   line: number | null;
@@ -132,6 +135,7 @@ export interface OpportunityLeg {
 export interface Opportunity {
   id: number;
   sport: string;
+  event_id?: string | null;
   match_id: string;
   resolved_event_id?: string | null;
   home_team: string | null;
@@ -139,10 +143,14 @@ export interface Opportunity {
   league_name: string | null;
   start_time: string | null;
   opportunity_type: string;
-  market_type: OutcomeMarketType;
+  market_type: string;
+  subject_type?: string | null;
+  subject_key?: string | null;
+  subject_name?: string | null;
   line: number | null;
   profit_margin: number | null;
   middle_profit_margin: number | null;
+  market_keys: string[];
   legs: OpportunityLeg[];
   detected_at: string | null;
   is_active: boolean;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -156,7 +156,7 @@ export interface Opportunity {
   is_active: boolean;
 }
 
-export type EdgeSport = 'basketball' | 'football';
+export type EdgeSport = 'basketball' | 'football' | 'tennis';
 
 export interface EdgeLeg {
   bookmaker_id: string;

--- a/frontend/src/components/EdgeRow.tsx
+++ b/frontend/src/components/EdgeRow.tsx
@@ -37,7 +37,7 @@ function LegCell({ edge, side }: { edge: Edge; side: 'a' | 'b' }) {
 }
 
 function SportPill({ sport }: { sport: Edge['sport'] }) {
-  const label = sport === 'football' ? '⚽' : '🏀';
+  const label = sport === 'football' ? '⚽' : sport === 'tennis' ? '🎾' : '🏀';
   return (
     <span
       className="inline-flex items-center rounded-full border border-border/70 bg-bg/60 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-text-secondary"

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -36,12 +36,13 @@ import { buildEdges } from '../utils/edgeAdapter';
 import { groupEdgesByMarket } from '../utils/edgeGrouping';
 
 type DashboardTab = 'opportunities' | 'tracked' | 'teams' | 'canonical' | 'warnings';
-type SportFilter = 'both' | 'basketball' | 'football';
+type SportFilter = 'both' | 'basketball' | 'football' | 'tennis';
 
 const SPORT_FILTER_OPTIONS: { value: SportFilter; label: string }[] = [
   { value: 'both', label: 'All sports' },
   { value: 'basketball', label: 'Basketball' },
   { value: 'football', label: 'Football' },
+  { value: 'tennis', label: 'Tennis' },
 ];
 
 function sportFilterToParam(value: SportFilter): string | undefined {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -20,6 +20,8 @@ export const MARKET_TYPES: readonly MarketType[] = [
   'football_result',
   'football_double_chance',
   'football_result_double_chance',
+  'match_winner',
+  'tennis_match_winner',
 ];
 
 export const MARKET_TYPE_LABELS: Record<MarketType, string> = {
@@ -42,11 +44,14 @@ export const MARKET_TYPE_LABELS: Record<MarketType, string> = {
   football_result: 'Match Result',
   football_double_chance: 'Double Chance',
   football_result_double_chance: 'Result + Double Chance',
+  match_winner: 'Match Winner',
+  tennis_match_winner: 'Tennis Match Winner',
 };
 
 export const SPORT_LABELS: Record<string, string> = {
   basketball: 'Basketball',
   football: 'Football',
+  tennis: 'Tennis',
 };
 
 export const STATUS_LABELS: Record<string, string> = {

--- a/frontend/src/utils/edgeAdapter.ts
+++ b/frontend/src/utils/edgeAdapter.ts
@@ -1,7 +1,13 @@
 import type { Discrepancy, Edge, EdgeLeg, EdgeSport, Opportunity, OpportunityLeg } from '../api/types';
 
 function inferSportFromMarketType(marketType: string): EdgeSport {
-  return marketType.startsWith('football_') ? 'football' : 'basketball';
+  if (marketType.startsWith('football_')) {
+    return 'football';
+  }
+  if (marketType === 'match_winner' || marketType.startsWith('tennis_')) {
+    return 'tennis';
+  }
+  return 'basketball';
 }
 
 export function discrepancyToEdge(d: Discrepancy): Edge {
@@ -74,7 +80,7 @@ export function opportunityToEdge(o: Opportunity): Edge | null {
     return null;
   }
   const sport: EdgeSport =
-    o.sport === 'football' || o.sport === 'basketball'
+    o.sport === 'football' || o.sport === 'basketball' || o.sport === 'tennis'
       ? o.sport
       : inferSportFromMarketType(o.market_type);
   return {
@@ -89,7 +95,7 @@ export function opportunityToEdge(o: Opportunity): Edge | null {
     league_name: o.league_name,
     start_time: o.start_time,
     market_type: o.market_type,
-    player_name: null,
+    player_name: o.subject_name ?? null,
     profit_margin: o.profit_margin,
     middle_profit_margin: o.middle_profit_margin,
     gap: gapFromOpportunity(o),

--- a/frontend/src/utils/edgeFormatting.ts
+++ b/frontend/src/utils/edgeFormatting.ts
@@ -65,10 +65,16 @@ export function formatLegLineLabel(leg: EdgeLeg, marketType: string): string {
 }
 
 function footballOpportunityHeadline(edge: Edge): string {
-  if (edge.opportunity_type === 'same_line_arbitrage') {
+  if (
+    edge.opportunity_type === 'same_line_arbitrage' &&
+    edge.market_type === 'football_total_goals'
+  ) {
     return `Total goals ${edge.leg_a.line ?? edge.leg_b.line ?? 2.5}`;
   }
   if (edge.opportunity_type === 'middle') {
+    if (edge.market_type !== 'football_total_goals') {
+      return `${marketTypeLabel(edge.market_type)} middle`;
+    }
     const overLeg =
       edge.leg_a.outcome_code === 'over'
         ? edge.leg_a


### PR DESCRIPTION
## Summary
- Promote /api/v1/opportunities to the generic canonical opportunity shape with event_id, subject metadata, market_keys, and generic legs while preserving existing fields
- Persist canonical subject identity and market keys on opportunities so the API does not reconstruct identity from lossy public leg fields
- Keep /discrepancies operational and retain the default basketball overlap guard for the current Dashboard, with opt-in include_legacy_discrepancy_overlap=true
- Update frontend API types/mock labels for the generic response

## Verification
- cd backend && ./venv/bin/python -m compileall -q app tests && ./venv/bin/pytest -q
- cd frontend && npm run build
- cd frontend && npm run lint

Closes #61