### PR TITLE
Harden regression coverage for auto resolution

### DIFF
--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -715,7 +715,8 @@ class Scheduler:
     async def _rollback_auto_applied_aliases(
         self,
         applied_aliases: list[tuple[str, str, str]],
-    ) -> None:
+    ) -> list[tuple[str, str, str]]:
+        failed_aliases: list[tuple[str, str, str]] = []
         for bookmaker_id, raw_team_name, sport in reversed(applied_aliases):
             try:
                 await asyncio.to_thread(
@@ -731,11 +732,14 @@ class Scheduler:
                     raw_team_name,
                     bookmaker_id,
                 )
+                failed_aliases.append((bookmaker_id, raw_team_name, sport))
+        return failed_aliases
 
     async def _rollback_auto_applied_merges(
         self,
         applied_merges: list[tuple[int, int]],
-    ) -> None:
+    ) -> list[tuple[int, int]]:
+        failed_merges: list[tuple[int, int]] = []
         for source_team_id, target_team_id in reversed(applied_merges):
             try:
                 await asyncio.to_thread(
@@ -748,6 +752,8 @@ class Scheduler:
                     source_team_id,
                     target_team_id,
                 )
+                failed_merges.append((source_team_id, target_team_id))
+        return failed_merges
 
     async def _apply_canonical_merges(
         self,
@@ -1033,6 +1039,7 @@ class Scheduler:
             team_review_cases = normalized_batch.team_review_cases
             applied_auto_aliases: list[tuple[str, str, str]] = []
             applied_auto_merges: list[tuple[int, int]] = []
+            auto_approved_team_review_case_ids: list[int] = []
             try:
                 (
                     same_time_auto_reviews,
@@ -1095,6 +1102,7 @@ class Scheduler:
                     case_id = await odds_store.insert_team_review_case(
                         team_review_case, scraped_at=cycle_scraped_at
                     )
+                    auto_approved_team_review_case_ids.append(case_id)
                     await odds_store.mark_team_review_case_approved(case_id)
                 await odds_store.set_current_snapshot(cycle_scraped_at)
 
@@ -1137,10 +1145,41 @@ class Scheduler:
                 notified = await self._notification_service.notify_opportunities(opportunities)
             except Exception:
                 await odds_store.rollback_pending_transaction()
+                rollback_failed = False
                 if applied_auto_merges:
-                    await self._rollback_auto_applied_merges(applied_auto_merges)
+                    rollback_failed = bool(
+                        await self._rollback_auto_applied_merges(applied_auto_merges)
+                    )
                 if applied_auto_aliases:
-                    await self._rollback_auto_applied_aliases(applied_auto_aliases)
+                    rollback_failed = (
+                        bool(
+                            await self._rollback_auto_applied_aliases(
+                                applied_auto_aliases
+                            )
+                        )
+                        or rollback_failed
+                    )
+                if auto_approved_team_review_case_ids:
+                    if rollback_failed:
+                        logger.warning(
+                            "Keeping auto-approved team review audit rows because "
+                            "auto-action rollback did not fully succeed"
+                        )
+                    else:
+                        try:
+                            await odds_store.delete_team_review_cases(
+                                auto_approved_team_review_case_ids,
+                                statuses=["approved"],
+                                review_kinds=[
+                                    AUTO_ALIAS_REVIEW_KIND,
+                                    AUTO_CANONICAL_MERGE_REVIEW_KIND,
+                                ],
+                            )
+                        except Exception:
+                            logger.exception(
+                                "Failed deleting auto-approved team review audit rows "
+                                "after failed scrape cycle"
+                            )
                 raise
             finally:
                 # Publish per-bookmaker benchmark snapshot regardless of whether

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -2327,6 +2327,31 @@ async def mark_team_review_case_declined(case_id: int) -> None:
     await db.commit()
 
 
+async def delete_team_review_cases(
+    case_ids: list[int],
+    *,
+    statuses: list[str] | None = None,
+    review_kinds: list[str] | None = None,
+) -> int:
+    if not case_ids:
+        return 0
+    db = await get_db()
+    conditions = [f"id IN ({_sql_placeholders(case_ids)})"]
+    params: list[object] = list(case_ids)
+    if statuses:
+        conditions.append(f"status IN ({_sql_placeholders(statuses)})")
+        params.extend(statuses)
+    if review_kinds:
+        conditions.append(f"review_kind IN ({_sql_placeholders(review_kinds)})")
+        params.extend(review_kinds)
+    cursor = await db.execute(
+        "DELETE FROM team_review_cases WHERE " + " AND ".join(conditions),
+        tuple(params),
+    )
+    await db.commit()
+    return cursor.rowcount or 0
+
+
 # ── Notifications ──────────────────────────────────────────
 
 async def insert_notification(

--- a/backend/tests/test_canonical_analyzer.py
+++ b/backend/tests/test_canonical_analyzer.py
@@ -199,6 +199,24 @@ def test_canonical_line_middle_uses_subject_key_before_display_name():
     }
 
 
+def test_canonical_line_middle_does_not_cross_resolved_events_for_same_player():
+    same_event = analyze_canonical_offers(
+        [
+            *_odds("mozzart", "Lundberg", 16.5, over=1.85, under=None, event_id="event-a"),
+            *_odds("meridian", "Lundberg", 18.5, over=None, under=2.00, event_id="event-a"),
+        ]
+    )
+    split_events = analyze_canonical_offers(
+        [
+            *_odds("mozzart", "Lundberg", 16.5, over=1.85, under=None, event_id="event-a"),
+            *_odds("meridian", "Lundberg", 18.5, over=None, under=2.00, event_id="event-b"),
+        ]
+    )
+
+    assert len(same_event) == 1
+    assert split_events == []
+
+
 def test_canonical_line_middle_rejects_invalid_odds():
     opportunities = analyze_canonical_offers(
         [

--- a/backend/tests/test_canonical_offers.py
+++ b/backend/tests/test_canonical_offers.py
@@ -190,3 +190,24 @@ def test_market_key_uses_event_identity_when_available():
 
     assert match_scoped.market_key != event_scoped.market_key
     assert event_scoped.market_key == same_event_scoped.market_key
+
+
+def test_player_market_key_keeps_subject_scoped_to_resolved_event():
+    event_a = canonical_offers_from_normalized_odds(
+        _odds("mozzart", match_id="bookmaker-match-a"),
+        event_id="resolved-event-a",
+        subject_key_override="player:nikola-jovic",
+    )[0]
+    same_event_a = canonical_offers_from_normalized_odds(
+        _odds("maxbet", match_id="bookmaker-match-b"),
+        event_id="resolved-event-a",
+        subject_key_override="player:nikola-jovic",
+    )[0]
+    event_b = canonical_offers_from_normalized_odds(
+        _odds("meridian", match_id="bookmaker-match-c"),
+        event_id="resolved-event-b",
+        subject_key_override="player:nikola-jovic",
+    )[0]
+
+    assert event_a.market_key == same_event_a.market_key
+    assert event_a.market_key != event_b.market_key

--- a/backend/tests/test_event_resolver.py
+++ b/backend/tests/test_event_resolver.py
@@ -13,6 +13,7 @@ from app.services.event_resolver import (
     _event_review_case,
     SameTimeCanonicalSlot,
     _same_time_slot_orientation,
+    build_event_resolution_groups,
     resolve_and_persist_events,
 )
 from app.services.normalizer import generate_match_id
@@ -101,6 +102,39 @@ def test_event_review_case_metadata_records_exact_source_variant_pairs():
         {"match_id": "match-z", "bookmaker_id": "book-z"},
     ]
     assert review_case.candidate_resolved_event_id is None
+
+
+def test_event_resolution_groups_keep_sports_separate_for_same_teams_and_time():
+    candidates = [
+        EventCandidate(
+            match_id="basketball-match",
+            bookmaker_id="book-a",
+            sport="basketball",
+            start_time=START_TIME,
+            home_team_id=1,
+            away_team_id=2,
+            home_team="Team Alpha",
+            away_team="Team Beta",
+        ),
+        EventCandidate(
+            match_id="football-match",
+            bookmaker_id="book-b",
+            sport="football",
+            start_time=START_TIME,
+            home_team_id=1,
+            away_team_id=2,
+            home_team="Team Alpha",
+            away_team="Team Beta",
+        ),
+    ]
+
+    resolutions, review_cases = build_event_resolution_groups(candidates)
+
+    assert review_cases == []
+    assert {(resolution.sport, resolution.primary_match_id) for resolution in resolutions} == {
+        ("basketball", "basketball-match"),
+        ("football", "football-match"),
+    }
 
 
 async def _seed_bookmakers(*bookmaker_ids: str) -> None:

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -202,6 +203,27 @@ def test_normalize_merge_pairings_rejects_reciprocal_cycles_regardless_of_order(
     assert normalized_reverse == {}
     assert conflicts_forward == {1, 2}
     assert conflicts_reverse == {1, 2}
+
+
+def test_normalize_merge_pairings_rejects_self_merge_and_conflicting_targets():
+    normalized, conflicts = _normalize_merge_pairings(
+        [
+            (1, 1),
+            (2, 3),
+            (2, 4),
+            (3, 5),
+        ]
+    )
+
+    assert normalized == {3: 5}
+    assert conflicts == {2}
+
+
+def test_normalize_merge_pairings_rejects_longer_cycles():
+    normalized, conflicts = _normalize_merge_pairings([(1, 2), (2, 3), (3, 1)])
+
+    assert normalized == {}
+    assert conflicts == {1, 2, 3}
 
 
 def test_scraper_capabilities_unify_threshold_and_outcome_lanes():
@@ -2115,15 +2137,13 @@ async def test_scheduler_run_cycle_rolls_back_auto_saved_alias_if_store_fails(
     assert normalize_team_name("Rilski Sport.", "bulgaria_nbl", "meridian") == "Rilski Sport."
 
 
-@pytest.mark.asyncio
-async def test_scheduler_run_cycle_rolls_back_auto_merge_if_store_fails(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    source_home = create_canonical_team(display_name="QA Rollback City")
-    source_away = create_canonical_team(display_name="QA Rollback United")
-    target_home = create_canonical_team(display_name="BC QA Rollback City")
-    target_away = create_canonical_team(display_name="BC QA Rollback United")
-
+def _register_auto_merge_rollback_scrapers(
+    *,
+    source_home,
+    source_away,
+    target_home,
+    target_away,
+) -> None:
     _register_test_scrapers(
         StubScraper(
             "book-a",
@@ -2169,21 +2189,216 @@ async def test_scheduler_run_cycle_rolls_back_auto_merge_if_store_fails(
         ),
     )
 
-    original_upsert_odds = odds_store.upsert_odds
-    call_count = 0
 
-    async def failing_upsert_odds(odds, *, scraped_at):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 2:
-            raise RuntimeError("simulated store failure")
-        return await original_upsert_odds(odds, scraped_at=scraped_at)
+@pytest.mark.asyncio
+async def test_scheduler_run_cycle_rolls_back_auto_merge_if_store_fails(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_home = create_canonical_team(display_name="QA Rollback City")
+    source_away = create_canonical_team(display_name="QA Rollback United")
+    target_home = create_canonical_team(display_name="BC QA Rollback City")
+    target_away = create_canonical_team(display_name="BC QA Rollback United")
 
-    monkeypatch.setattr(odds_store, "upsert_odds", failing_upsert_odds)
+    _register_auto_merge_rollback_scrapers(
+        source_home=source_home,
+        source_away=source_away,
+        target_home=target_home,
+        target_away=target_away,
+    )
 
-    with pytest.raises(RuntimeError, match="simulated store failure"):
+    async def failing_set_current_snapshot(snapshot_at: str) -> None:
+        raise RuntimeError("simulated snapshot failure")
+
+    monkeypatch.setattr(odds_store, "set_current_snapshot", failing_set_current_snapshot)
+
+    with pytest.raises(RuntimeError, match="simulated snapshot failure"):
         await Scheduler(interval_minutes=1).run_cycle()
 
+    with sqlite3.connect(settings.db_path) as conn:
+        auto_merge_audit_rows = conn.execute(
+            """
+            SELECT status
+            FROM team_review_cases
+            WHERE review_kind = 'auto_canonical_merge_suggestion'
+            """
+        ).fetchall()
+
+    assert auto_merge_audit_rows == []
+    assert get_canonical_team(source_home.team_id) is not None
+    assert get_canonical_team(source_away.team_id) is not None
+    assert get_canonical_team(target_home.team_id) is not None
+    assert get_canonical_team(target_away.team_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_auto_merge_audit_cleanup_failure_does_not_block_canonical_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_home = create_canonical_team(display_name="QA Cleanup City")
+    source_away = create_canonical_team(display_name="QA Cleanup United")
+    target_home = create_canonical_team(display_name="BC QA Cleanup City")
+    target_away = create_canonical_team(display_name="BC QA Cleanup United")
+    delete_called = False
+
+    _register_auto_merge_rollback_scrapers(
+        source_home=source_home,
+        source_away=source_away,
+        target_home=target_home,
+        target_away=target_away,
+    )
+
+    async def failing_set_current_snapshot(snapshot_at: str) -> None:
+        raise RuntimeError("simulated snapshot failure")
+
+    async def failing_delete_team_review_cases(
+        case_ids: list[int],
+        **kwargs,
+    ) -> int:
+        nonlocal delete_called
+        delete_called = True
+        raise RuntimeError("simulated audit cleanup failure")
+
+    monkeypatch.setattr(odds_store, "set_current_snapshot", failing_set_current_snapshot)
+    monkeypatch.setattr(
+        odds_store,
+        "delete_team_review_cases",
+        failing_delete_team_review_cases,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated snapshot failure"):
+        await Scheduler(interval_minutes=1).run_cycle()
+
+    with sqlite3.connect(settings.db_path) as conn:
+        auto_merge_audit_rows = conn.execute(
+            """
+            SELECT status
+            FROM team_review_cases
+            WHERE review_kind = 'auto_canonical_merge_suggestion'
+            """
+        ).fetchall()
+
+    assert delete_called
+    assert auto_merge_audit_rows == [("approved",), ("approved",)]
+    assert get_canonical_team(source_home.team_id) is not None
+    assert get_canonical_team(source_away.team_id) is not None
+    assert get_canonical_team(target_home.team_id) is not None
+    assert get_canonical_team(target_away.team_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_auto_merge_audit_rows_remain_when_canonical_rollback_fails(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_home = create_canonical_team(display_name="QA Failed Rollback City")
+    source_away = create_canonical_team(display_name="QA Failed Rollback United")
+    target_home = create_canonical_team(display_name="BC QA Failed Rollback City")
+    target_away = create_canonical_team(display_name="BC QA Failed Rollback United")
+    delete_called = False
+
+    _register_auto_merge_rollback_scrapers(
+        source_home=source_home,
+        source_away=source_away,
+        target_home=target_home,
+        target_away=target_away,
+    )
+
+    async def failing_set_current_snapshot(snapshot_at: str) -> None:
+        raise RuntimeError("simulated snapshot failure")
+
+    async def failed_auto_merge_rollback(self, applied_merges):
+        return list(applied_merges)
+
+    async def tracking_delete_team_review_cases(
+        case_ids: list[int],
+        **kwargs,
+    ) -> int:
+        nonlocal delete_called
+        delete_called = True
+        return len(case_ids)
+
+    monkeypatch.setattr(odds_store, "set_current_snapshot", failing_set_current_snapshot)
+    monkeypatch.setattr(
+        Scheduler,
+        "_rollback_auto_applied_merges",
+        failed_auto_merge_rollback,
+    )
+    monkeypatch.setattr(
+        odds_store,
+        "delete_team_review_cases",
+        tracking_delete_team_review_cases,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated snapshot failure"):
+        await Scheduler(interval_minutes=1).run_cycle()
+
+    with sqlite3.connect(settings.db_path) as conn:
+        auto_merge_audit_rows = conn.execute(
+            """
+            SELECT status
+            FROM team_review_cases
+            WHERE review_kind = 'auto_canonical_merge_suggestion'
+            """
+        ).fetchall()
+
+    assert not delete_called
+    assert auto_merge_audit_rows == [("approved",), ("approved",)]
+    assert get_canonical_team(source_home.team_id) is None
+    assert get_canonical_team(source_away.team_id) is None
+    assert get_canonical_team(target_home.team_id) is not None
+    assert get_canonical_team(target_away.team_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_failed_cycle_cleanup_keeps_human_declined_auto_merge_audit_row(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_home = create_canonical_team(display_name="QA Human Veto City")
+    source_away = create_canonical_team(display_name="QA Human Veto United")
+    target_home = create_canonical_team(display_name="BC QA Human Veto City")
+    target_away = create_canonical_team(display_name="BC QA Human Veto United")
+
+    _register_auto_merge_rollback_scrapers(
+        source_home=source_home,
+        source_away=source_away,
+        target_home=target_home,
+        target_away=target_away,
+    )
+
+    async def declining_notification_failure(opportunities):
+        with sqlite3.connect(settings.db_path) as conn:
+            case_id = conn.execute(
+                """
+                SELECT id
+                FROM team_review_cases
+                WHERE review_kind = 'auto_canonical_merge_suggestion'
+                ORDER BY id
+                LIMIT 1
+                """
+            ).fetchone()[0]
+        await odds_store.mark_team_review_case_declined(case_id)
+        raise RuntimeError("simulated notification failure")
+
+    scheduler = Scheduler(interval_minutes=1)
+    monkeypatch.setattr(
+        scheduler._notification_service,
+        "notify_opportunities",
+        declining_notification_failure,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated notification failure"):
+        await scheduler.run_cycle()
+
+    with sqlite3.connect(settings.db_path) as conn:
+        auto_merge_audit_rows = conn.execute(
+            """
+            SELECT status
+            FROM team_review_cases
+            WHERE review_kind = 'auto_canonical_merge_suggestion'
+            ORDER BY id
+            """
+        ).fetchall()
+
+    assert auto_merge_audit_rows == [("declined",)]
     assert get_canonical_team(source_home.team_id) is not None
     assert get_canonical_team(source_away.team_id) is not None
     assert get_canonical_team(target_home.team_id) is not None


### PR DESCRIPTION
## Summary
- add regression coverage for merge-pair invariants, sport-separated event resolution, event-scoped canonical grouping, and player market keys
- fix failed-cycle rollback so auto-approved team review audit rows are cleaned up only after canonical auto-actions roll back successfully
- preserve audit rows when rollback fails or when a human declines a visible auto-approved review row during a failed cycle

Closes #50

## Verification
- cd backend && ./venv/bin/python -m compileall -q app tests && ./venv/bin/pytest tests/test_scheduler.py tests/test_event_resolver.py tests/test_canonical_analyzer.py tests/test_canonical_offers.py tests/test_store.py -q
- cd backend && ./venv/bin/pytest -q
- git diff --check
- code-review: gpt-5.5, claude-opus-4.7-xhigh, claude-opus-4.7-1m-internal final review found no significant issues

## Review notes
Earlier review rounds caught a false-positive rollback assertion and cleanup ordering/concurrency risks. The final diff includes fixes and guardrail tests for those cases.