### PR TITLE
Limit scrape cycle to player markets

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,7 +18,9 @@ BOOKMAKERS=mozzart,maxbet,oktagonbet,admiralbet,balkanbet,merkurxtip,pinnbet,soc
 # Comma-separated sports enabled in the canonical offer pipeline.
 ENABLED_SPORTS=basketball
 
-# all = persist every supported market; player_props = persist only player_* markets.
+# all = persist/analyze every supported market.
+# player_props = skip outcome-offer lanes and persist/analyze only player_* thresholds.
+# Basketball threshold scrapers may still fetch game rows as normalization/event context.
 SCRAPE_MARKET_SCOPE=player_props
 
 # Use "mock" for deterministic local development or "real" for live bookmaker HTTP calls.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,9 @@ BOOKMAKERS=mozzart,maxbet,oktagonbet,admiralbet,balkanbet,merkurxtip,pinnbet,soc
 # Comma-separated sports enabled in the canonical offer pipeline.
 ENABLED_SPORTS=basketball
 
+# all = persist every supported market; player_props = persist only player_* markets.
+SCRAPE_MARKET_SCOPE=player_props
+
 # Use "mock" for deterministic local development or "real" for live bookmaker HTTP calls.
 SCRAPER_MODE=mock
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     cors_origins: str = "*"
     bookmakers: str = "mozzart,maxbet,oktagonbet,admiralbet,balkanbet,merkurxtip,pinnbet,soccerbet,superbet,betole,365,volcanobet"
     enabled_sports: str = "basketball"
-    # player_props = scrape and persist only player_* threshold markets.
+    # player_props = skip outcome-offer lanes and persist/analyze player_* thresholds.
     scrape_market_scope: Literal["all", "player_props"] = "player_props"
     notification_gap_threshold: float = 1.5
     persist_inapp_notifications: bool = False

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,6 +14,8 @@ class Settings(BaseSettings):
     cors_origins: str = "*"
     bookmakers: str = "mozzart,maxbet,oktagonbet,admiralbet,balkanbet,merkurxtip,pinnbet,soccerbet,superbet,betole,365,volcanobet"
     enabled_sports: str = "basketball"
+    # player_props = scrape and persist only player_* threshold markets.
+    scrape_market_scope: Literal["all", "player_props"] = "player_props"
     notification_gap_threshold: float = 1.5
     persist_inapp_notifications: bool = False
     notification_retention_days: int = 3

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -23,6 +23,7 @@ from ..services.league_registry import league_country, league_display_name
 from ..services.normalizer import (
     ANCHORED_AUTO_APPLY_THRESHOLD,
     log_unresolved_shared_platform_diagnostics,
+    normalize_market_type,
     normalize_odds_with_diagnostics,
     resolve_team_name,
 )
@@ -113,8 +114,32 @@ def _enabled_scraper_capabilities(
     return [
         capability
         for capability in scraper.get_scraper_capabilities()
-        if capability.sport in enabled_sports
+        if _is_enabled_scraper_capability(capability, enabled_sports)
     ]
+
+
+def _is_enabled_scraper_capability(
+    capability: ScraperCapability,
+    enabled_sports: set[str],
+) -> bool:
+    if capability.sport not in enabled_sports:
+        return False
+    if (
+        settings.scrape_market_scope == "player_props"
+        and capability.lane == "outcome_offer"
+    ):
+        return False
+    return True
+
+
+def _is_player_market_type(market_type: str) -> bool:
+    return normalize_market_type(market_type).startswith("player_")
+
+
+def _filter_raw_odds_by_market_scope(rows: list[RawOddsData]) -> list[RawOddsData]:
+    if settings.scrape_market_scope != "player_props":
+        return rows
+    return [row for row in rows if _is_player_market_type(row.market_type)]
 
 
 def _normalize_pipeline_batch(
@@ -859,9 +884,11 @@ class Scheduler:
             )
             return []
 
-        filtered_raw = filter_raw_odds_by_lookahead(raw)
-        dropped_count = len(raw) - len(filtered_raw)
-        raw = filtered_raw
+        lookahead_filtered_raw = filter_raw_odds_by_lookahead(raw)
+        lookahead_dropped_count = len(raw) - len(lookahead_filtered_raw)
+        market_filtered_raw = _filter_raw_odds_by_market_scope(lookahead_filtered_raw)
+        market_dropped_count = len(lookahead_filtered_raw) - len(market_filtered_raw)
+        raw = market_filtered_raw
         duration_ms = int((time.perf_counter() - started_at) * 1000)
         self._scan_completed_tasks += 1
         self._scan_active_tasks = max(0, self._scan_active_tasks - 1)
@@ -878,12 +905,19 @@ class Scheduler:
             duration_ms,
             len(raw),
         )
-        if dropped_count:
+        if lookahead_dropped_count:
             logger.info(
                 "Scraper %s dropped %d items outside %dh lookahead",
                 bookmaker_id,
-                dropped_count,
+                lookahead_dropped_count,
                 configured_lookahead_hours(),
+            )
+        if market_dropped_count:
+            logger.info(
+                "Scraper %s dropped %d non-player market items for SCRAPE_MARKET_SCOPE=%s",
+                bookmaker_id,
+                market_dropped_count,
+                settings.scrape_market_scope,
             )
         return raw
 

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -136,10 +136,35 @@ def _is_player_market_type(market_type: str) -> bool:
     return normalize_market_type(market_type).startswith("player_")
 
 
-def _filter_raw_odds_by_market_scope(rows: list[RawOddsData]) -> list[RawOddsData]:
+def _filter_normalized_pipeline_batch_by_market_scope(
+    batch: _NormalizedPipelineBatch,
+) -> _NormalizedPipelineBatch:
     if settings.scrape_market_scope != "player_props":
-        return rows
-    return [row for row in rows if _is_player_market_type(row.market_type)]
+        return batch
+    return _NormalizedPipelineBatch(
+        odds=[row for row in batch.odds if _is_player_market_type(row.market_type)],
+        outcome_offers=[],
+        unresolved_odds=[
+            row for row in batch.unresolved_odds if _is_player_market_type(row.market_type)
+        ],
+        team_review_cases=batch.team_review_cases,
+    )
+
+
+def _event_resolution_batch_for_market_scope(
+    full_batch: _NormalizedPipelineBatch,
+    persisted_batch: _NormalizedPipelineBatch,
+) -> _NormalizedPipelineBatch:
+    if settings.scrape_market_scope != "player_props":
+        return full_batch
+
+    persisted_match_ids = {row.match_id for row in persisted_batch.odds}
+    return _NormalizedPipelineBatch(
+        odds=[row for row in full_batch.odds if row.match_id in persisted_match_ids],
+        outcome_offers=[],
+        unresolved_odds=full_batch.unresolved_odds,
+        team_review_cases=full_batch.team_review_cases,
+    )
 
 
 def _normalize_pipeline_batch(
@@ -884,11 +909,9 @@ class Scheduler:
             )
             return []
 
-        lookahead_filtered_raw = filter_raw_odds_by_lookahead(raw)
-        lookahead_dropped_count = len(raw) - len(lookahead_filtered_raw)
-        market_filtered_raw = _filter_raw_odds_by_market_scope(lookahead_filtered_raw)
-        market_dropped_count = len(lookahead_filtered_raw) - len(market_filtered_raw)
-        raw = market_filtered_raw
+        filtered_raw = filter_raw_odds_by_lookahead(raw)
+        dropped_count = len(raw) - len(filtered_raw)
+        raw = filtered_raw
         duration_ms = int((time.perf_counter() - started_at) * 1000)
         self._scan_completed_tasks += 1
         self._scan_active_tasks = max(0, self._scan_active_tasks - 1)
@@ -905,19 +928,12 @@ class Scheduler:
             duration_ms,
             len(raw),
         )
-        if lookahead_dropped_count:
+        if dropped_count:
             logger.info(
                 "Scraper %s dropped %d items outside %dh lookahead",
                 bookmaker_id,
-                lookahead_dropped_count,
+                dropped_count,
                 configured_lookahead_hours(),
-            )
-        if market_dropped_count:
-            logger.info(
-                "Scraper %s dropped %d non-player market items for SCRAPE_MARKET_SCOPE=%s",
-                bookmaker_id,
-                market_dropped_count,
-                settings.scrape_market_scope,
             )
         return raw
 
@@ -1062,10 +1078,17 @@ class Scheduler:
             canonical_shadow = _CanonicalShadowResult()
             notified = 0
             pending_auto_merges: list[tuple[int, int]] = []
-            normalized_batch = _normalize_pipeline_batch(
+            full_normalized_batch = _normalize_pipeline_batch(
                 all_raw,
                 all_raw_outcome_offers,
                 log_unresolved_shared_platform=False,
+            )
+            normalized_batch = _filter_normalized_pipeline_batch_by_market_scope(
+                full_normalized_batch
+            )
+            event_resolution_batch = _event_resolution_batch_for_market_scope(
+                full_normalized_batch,
+                normalized_batch,
             )
             normalized = normalized_batch.odds
             normalized_outcome_offers = normalized_batch.outcome_offers
@@ -1100,9 +1123,16 @@ class Scheduler:
                         pending_auto_merges
                     )
                 if auto_approved_team_reviews or applied_auto_merges:
-                    normalized_batch = _normalize_pipeline_batch(
+                    full_normalized_batch = _normalize_pipeline_batch(
                         all_raw,
                         all_raw_outcome_offers,
+                    )
+                    normalized_batch = _filter_normalized_pipeline_batch_by_market_scope(
+                        full_normalized_batch
+                    )
+                    event_resolution_batch = _event_resolution_batch_for_market_scope(
+                        full_normalized_batch,
+                        normalized_batch,
                     )
                     normalized = normalized_batch.odds
                     normalized_outcome_offers = normalized_batch.outcome_offers
@@ -1121,8 +1151,8 @@ class Scheduler:
                 await resolve_and_persist_events(
                     raw_odds=all_raw,
                     raw_outcome_offers=all_raw_outcome_offers,
-                    normalized_odds=normalized,
-                    normalized_outcome_offers=normalized_outcome_offers,
+                    normalized_odds=event_resolution_batch.odds,
+                    normalized_outcome_offers=event_resolution_batch.outcome_offers,
                 )
                 for unresolved in unresolved_odds:
                     await odds_store.insert_unresolved_odds(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -45,6 +45,13 @@ def wide_scrape_lookahead(monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def all_market_scrape_scope(monkeypatch):
+    """Preserve full-market coverage in tests unless a test opts into player-only mode."""
+    monkeypatch.setattr(settings, "scrape_market_scope", "all")
+    yield
+
+
 @pytest.fixture
 def league_registry_file(tmp_path, monkeypatch):
     source_path = Path(settings.league_registry_path)

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -374,6 +374,88 @@ async def test_scheduler_runs_canonical_analysis_for_current_snapshot():
 
 
 @pytest.mark.asyncio
+async def test_scheduler_player_props_scope_filters_non_player_threshold_markets(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "scrape_market_scope", "player_props")
+    _register_test_scrapers(
+        StubScraper(
+            "alpha",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds(
+                        "alpha",
+                        18.5,
+                        market_type="points",
+                    ),
+                    _raw_odds(
+                        "alpha",
+                        155.5,
+                        market_type="game_total",
+                        player_name=None,
+                    ),
+                ],
+            },
+        ),
+        StubScraper(
+            "beta",
+            payload_by_league={
+                "euroleague": [
+                    _raw_odds("beta", 20.5),
+                    _raw_odds(
+                        "beta",
+                        158.5,
+                        market_type="game_total",
+                        player_name=None,
+                    ),
+                ],
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["odds_scraped"] == 2
+    assert result["outcome_offers_scraped"] == 0
+    assert result["opportunities_found"] == 1
+    opportunities = await odds_store.get_opportunities(sport="basketball")
+    assert [(item.opportunity_type, item.market_type) for item in opportunities] == [
+        ("middle", "player_points")
+    ]
+    stored_odds = await odds_store.get_odds_for_match(opportunities[0].match_id)
+    assert {row.market_type for row in stored_odds} == {"player_points"}
+
+
+@pytest.mark.asyncio
+async def test_scheduler_player_props_scope_skips_outcome_offer_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "enabled_sports", "football")
+    monkeypatch.setattr(settings, "scrape_market_scope", "player_props")
+    outcome_calls: list[str] = []
+
+    class RecordingOutcomeScraper(StubScraper):
+        async def scrape_outcome_offers(self, sport: str) -> list[RawOutcomeOffer]:
+            outcome_calls.append(sport)
+            return [_raw_outcome_offer("alpha", "home", sport=sport)]
+
+    _register_test_scrapers(
+        RecordingOutcomeScraper(
+            "alpha",
+            leagues=(),
+            outcome_sports=("football",),
+        )
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert outcome_calls == []
+    assert result["odds_scraped"] == 0
+    assert result["outcome_offers_scraped"] == 0
+    assert result["opportunities_found"] == 0
+
+
+@pytest.mark.asyncio
 async def test_scheduler_persists_canonical_basketball_total_opportunity():
     _register_test_scrapers(
         StubScraper(

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -427,6 +427,66 @@ async def test_scheduler_player_props_scope_filters_non_player_threshold_markets
 
 
 @pytest.mark.asyncio
+async def test_scheduler_player_props_scope_keeps_context_rows_for_shared_platform_props(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "scrape_market_scope", "player_props")
+    _register_test_scrapers(
+        StubScraper(
+            "meridian",
+            payload_by_league={
+                "euroleague": [
+                    RawOddsData(
+                        bookmaker_id="meridian",
+                        league_id="nba",
+                        home_team="Minnesota",
+                        away_team="Houston",
+                        market_type="game_total",
+                        player_name=None,
+                        threshold=219.5,
+                        over_odds=1.9,
+                        under_odds=1.9,
+                        start_time="2030-01-01T20:00:00+00:00",
+                    )
+                ],
+            },
+        ),
+        StubScraper(
+            "maxbet",
+            payload_by_league={
+                "euroleague": [
+                    RawOddsData(
+                        bookmaker_id="maxbet",
+                        league_id="nba",
+                        home_team="Houston",
+                        away_team="Kevin Durant",
+                        market_type="player_points",
+                        player_name="Kevin Durant",
+                        threshold=23.5,
+                        over_odds=1.85,
+                        under_odds=1.95,
+                        start_time="2030-01-01T20:00:00+00:00",
+                    )
+                ],
+            },
+        ),
+    )
+
+    result = await Scheduler(interval_minutes=1).run_cycle()
+
+    assert result["matches_scraped"] == 1
+    assert result["odds_scraped"] == 1
+    matches = await odds_store.get_matches(sport="basketball")
+    assert len(matches) == 1
+    assert matches[0].home_team == "Minnesota Timberwolves"
+    assert matches[0].away_team == "Houston Rockets"
+    stored_odds = await odds_store.get_odds_for_match(matches[0].id)
+    assert [(row.market_type, row.player_name) for row in stored_odds] == [
+        ("player_points", "Kevin Durant")
+    ]
+
+
+@pytest.mark.asyncio
 async def test_scheduler_player_props_scope_skips_outcome_offer_capabilities(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
## Summary
- add SCRAPE_MARKET_SCOPE=player_props default for backend scrape cycles
- skip outcome-offer game-market lanes in player-only mode
- filter non-player threshold markets after canonical market normalization
- add scheduler coverage for player-only scraping and skipped outcome offers

## Verification
- cd backend && ./venv/bin/python -m py_compile app/config.py app/services/scheduler.py tests/conftest.py tests/test_scheduler.py
- cd backend && ./venv/bin/pytest tests/test_scheduler.py::test_scheduler_player_props_scope_filters_non_player_threshold_markets tests/test_scheduler.py::test_scheduler_player_props_scope_skips_outcome_offer_capabilities tests/test_scheduler.py::test_scheduler_runs_canonical_analysis_for_current_snapshot tests/test_scheduler.py::test_scheduler_persists_canonical_basketball_total_opportunity tests/test_scheduler.py::test_scheduler_persists_canonical_football_total_opportunity -q
- cd backend && ./venv/bin/pytest -q