### PR TITLE
Implement atomic scrape snapshots

### DIFF
--- a/backend/app/api/matches.py
+++ b/backend/app/api/matches.py
@@ -51,7 +51,7 @@ async def get_match_odds(match_id: str):
 
 @router.get("/{match_id}/history", response_model=list[OddsOut])
 async def get_match_history(match_id: str):
-    match = await odds_store.get_match(match_id)
+    match = await odds_store.get_match(match_id, require_current_snapshot=True)
     if not match:
         raise HTTPException(status_code=404, detail="Match not found")
     return await odds_store.get_odds_history_for_match(match_id)

--- a/backend/app/api/matches.py
+++ b/backend/app/api/matches.py
@@ -35,7 +35,7 @@ async def list_matches(
 
 @router.get("/{match_id}", response_model=MatchOut)
 async def get_match(match_id: str):
-    match = await odds_store.get_match(match_id)
+    match = await odds_store.get_match(match_id, require_current_snapshot=True)
     if not match:
         raise HTTPException(status_code=404, detail="Match not found")
     return match
@@ -43,7 +43,7 @@ async def get_match(match_id: str):
 
 @router.get("/{match_id}/odds", response_model=list[OddsOut])
 async def get_match_odds(match_id: str):
-    match = await odds_store.get_match(match_id)
+    match = await odds_store.get_match(match_id, require_current_snapshot=True)
     if not match:
         raise HTTPException(status_code=404, detail="Match not found")
     return await odds_store.get_odds_for_match(match_id)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -34,12 +34,12 @@ CREATE TABLE IF NOT EXISTS matches (
 
 CREATE TABLE IF NOT EXISTS match_bookmaker_sources (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_id TEXT,
     match_id TEXT NOT NULL REFERENCES matches(id),
     bookmaker_id TEXT NOT NULL REFERENCES bookmakers(id),
     source_url TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(match_id, bookmaker_id)
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS snapshot_matches (
@@ -516,6 +516,55 @@ async def _rebuild_resolved_event_members_for_snapshots(
     )
 
 
+async def _rebuild_match_bookmaker_sources_for_snapshots(
+    conn: aiosqlite.Connection,
+) -> None:
+    columns = await conn.execute_fetchall("PRAGMA table_info(match_bookmaker_sources)")
+    existing = {row[1] for row in columns}
+    snapshot_expr = "snapshot_id" if "snapshot_id" in existing else "NULL"
+    await conn.execute("DROP INDEX IF EXISTS idx_match_bookmaker_sources_unique_snapshot")
+    await conn.execute("DROP INDEX IF EXISTS idx_match_bookmaker_sources_lookup")
+    await conn.execute(
+        """
+        CREATE TABLE match_bookmaker_sources__new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            snapshot_id TEXT,
+            match_id TEXT NOT NULL REFERENCES matches(id),
+            bookmaker_id TEXT NOT NULL REFERENCES bookmakers(id),
+            source_url TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    await conn.execute(
+        f"""
+        INSERT INTO match_bookmaker_sources__new (
+            id,
+            snapshot_id,
+            match_id,
+            bookmaker_id,
+            source_url,
+            created_at,
+            updated_at
+        )
+        SELECT
+            id,
+            {snapshot_expr},
+            match_id,
+            bookmaker_id,
+            source_url,
+            created_at,
+            updated_at
+        FROM match_bookmaker_sources
+        """
+    )
+    await conn.execute("DROP TABLE match_bookmaker_sources")
+    await conn.execute(
+        "ALTER TABLE match_bookmaker_sources__new RENAME TO match_bookmaker_sources"
+    )
+
+
 async def _rebuild_odds_for_snapshots(conn: aiosqlite.Connection) -> None:
     await conn.execute("DROP INDEX IF EXISTS idx_odds_unique_snapshot_line")
     await conn.execute("DROP INDEX IF EXISTS idx_odds_snapshot")
@@ -751,6 +800,7 @@ async def _rebuild_team_review_cases(conn: aiosqlite.Connection) -> None:
 async def _backfill_snapshot_metadata(conn: aiosqlite.Connection) -> None:
     snapshot_sources = (
         ("odds", "scraped_at"),
+        ("odds_history", "scraped_at"),
         ("outcome_offers", "scraped_at"),
         ("unresolved_odds", "scraped_at"),
         ("team_review_cases", "scraped_at"),
@@ -935,6 +985,41 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
         )
     ):
         await _rebuild_matches(conn)
+
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS match_bookmaker_sources (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               snapshot_id TEXT,
+               match_id TEXT NOT NULL REFERENCES matches(id),
+               bookmaker_id TEXT NOT NULL REFERENCES bookmakers(id),
+               source_url TEXT,
+               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+               updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+           )"""
+    )
+    source_columns = await conn.execute_fetchall("PRAGMA table_info(match_bookmaker_sources)")
+    existing_sources = {row[1] for row in source_columns}
+    source_indexes = await conn.execute_fetchall("PRAGMA index_list(match_bookmaker_sources)")
+    if source_columns and (
+        "snapshot_id" not in existing_sources
+        or any(
+            str(row[1]).startswith("sqlite_autoindex_match_bookmaker_sources")
+            for row in source_indexes
+        )
+    ):
+        await _rebuild_match_bookmaker_sources_for_snapshots(conn)
+    await conn.execute(
+        """CREATE UNIQUE INDEX IF NOT EXISTS idx_match_bookmaker_sources_unique_snapshot
+           ON match_bookmaker_sources (
+               COALESCE(snapshot_id, ''),
+               match_id,
+               bookmaker_id
+           )"""
+    )
+    await conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_match_bookmaker_sources_lookup
+           ON match_bookmaker_sources (match_id, bookmaker_id, snapshot_id)"""
+    )
 
     await conn.execute(
         """CREATE TABLE IF NOT EXISTS snapshot_matches (

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -42,6 +42,23 @@ CREATE TABLE IF NOT EXISTS match_bookmaker_sources (
     UNIQUE(match_id, bookmaker_id)
 );
 
+CREATE TABLE IF NOT EXISTS snapshot_matches (
+    snapshot_id TEXT NOT NULL,
+    match_id TEXT NOT NULL REFERENCES matches(id),
+    league_id TEXT REFERENCES leagues(id),
+    sport TEXT NOT NULL DEFAULT 'basketball',
+    home_team_id INTEGER REFERENCES canonical_teams(id),
+    away_team_id INTEGER REFERENCES canonical_teams(id),
+    home_team TEXT NOT NULL,
+    away_team TEXT NOT NULL,
+    start_time TIMESTAMP,
+    status TEXT DEFAULT 'upcoming',
+    PRIMARY KEY (snapshot_id, match_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshot_matches_match
+ON snapshot_matches (match_id, snapshot_id);
+
 CREATE TABLE IF NOT EXISTS resolved_events (
     id TEXT PRIMARY KEY,
     sport TEXT NOT NULL,
@@ -66,6 +83,7 @@ ON resolved_events (primary_match_id);
 
 CREATE TABLE IF NOT EXISTS resolved_event_members (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_id TEXT,
     resolved_event_id TEXT NOT NULL REFERENCES resolved_events(id),
     match_id TEXT NOT NULL REFERENCES matches(id),
     bookmaker_id TEXT NOT NULL REFERENCES bookmakers(id),
@@ -81,8 +99,7 @@ CREATE TABLE IF NOT EXISTS resolved_event_members (
     evidence TEXT NOT NULL DEFAULT '[]',
     metadata TEXT NOT NULL DEFAULT '{}',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(match_id, bookmaker_id)
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS idx_resolved_event_members_event
@@ -123,8 +140,25 @@ ON event_review_cases (candidate_resolved_event_id);
 CREATE INDEX IF NOT EXISTS idx_event_review_cases_resolved_event
 ON event_review_cases (resolved_event_id);
 
+CREATE TABLE IF NOT EXISTS scrape_snapshots (
+    id TEXT PRIMARY KEY,
+    scraped_at TIMESTAMP NOT NULL UNIQUE,
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    status TEXT NOT NULL DEFAULT 'persisted',
+    matches_count INTEGER NOT NULL DEFAULT 0,
+    odds_count INTEGER NOT NULL DEFAULT 0,
+    outcome_offers_count INTEGER NOT NULL DEFAULT 0,
+    unresolved_odds_count INTEGER NOT NULL DEFAULT 0,
+    team_review_cases_count INTEGER NOT NULL DEFAULT 0,
+    error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE IF NOT EXISTS odds (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_id TEXT,
     match_id TEXT REFERENCES matches(id),
     bookmaker_id TEXT REFERENCES bookmakers(id),
     market_type TEXT NOT NULL,
@@ -132,12 +166,12 @@ CREATE TABLE IF NOT EXISTS odds (
     threshold REAL NOT NULL,
     over_odds REAL,
     under_odds REAL,
-    scraped_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(match_id, bookmaker_id, market_type, player_name, threshold)
+    scraped_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS odds_history (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_id TEXT,
     match_id TEXT,
     bookmaker_id TEXT,
     market_type TEXT,
@@ -150,6 +184,7 @@ CREATE TABLE IF NOT EXISTS odds_history (
 
 CREATE TABLE IF NOT EXISTS outcome_offers (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_id TEXT,
     match_id TEXT REFERENCES matches(id),
     bookmaker_id TEXT REFERENCES bookmakers(id),
     market_type TEXT NOT NULL,
@@ -160,20 +195,20 @@ CREATE TABLE IF NOT EXISTS outcome_offers (
     scraped_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_outcome_offers_unique_line
-ON outcome_offers (
-    match_id,
-    bookmaker_id,
-    market_type,
-    outcome_code,
-    COALESCE(line, -999999.0)
+CREATE TABLE IF NOT EXISTS opportunity_publishes (
+    id TEXT PRIMARY KEY,
+    snapshot_id TEXT,
+    detected_at TIMESTAMP NOT NULL,
+    status TEXT NOT NULL DEFAULT 'published',
+    opportunity_count INTEGER NOT NULL DEFAULT 0,
+    error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-
-CREATE INDEX IF NOT EXISTS idx_outcome_offers_snapshot
-ON outcome_offers (scraped_at, match_id, bookmaker_id);
 
 CREATE TABLE IF NOT EXISTS opportunities (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    publish_id TEXT,
     sport TEXT NOT NULL,
     match_id TEXT REFERENCES matches(id),
     resolved_event_id TEXT REFERENCES resolved_events(id),
@@ -196,6 +231,7 @@ ON opportunities (is_active, sport, detected_at);
 
 CREATE TABLE IF NOT EXISTS unresolved_odds (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_id TEXT,
     bookmaker_id TEXT REFERENCES bookmakers(id),
     raw_league_id TEXT NOT NULL,
     league_id TEXT NOT NULL,
@@ -217,6 +253,7 @@ CREATE TABLE IF NOT EXISTS unresolved_odds (
 
 CREATE TABLE IF NOT EXISTS team_review_cases (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_id TEXT,
     bookmaker_id TEXT REFERENCES bookmakers(id),
     raw_league_id TEXT NOT NULL,
     normalized_raw_league_id TEXT NOT NULL,
@@ -296,7 +333,9 @@ CREATE TABLE IF NOT EXISTS notifications (
 
 CREATE TABLE IF NOT EXISTS scrape_state (
     id INTEGER PRIMARY KEY CHECK (id = 1),
+    current_snapshot_id TEXT,
     current_snapshot_at TIMESTAMP,
+    current_opportunity_publish_id TEXT,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 """
@@ -313,6 +352,22 @@ async def _table_has_foreign_key(
 ) -> bool:
     rows = await conn.execute_fetchall(f"PRAGMA foreign_key_list({table_name})")
     return any(row[2] == target_table and row[3] == from_column for row in rows)
+
+
+async def _index_sql_contains(
+    conn: aiosqlite.Connection,
+    *,
+    index_name: str,
+    expected: str,
+) -> bool | None:
+    rows = await conn.execute_fetchall(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+        (index_name,),
+    )
+    if not rows:
+        return None
+    sql = rows[0][0] or ""
+    return expected.lower() in str(sql).lower()
 
 
 async def _rebuild_matches(conn: aiosqlite.Connection) -> None:
@@ -380,11 +435,145 @@ async def _rebuild_matches(conn: aiosqlite.Connection) -> None:
     await conn.execute("ALTER TABLE matches__new RENAME TO matches")
 
 
+async def _rebuild_resolved_event_members_for_snapshots(
+    conn: aiosqlite.Connection,
+) -> None:
+    await conn.execute("DROP INDEX IF EXISTS idx_resolved_event_members_event")
+    await conn.execute("DROP INDEX IF EXISTS idx_resolved_event_members_match")
+    await conn.execute("DROP INDEX IF EXISTS idx_resolved_event_members_unique_snapshot")
+    await conn.execute(
+        """
+        CREATE TABLE resolved_event_members__new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            snapshot_id TEXT,
+            resolved_event_id TEXT NOT NULL REFERENCES resolved_events(id),
+            match_id TEXT NOT NULL REFERENCES matches(id),
+            bookmaker_id TEXT NOT NULL REFERENCES bookmakers(id),
+            orientation TEXT NOT NULL DEFAULT 'as_listed',
+            confidence REAL,
+            status TEXT NOT NULL DEFAULT 'active',
+            source_url TEXT,
+            source_league_id TEXT,
+            source_league_name TEXT,
+            source_home_team TEXT,
+            source_away_team TEXT,
+            source_start_time TIMESTAMP,
+            evidence TEXT NOT NULL DEFAULT '[]',
+            metadata TEXT NOT NULL DEFAULT '{}',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    await conn.execute(
+        """
+        INSERT INTO resolved_event_members__new (
+            id,
+            snapshot_id,
+            resolved_event_id,
+            match_id,
+            bookmaker_id,
+            orientation,
+            confidence,
+            status,
+            source_url,
+            source_league_id,
+            source_league_name,
+            source_home_team,
+            source_away_team,
+            source_start_time,
+            evidence,
+            metadata,
+            created_at,
+            updated_at
+        )
+        SELECT
+            id,
+            snapshot_id,
+            resolved_event_id,
+            match_id,
+            bookmaker_id,
+            orientation,
+            confidence,
+            status,
+            source_url,
+            source_league_id,
+            source_league_name,
+            source_home_team,
+            source_away_team,
+            source_start_time,
+            evidence,
+            metadata,
+            created_at,
+            updated_at
+        FROM resolved_event_members
+        ORDER BY id ASC
+        """
+    )
+    await conn.execute("DROP TABLE resolved_event_members")
+    await conn.execute(
+        "ALTER TABLE resolved_event_members__new RENAME TO resolved_event_members"
+    )
+
+
+async def _rebuild_odds_for_snapshots(conn: aiosqlite.Connection) -> None:
+    await conn.execute("DROP INDEX IF EXISTS idx_odds_unique_snapshot_line")
+    await conn.execute("DROP INDEX IF EXISTS idx_odds_snapshot")
+    await conn.execute(
+        """
+        CREATE TABLE odds__new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            snapshot_id TEXT,
+            match_id TEXT REFERENCES matches(id),
+            bookmaker_id TEXT REFERENCES bookmakers(id),
+            market_type TEXT NOT NULL,
+            player_name TEXT,
+            threshold REAL NOT NULL,
+            over_odds REAL,
+            under_odds REAL,
+            scraped_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    await conn.execute(
+        """
+        INSERT OR REPLACE INTO odds__new (
+            id,
+            snapshot_id,
+            match_id,
+            bookmaker_id,
+            market_type,
+            player_name,
+            threshold,
+            over_odds,
+            under_odds,
+            scraped_at
+        )
+        SELECT
+            id,
+            COALESCE(snapshot_id, scraped_at),
+            match_id,
+            bookmaker_id,
+            market_type,
+            player_name,
+            threshold,
+            over_odds,
+            under_odds,
+            scraped_at
+        FROM odds
+        ORDER BY id ASC
+        """
+    )
+    await conn.execute("DROP TABLE odds")
+    await conn.execute("ALTER TABLE odds__new RENAME TO odds")
+
+
 async def _rebuild_opportunities(conn: aiosqlite.Connection) -> None:
     await conn.execute(
         """
         CREATE TABLE opportunities__new (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            publish_id TEXT,
             sport TEXT NOT NULL,
             match_id TEXT REFERENCES matches(id),
             resolved_event_id TEXT REFERENCES resolved_events(id),
@@ -407,6 +596,7 @@ async def _rebuild_opportunities(conn: aiosqlite.Connection) -> None:
         """
         INSERT INTO opportunities__new (
             id,
+            publish_id,
             sport,
             match_id,
             resolved_event_id,
@@ -425,6 +615,7 @@ async def _rebuild_opportunities(conn: aiosqlite.Connection) -> None:
         )
         SELECT
             id,
+            publish_id,
             sport,
             match_id,
             CASE
@@ -460,6 +651,7 @@ async def _rebuild_team_review_cases(conn: aiosqlite.Connection) -> None:
         """
         CREATE TABLE team_review_cases__new (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            snapshot_id TEXT,
             bookmaker_id TEXT REFERENCES bookmakers(id),
             raw_league_id TEXT NOT NULL,
             normalized_raw_league_id TEXT NOT NULL,
@@ -490,6 +682,7 @@ async def _rebuild_team_review_cases(conn: aiosqlite.Connection) -> None:
         """
         INSERT INTO team_review_cases__new (
             id,
+            snapshot_id,
             bookmaker_id,
             raw_league_id,
             normalized_raw_league_id,
@@ -516,6 +709,7 @@ async def _rebuild_team_review_cases(conn: aiosqlite.Connection) -> None:
         )
         SELECT
             id,
+            COALESCE(snapshot_id, scraped_at),
             bookmaker_id,
             raw_league_id,
             normalized_raw_league_id,
@@ -554,7 +748,168 @@ async def _rebuild_team_review_cases(conn: aiosqlite.Connection) -> None:
     await conn.execute("ALTER TABLE team_review_cases__new RENAME TO team_review_cases")
 
 
+async def _backfill_snapshot_metadata(conn: aiosqlite.Connection) -> None:
+    snapshot_sources = (
+        ("odds", "scraped_at"),
+        ("outcome_offers", "scraped_at"),
+        ("unresolved_odds", "scraped_at"),
+        ("team_review_cases", "scraped_at"),
+    )
+    for table_name, column_name in snapshot_sources:
+        await conn.execute(
+            f"""INSERT OR IGNORE INTO scrape_snapshots (
+                    id,
+                    scraped_at,
+                    completed_at,
+                    status
+                )
+                SELECT DISTINCT {column_name}, {column_name}, {column_name}, 'published'
+                FROM {table_name}
+                WHERE {column_name} IS NOT NULL"""
+        )
+        await conn.execute(
+            f"""UPDATE {table_name}
+                SET snapshot_id = {column_name}
+                WHERE snapshot_id IS NULL
+                  AND {column_name} IS NOT NULL"""
+        )
+
+    await conn.execute(
+        """INSERT OR IGNORE INTO opportunity_publishes (
+               id,
+               snapshot_id,
+               detected_at,
+               status,
+               opportunity_count
+           )
+           SELECT
+               detected_at,
+               detected_at,
+               detected_at,
+               'published',
+               COUNT(*)
+           FROM opportunities
+           WHERE detected_at IS NOT NULL
+           GROUP BY detected_at"""
+    )
+    await conn.execute(
+        """UPDATE opportunities
+           SET publish_id = detected_at
+           WHERE publish_id IS NULL
+             AND detected_at IS NOT NULL
+             AND is_active = TRUE"""
+    )
+    await conn.execute(
+        """UPDATE scrape_state
+           SET current_snapshot_id = COALESCE(current_snapshot_id, current_snapshot_at)
+           WHERE id = 1
+             AND current_snapshot_at IS NOT NULL"""
+    )
+    await conn.execute(
+        """UPDATE scrape_state
+           SET current_opportunity_publish_id = COALESCE(
+                   current_opportunity_publish_id,
+                   (
+                       SELECT publish_id
+                       FROM opportunities
+                       WHERE is_active = TRUE
+                         AND publish_id IS NOT NULL
+                       GROUP BY publish_id
+                       ORDER BY MAX(detected_at) DESC
+                       LIMIT 1
+                   )
+               )
+           WHERE id = 1"""
+    )
+    await conn.execute(
+        """INSERT OR IGNORE INTO snapshot_matches (
+               snapshot_id,
+               match_id,
+               league_id,
+               sport,
+               home_team_id,
+               away_team_id,
+               home_team,
+               away_team,
+               start_time,
+               status
+           )
+           SELECT DISTINCT
+               COALESCE(o.snapshot_id, o.scraped_at),
+               m.id,
+               m.league_id,
+               m.sport,
+               m.home_team_id,
+               m.away_team_id,
+               m.home_team,
+               m.away_team,
+               m.start_time,
+               m.status
+           FROM odds o
+           JOIN matches m ON m.id = o.match_id
+           WHERE COALESCE(o.snapshot_id, o.scraped_at) IS NOT NULL"""
+    )
+    await conn.execute(
+        """INSERT OR IGNORE INTO snapshot_matches (
+               snapshot_id,
+               match_id,
+               league_id,
+               sport,
+               home_team_id,
+               away_team_id,
+               home_team,
+               away_team,
+               start_time,
+               status
+           )
+           SELECT DISTINCT
+               COALESCE(oo.snapshot_id, oo.scraped_at),
+               m.id,
+               m.league_id,
+               m.sport,
+               m.home_team_id,
+               m.away_team_id,
+               m.home_team,
+               m.away_team,
+               m.start_time,
+               m.status
+           FROM outcome_offers oo
+           JOIN matches m ON m.id = oo.match_id
+           WHERE COALESCE(oo.snapshot_id, oo.scraped_at) IS NOT NULL"""
+    )
+
+
 async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS scrape_snapshots (
+               id TEXT PRIMARY KEY,
+               scraped_at TIMESTAMP NOT NULL UNIQUE,
+               started_at TIMESTAMP,
+               completed_at TIMESTAMP,
+               status TEXT NOT NULL DEFAULT 'persisted',
+               matches_count INTEGER NOT NULL DEFAULT 0,
+               odds_count INTEGER NOT NULL DEFAULT 0,
+               outcome_offers_count INTEGER NOT NULL DEFAULT 0,
+               unresolved_odds_count INTEGER NOT NULL DEFAULT 0,
+               team_review_cases_count INTEGER NOT NULL DEFAULT 0,
+               error TEXT,
+               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+               updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+           )"""
+    )
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS opportunity_publishes (
+               id TEXT PRIMARY KEY,
+               snapshot_id TEXT,
+               detected_at TIMESTAMP NOT NULL,
+               status TEXT NOT NULL DEFAULT 'published',
+               opportunity_count INTEGER NOT NULL DEFAULT 0,
+               error TEXT,
+               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+               updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+           )"""
+    )
+
     match_columns = await conn.execute_fetchall("PRAGMA table_info(matches)")
     existing_matches = {row[1] for row in match_columns}
     if match_columns and "sport" not in existing_matches:
@@ -581,8 +936,62 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
     ):
         await _rebuild_matches(conn)
 
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS snapshot_matches (
+               snapshot_id TEXT NOT NULL,
+               match_id TEXT NOT NULL REFERENCES matches(id),
+               league_id TEXT REFERENCES leagues(id),
+               sport TEXT NOT NULL DEFAULT 'basketball',
+               home_team_id INTEGER REFERENCES canonical_teams(id),
+               away_team_id INTEGER REFERENCES canonical_teams(id),
+               home_team TEXT NOT NULL,
+               away_team TEXT NOT NULL,
+               start_time TIMESTAMP,
+               status TEXT DEFAULT 'upcoming',
+               PRIMARY KEY (snapshot_id, match_id)
+           )"""
+    )
+    await conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_snapshot_matches_match
+           ON snapshot_matches (match_id, snapshot_id)"""
+    )
+
+    resolved_member_columns = await conn.execute_fetchall(
+        "PRAGMA table_info(resolved_event_members)"
+    )
+    existing_resolved_members = {row[1] for row in resolved_member_columns}
+    if resolved_member_columns and "snapshot_id" not in existing_resolved_members:
+        await conn.execute("ALTER TABLE resolved_event_members ADD COLUMN snapshot_id TEXT")
+        existing_resolved_members.add("snapshot_id")
+    resolved_member_indexes = await conn.execute_fetchall(
+        "PRAGMA index_list(resolved_event_members)"
+    )
+    if resolved_member_columns and any(
+        str(row[1]).startswith("sqlite_autoindex_resolved_event_members")
+        for row in resolved_member_indexes
+    ):
+        await _rebuild_resolved_event_members_for_snapshots(conn)
+    await conn.execute(
+        """CREATE UNIQUE INDEX IF NOT EXISTS idx_resolved_event_members_unique_snapshot
+           ON resolved_event_members (
+               COALESCE(snapshot_id, ''),
+               match_id,
+               bookmaker_id
+           )"""
+    )
+    await conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_resolved_event_members_event
+           ON resolved_event_members (resolved_event_id, status)"""
+    )
+    await conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_resolved_event_members_match
+           ON resolved_event_members (match_id, bookmaker_id, snapshot_id)"""
+    )
+
     unresolved_columns = await conn.execute_fetchall("PRAGMA table_info(unresolved_odds)")
     existing_unresolved = {row[1] for row in unresolved_columns}
+    if unresolved_columns and "snapshot_id" not in existing_unresolved:
+        await conn.execute("ALTER TABLE unresolved_odds ADD COLUMN snapshot_id TEXT")
     if unresolved_columns and "sport" not in existing_unresolved:
         await conn.execute(
             "ALTER TABLE unresolved_odds ADD COLUMN sport TEXT NOT NULL DEFAULT 'basketball'"
@@ -590,9 +999,39 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
 
     await conn.execute("DROP TABLE IF EXISTS discrepancies")
 
+    odds_columns = await conn.execute_fetchall("PRAGMA table_info(odds)")
+    existing_odds = {row[1] for row in odds_columns}
+    if odds_columns and "snapshot_id" not in existing_odds:
+        await conn.execute("ALTER TABLE odds ADD COLUMN snapshot_id TEXT")
+        existing_odds.add("snapshot_id")
+    odds_indexes = await conn.execute_fetchall("PRAGMA index_list(odds)")
+    if odds_columns and any(str(row[1]).startswith("sqlite_autoindex_odds") for row in odds_indexes):
+        await _rebuild_odds_for_snapshots(conn)
+    await conn.execute(
+        """CREATE UNIQUE INDEX IF NOT EXISTS idx_odds_unique_snapshot_line
+           ON odds (
+               COALESCE(snapshot_id, ''),
+               match_id,
+               bookmaker_id,
+               market_type,
+               COALESCE(player_name, ''),
+               threshold
+           )"""
+    )
+    await conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_odds_snapshot
+           ON odds (snapshot_id, scraped_at, match_id, bookmaker_id)"""
+    )
+
+    odds_history_columns = await conn.execute_fetchall("PRAGMA table_info(odds_history)")
+    existing_odds_history = {row[1] for row in odds_history_columns}
+    if odds_history_columns and "snapshot_id" not in existing_odds_history:
+        await conn.execute("ALTER TABLE odds_history ADD COLUMN snapshot_id TEXT")
+
     await conn.execute(
         """CREATE TABLE IF NOT EXISTS outcome_offers (
                id INTEGER PRIMARY KEY AUTOINCREMENT,
+               snapshot_id TEXT,
                match_id TEXT REFERENCES matches(id),
                bookmaker_id TEXT REFERENCES bookmakers(id),
                market_type TEXT NOT NULL,
@@ -603,9 +1042,21 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
                scraped_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
            )"""
     )
+    outcome_offer_columns = await conn.execute_fetchall("PRAGMA table_info(outcome_offers)")
+    existing_outcome_offers = {row[1] for row in outcome_offer_columns}
+    if outcome_offer_columns and "snapshot_id" not in existing_outcome_offers:
+        await conn.execute("ALTER TABLE outcome_offers ADD COLUMN snapshot_id TEXT")
+    outcome_offer_unique_index_has_snapshot = await _index_sql_contains(
+        conn,
+        index_name="idx_outcome_offers_unique_line",
+        expected="snapshot_id",
+    )
+    if outcome_offer_unique_index_has_snapshot is False:
+        await conn.execute("DROP INDEX IF EXISTS idx_outcome_offers_unique_line")
     await conn.execute(
         """CREATE UNIQUE INDEX IF NOT EXISTS idx_outcome_offers_unique_line
            ON outcome_offers (
+               COALESCE(snapshot_id, ''),
                match_id,
                bookmaker_id,
                market_type,
@@ -615,11 +1066,12 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
     )
     await conn.execute(
         """CREATE INDEX IF NOT EXISTS idx_outcome_offers_snapshot
-           ON outcome_offers (scraped_at, match_id, bookmaker_id)"""
+           ON outcome_offers (snapshot_id, scraped_at, match_id, bookmaker_id)"""
     )
     await conn.execute(
         """CREATE TABLE IF NOT EXISTS opportunities (
                id INTEGER PRIMARY KEY AUTOINCREMENT,
+               publish_id TEXT,
                sport TEXT NOT NULL,
                match_id TEXT REFERENCES matches(id),
                resolved_event_id TEXT REFERENCES resolved_events(id),
@@ -643,6 +1095,9 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
     )
     opportunity_columns = await conn.execute_fetchall("PRAGMA table_info(opportunities)")
     existing_opportunities = {row[1] for row in opportunity_columns}
+    if opportunity_columns and "publish_id" not in existing_opportunities:
+        await conn.execute("ALTER TABLE opportunities ADD COLUMN publish_id TEXT")
+        existing_opportunities.add("publish_id")
     if opportunity_columns and "middle_profit_margin" not in existing_opportunities:
         await conn.execute("ALTER TABLE opportunities ADD COLUMN middle_profit_margin REAL")
     if opportunity_columns and "resolved_event_id" not in existing_opportunities:
@@ -674,9 +1129,16 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
         """CREATE INDEX IF NOT EXISTS idx_opportunities_resolved_event_active
            ON opportunities (resolved_event_id, is_active)"""
     )
+    await conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_opportunities_publish
+           ON opportunities (publish_id, sport, detected_at)"""
+    )
 
     team_review_columns = await conn.execute_fetchall("PRAGMA table_info(team_review_cases)")
     existing_team_review = {row[1] for row in team_review_columns}
+    if team_review_columns and "snapshot_id" not in existing_team_review:
+        await conn.execute("ALTER TABLE team_review_cases ADD COLUMN snapshot_id TEXT")
+        existing_team_review.add("snapshot_id")
     if team_review_columns and "sport" not in existing_team_review:
         await conn.execute(
             "ALTER TABLE team_review_cases ADD COLUMN sport TEXT NOT NULL DEFAULT 'basketball'"
@@ -722,6 +1184,17 @@ async def _ensure_schema_compatibility(conn: aiosqlite.Connection) -> None:
             target_table="canonical_teams",
         ):
             await _rebuild_team_review_cases(conn)
+
+    scrape_state_columns = await conn.execute_fetchall("PRAGMA table_info(scrape_state)")
+    existing_scrape_state = {row[1] for row in scrape_state_columns}
+    if scrape_state_columns and "current_snapshot_id" not in existing_scrape_state:
+        await conn.execute("ALTER TABLE scrape_state ADD COLUMN current_snapshot_id TEXT")
+    if scrape_state_columns and "current_opportunity_publish_id" not in existing_scrape_state:
+        await conn.execute(
+            "ALTER TABLE scrape_state ADD COLUMN current_opportunity_publish_id TEXT"
+        )
+
+    await _backfill_snapshot_metadata(conn)
 
     team_merge_history_columns = await conn.execute_fetchall(
         "PRAGMA table_info(team_merge_history)"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -924,8 +924,45 @@ async def _backfill_snapshot_metadata(conn: aiosqlite.Connection) -> None:
                m.start_time,
                m.status
            FROM outcome_offers oo
-           JOIN matches m ON m.id = oo.match_id
-           WHERE COALESCE(oo.snapshot_id, oo.scraped_at) IS NOT NULL"""
+            JOIN matches m ON m.id = oo.match_id
+            WHERE COALESCE(oo.snapshot_id, oo.scraped_at) IS NOT NULL"""
+    )
+    await conn.execute(
+        """INSERT OR IGNORE INTO match_bookmaker_sources (
+               snapshot_id,
+               match_id,
+               bookmaker_id,
+               source_url,
+               created_at,
+               updated_at
+           )
+           SELECT DISTINCT
+               scoped_sources.snapshot_id,
+               legacy_sources.match_id,
+               legacy_sources.bookmaker_id,
+               legacy_sources.source_url,
+               legacy_sources.created_at,
+               legacy_sources.updated_at
+           FROM match_bookmaker_sources legacy_sources
+           JOIN (
+               SELECT DISTINCT
+                   COALESCE(snapshot_id, scraped_at) AS snapshot_id,
+                   match_id,
+                   bookmaker_id
+               FROM odds
+               WHERE COALESCE(snapshot_id, scraped_at) IS NOT NULL
+               UNION
+               SELECT DISTINCT
+                   COALESCE(snapshot_id, scraped_at) AS snapshot_id,
+                   match_id,
+                   bookmaker_id
+               FROM outcome_offers
+               WHERE COALESCE(snapshot_id, scraped_at) IS NOT NULL
+           ) scoped_sources
+             ON scoped_sources.match_id = legacy_sources.match_id
+            AND scoped_sources.bookmaker_id = legacy_sources.bookmaker_id
+           WHERE legacy_sources.snapshot_id IS NULL
+             AND legacy_sources.source_url IS NOT NULL"""
     )
 
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -60,6 +60,7 @@ class ResolvedEventIn(BaseModel):
 
 
 class ResolvedEventMemberIn(BaseModel):
+    snapshot_id: Optional[str] = None
     resolved_event_id: str
     match_id: str
     bookmaker_id: str

--- a/backend/app/services/event_resolver.py
+++ b/backend/app/services/event_resolver.py
@@ -1159,8 +1159,11 @@ def build_event_resolution_groups(
 async def persist_event_resolution_groups(
     resolutions: list[EventResolutionGroup],
     review_cases: list[EventReviewCaseIn],
+    *,
+    snapshot_id: str | None = None,
 ) -> EventResolverResult:
-    member_count = 0
+    events: list[ResolvedEventIn] = []
+    members: list[ResolvedEventMemberIn] = []
     for resolution in resolutions:
         source_league_labels = sorted(
             {
@@ -1170,7 +1173,7 @@ async def persist_event_resolution_groups(
             }
         )
         source_match_ids = sorted({member.match_id for member in resolution.members})
-        await odds_store.upsert_resolved_event(
+        events.append(
             ResolvedEventIn(
                 id=resolution.event_id,
                 sport=resolution.sport,
@@ -1194,7 +1197,7 @@ async def persist_event_resolution_groups(
             key=lambda candidate: (candidate.match_id, candidate.bookmaker_id),
         )
         for member in resolution.members:
-            await odds_store.link_resolved_event_member(
+            members.append(
                 ResolvedEventMemberIn(
                     resolved_event_id=resolution.event_id,
                     match_id=member.match_id,
@@ -1216,23 +1219,25 @@ async def persist_event_resolution_groups(
                     },
                 )
             )
-            member_count += 1
 
-    persisted_review_cases = 0
-    for review_case in review_cases:
-        await odds_store.upsert_event_review_case(review_case)
-        persisted_review_cases += 1
+    result = await odds_store.persist_event_resolution_batch(
+        snapshot_id=snapshot_id,
+        events=events,
+        members=members,
+        review_cases=review_cases,
+    )
 
     return EventResolverResult(
-        candidates=member_count,
-        resolved_events=len(resolutions),
-        resolved_event_members=member_count,
-        review_cases=persisted_review_cases,
+        candidates=len(members),
+        resolved_events=result["resolved_events"],
+        resolved_event_members=result["resolved_event_members"],
+        review_cases=result["review_cases"],
     )
 
 
 async def resolve_and_persist_events(
     *,
+    snapshot_id: str | None = None,
     raw_odds: list[RawOddsData],
     raw_outcome_offers: list[RawOutcomeOffer],
     normalized_odds: list[NormalizedOdds],
@@ -1245,7 +1250,11 @@ async def resolve_and_persist_events(
         normalized_outcome_offers=normalized_outcome_offers,
     )
     resolutions, review_cases = build_event_resolution_groups(candidates)
-    result = await persist_event_resolution_groups(resolutions, review_cases)
+    result = await persist_event_resolution_groups(
+        resolutions,
+        review_cases,
+        snapshot_id=snapshot_id,
+    )
     logger.info(
         "Resolved %d source-event candidates into %d events (%d members, %d review cases)",
         len(candidates),

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1111,13 +1111,15 @@ class Scheduler:
                 self._scan_phase = "analyzing"
                 canonical_analysis = _CanonicalAnalysisResult()
                 canonical_analysis_failed = False
+                canonical_analysis_error: str | None = None
                 try:
                     canonical_analysis = await _load_current_canonical_analysis(
                         match_ids=seen_matches,
                         snapshot_id=snapshot_id,
                     )
-                except Exception:
+                except Exception as exc:
                     canonical_analysis_failed = True
+                    canonical_analysis_error = f"{type(exc).__name__}: {exc}"
                     logger.exception("Canonical opportunity analysis failed")
                 opportunities = list(canonical_analysis.opportunities)
 
@@ -1127,6 +1129,12 @@ class Scheduler:
                         snapshot_at=cycle_scraped_at,
                         opportunities=opportunities,
                         detected_at=cycle_scraped_at,
+                    )
+                else:
+                    await odds_store.mark_scrape_snapshot_analysis_failed(
+                        snapshot_id=snapshot_id,
+                        snapshot_at=cycle_scraped_at,
+                        error=canonical_analysis_error,
                     )
 
                 if canonical_analysis_failed:

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -209,9 +209,14 @@ def _publish_benchmark_snapshot(
     )
 
 
-async def _load_current_canonical_analysis(match_ids: set[str]) -> _CanonicalAnalysisResult:
+async def _load_current_canonical_analysis(
+    match_ids: set[str],
+    *,
+    snapshot_id: str | None = None,
+) -> _CanonicalAnalysisResult:
     canonical_offers = await odds_store.get_current_canonical_offers_for_matches(
-        sorted(match_ids)
+        sorted(match_ids),
+        snapshot_id=snapshot_id,
     )
     event_ids = sorted(
         {
@@ -1079,32 +1084,29 @@ class Scheduler:
 
                 self._scan_phase = "storing"
                 cycle_scraped_at = datetime.utcnow().isoformat()
-                await _persist_normalized_pipeline_batch(
-                    normalized_batch,
-                    cycle_scraped_at=cycle_scraped_at,
-                    seen_matches=seen_matches,
+                persisted_snapshot = await odds_store.persist_scrape_snapshot_batch(
+                    snapshot_at=cycle_scraped_at,
+                    odds=normalized,
+                    outcome_offers=normalized_outcome_offers,
+                    unresolved_odds=unresolved_odds,
+                    team_review_cases=team_review_cases,
+                    auto_approved_team_reviews=auto_approved_team_reviews,
+                )
+                seen_matches = set(persisted_snapshot["seen_match_ids"])
+                snapshot_id = str(persisted_snapshot["snapshot_id"])
+                auto_approved_team_review_case_ids.extend(
+                    int(case_id)
+                    for case_id in persisted_snapshot[
+                        "auto_approved_team_review_case_ids"
+                    ]
                 )
                 await resolve_and_persist_events(
+                    snapshot_id=snapshot_id,
                     raw_odds=all_raw,
                     raw_outcome_offers=all_raw_outcome_offers,
                     normalized_odds=normalized,
                     normalized_outcome_offers=normalized_outcome_offers,
                 )
-                for unresolved in unresolved_odds:
-                    await odds_store.insert_unresolved_odds(
-                        unresolved, scraped_at=cycle_scraped_at
-                    )
-                for team_review_case in team_review_cases:
-                    await odds_store.insert_team_review_case(
-                        team_review_case, scraped_at=cycle_scraped_at
-                    )
-                for team_review_case in auto_approved_team_reviews:
-                    case_id = await odds_store.insert_team_review_case(
-                        team_review_case, scraped_at=cycle_scraped_at
-                    )
-                    auto_approved_team_review_case_ids.append(case_id)
-                    await odds_store.mark_team_review_case_approved(case_id)
-                await odds_store.set_current_snapshot(cycle_scraped_at)
 
                 self._scan_phase = "analyzing"
                 canonical_analysis = _CanonicalAnalysisResult()
@@ -1112,19 +1114,20 @@ class Scheduler:
                 try:
                     canonical_analysis = await _load_current_canonical_analysis(
                         match_ids=seen_matches,
+                        snapshot_id=snapshot_id,
                     )
                 except Exception:
                     canonical_analysis_failed = True
                     logger.exception("Canonical opportunity analysis failed")
                 opportunities = list(canonical_analysis.opportunities)
 
-                await odds_store.deactivate_opportunities()
                 if not canonical_analysis_failed:
-                    for opportunity in opportunities:
-                        await odds_store.insert_opportunity(
-                            opportunity,
-                            detected_at=cycle_scraped_at,
-                        )
+                    await odds_store.publish_opportunities(
+                        snapshot_id=snapshot_id,
+                        snapshot_at=cycle_scraped_at,
+                        opportunities=opportunities,
+                        detected_at=cycle_scraped_at,
+                    )
 
                 if canonical_analysis_failed:
                     canonical_shadow = _CanonicalShadowResult(

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -338,20 +338,33 @@ async def _get_current_snapshot(
     row = await db.execute_fetchall(
         "SELECT current_snapshot_id, current_snapshot_at FROM scrape_state WHERE id = 1"
     )
-    if not row:
-        return None, None
-    snapshot_id = row[0]["current_snapshot_id"]
-    snapshot_at = row[0]["current_snapshot_at"]
-    if snapshot_id:
-        return snapshot_id, snapshot_at or snapshot_id
-    if snapshot_at:
-        return _snapshot_id_from_scraped_at(snapshot_at), snapshot_at
+    if row:
+        snapshot_id = row[0]["current_snapshot_id"]
+        snapshot_at = row[0]["current_snapshot_at"]
+        if snapshot_id:
+            return snapshot_id, snapshot_at or snapshot_id
+        if snapshot_at:
+            return _snapshot_id_from_scraped_at(snapshot_at), snapshot_at
+    published_row = await db.execute_fetchall(
+        """SELECT id, scraped_at
+           FROM scrape_snapshots
+           WHERE status = 'published'
+           ORDER BY datetime(scraped_at) DESC, scraped_at DESC
+           LIMIT 1"""
+    )
+    if published_row:
+        return published_row[0]["id"], published_row[0]["scraped_at"]
     return None, None
 
 
 async def _get_current_snapshot_id(db: aiosqlite.Connection) -> str | None:
     snapshot_id, _ = await _get_current_snapshot(db)
     return snapshot_id
+
+
+async def _has_scrape_snapshots(db: aiosqlite.Connection) -> bool:
+    row = await db.execute_fetchall("SELECT 1 FROM scrape_snapshots LIMIT 1")
+    return bool(row)
 
 
 async def _get_current_snapshot_at(db: aiosqlite.Connection) -> str | None:
@@ -427,6 +440,9 @@ async def _current_or_legacy_snapshot_filter(
     if current_snapshot_at is not None:
         return f"{alias}.scraped_at = ?", [current_snapshot_at]
 
+    if await _has_scrape_snapshots(db):
+        return None, []
+
     legacy_window = await _get_legacy_snapshot_cutoff(db)
     if legacy_window is None:
         return None, []
@@ -481,22 +497,24 @@ async def upsert_match(
 async def _upsert_match_bookmaker_source_tx(
     db: aiosqlite.Connection,
     *,
+    snapshot_id: str | None = None,
     match_id: str,
     bookmaker_id: str,
     source_url: str | None,
 ) -> None:
     await db.execute(
-        """INSERT INTO match_bookmaker_sources (match_id, bookmaker_id, source_url)
-           VALUES (?, ?, ?)
-           ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
+        """INSERT INTO match_bookmaker_sources (snapshot_id, match_id, bookmaker_id, source_url)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(COALESCE(snapshot_id, ''), match_id, bookmaker_id) DO UPDATE SET
                 source_url = COALESCE(excluded.source_url, match_bookmaker_sources.source_url),
                 updated_at = CURRENT_TIMESTAMP""",
-        (match_id, bookmaker_id, source_url),
+        (snapshot_id, match_id, bookmaker_id, source_url),
     )
 
 
 async def upsert_match_bookmaker_source(
     *,
+    snapshot_id: str | None = None,
     match_id: str,
     bookmaker_id: str,
     source_url: str | None,
@@ -504,6 +522,7 @@ async def upsert_match_bookmaker_source(
     db = await get_db()
     await _upsert_match_bookmaker_source_tx(
         db,
+        snapshot_id=snapshot_id,
         match_id=match_id,
         bookmaker_id=bookmaker_id,
         source_url=source_url,
@@ -640,14 +659,14 @@ async def persist_scrape_snapshot_batch(
             ],
         )
         source_rows = [
-            (row.match_id, row.bookmaker_id, row.source_url)
+            (snapshot_id, row.match_id, row.bookmaker_id, row.source_url)
             for row in rows
             if row.source_url is not None
         ]
         await db.executemany(
-            """INSERT INTO match_bookmaker_sources (match_id, bookmaker_id, source_url)
-               VALUES (?, ?, ?)
-               ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
+            """INSERT INTO match_bookmaker_sources (snapshot_id, match_id, bookmaker_id, source_url)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(COALESCE(snapshot_id, ''), match_id, bookmaker_id) DO UPDATE SET
                     source_url = COALESCE(excluded.source_url, match_bookmaker_sources.source_url),
                     updated_at = CURRENT_TIMESTAMP""",
             source_rows,
@@ -913,6 +932,8 @@ async def get_matches(
                    WHERE {offers_filter}
                )"""
     else:
+        if await _has_scrape_snapshots(db):
+            return []
         legacy_window = await _get_legacy_snapshot_cutoff(db)
         if legacy_window is None:
             return []
@@ -1059,6 +1080,8 @@ async def get_match(
             params,
         )
     else:
+        if require_current_snapshot and await _has_scrape_snapshots(db):
+            return None
         row = await db.execute_fetchall(
             """SELECT m.*, l.name as league_name,
                       (
@@ -1221,6 +1244,7 @@ async def link_resolved_event_member(member: ResolvedEventMemberIn) -> int:
         )
         await _upsert_match_bookmaker_source_tx(
             db,
+            snapshot_id=member.snapshot_id,
             match_id=member.match_id,
             bookmaker_id=member.bookmaker_id,
             source_url=member.source_url,
@@ -1730,13 +1754,18 @@ async def persist_event_resolution_batch(
             ],
         )
         await db.executemany(
-            """INSERT INTO match_bookmaker_sources (match_id, bookmaker_id, source_url)
-               VALUES (?, ?, ?)
-               ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
+            """INSERT INTO match_bookmaker_sources (snapshot_id, match_id, bookmaker_id, source_url)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(COALESCE(snapshot_id, ''), match_id, bookmaker_id) DO UPDATE SET
                     source_url = COALESCE(excluded.source_url, match_bookmaker_sources.source_url),
                     updated_at = CURRENT_TIMESTAMP""",
             [
-                (member.match_id, member.bookmaker_id, member.source_url)
+                (
+                    member.snapshot_id or snapshot_id,
+                    member.match_id,
+                    member.bookmaker_id,
+                    member.source_url,
+                )
                 for member in members
                 if member.source_url is not None
             ],
@@ -1891,12 +1920,22 @@ async def _get_event_review_case_variants_tx(
         )
     )
     if candidate_match_ids:
+        current_snapshot_id = await _get_current_snapshot_id(db)
         placeholders = _sql_placeholders(candidate_match_ids)
+        if current_snapshot_id is not None:
+            source_snapshot_clause = "AND s.snapshot_id = ?"
+            source_params: list[object] = [current_snapshot_id]
+        elif await _has_scrape_snapshots(db):
+            source_snapshot_clause = "AND 1 = 0"
+            source_params = []
+        else:
+            source_snapshot_clause = "AND s.snapshot_id IS NULL"
+            source_params = []
         rows = await db.execute_fetchall(
             f"""SELECT m.id AS match_id,
-                       s.bookmaker_id,
-                       b.name AS bookmaker_name,
-                       m.league_id,
+                        s.bookmaker_id,
+                        b.name AS bookmaker_name,
+                        m.league_id,
                        l.name AS league_name,
                        m.home_team,
                        m.away_team,
@@ -1912,11 +1951,14 @@ async def _get_event_review_case_variants_tx(
                        '[]' AS member_evidence
                 FROM matches m
                 LEFT JOIN leagues l ON l.id = m.league_id
-                LEFT JOIN match_bookmaker_sources s ON s.match_id = m.id
+                LEFT JOIN match_bookmaker_sources s
+                  ON s.match_id = m.id
+                 {source_snapshot_clause}
                 LEFT JOIN bookmakers b ON b.id = s.bookmaker_id
                 WHERE m.id IN ({placeholders})
-                ORDER BY m.start_time ASC, m.id ASC, s.bookmaker_id ASC""",
-            candidate_match_ids,
+                ORDER BY m.start_time ASC, m.id ASC, s.bookmaker_id ASC,
+                         s.id ASC""",
+            [*source_params, *candidate_match_ids],
         )
         for row in rows:
             key = (row["match_id"], row["bookmaker_id"])
@@ -2226,20 +2268,26 @@ async def merge_matches(
         )
         reassigned_outcome_offers = reassigned_outcome_cur.rowcount or 0
 
-        # 5. match_bookmaker_sources has UNIQUE(match_id, bookmaker_id), so it
-        #    needs the same dedupe-before-update treatment as odds.
+        # 5. match_bookmaker_sources is keyed by snapshot, match, and bookmaker,
+        #    so it needs the same dedupe-before-update treatment as odds.
         source_rows = await db.execute_fetchall(
             f"""
-            SELECT id, match_id, bookmaker_id, source_url
+            SELECT id, snapshot_id, match_id, bookmaker_id, source_url
             FROM match_bookmaker_sources
             WHERE match_id IN ({all_placeholders})
             """,
             all_match_ids,
         )
 
-        source_groups: dict[str, list[aiosqlite.Row]] = {}
+        source_groups: dict[tuple[str, str], list[aiosqlite.Row]] = {}
         for row in source_rows:
-            source_groups.setdefault(str(row["bookmaker_id"]), []).append(row)
+            source_groups.setdefault(
+                (
+                    str(row["snapshot_id"] or ""),
+                    str(row["bookmaker_id"]),
+                ),
+                [],
+            ).append(row)
 
         source_ids_to_delete: list[int] = []
         for grouped_rows in source_groups.values():
@@ -2463,7 +2511,7 @@ async def _get_normalized_odds_for_matches_snapshot(
                    COALESCE(sm.away_team_id, m.away_team_id, 0) AS away_team_id,
                    COALESCE(sm.home_team, m.home_team) AS home_team,
                    COALESCE(sm.away_team, m.away_team) AS away_team,
-                   s.source_url,
+                   s.source_url AS source_url,
                    o.market_type,
                    o.player_name,
                    o.threshold,
@@ -2475,7 +2523,9 @@ async def _get_normalized_odds_for_matches_snapshot(
             JOIN matches m ON m.id = o.match_id
             LEFT JOIN snapshot_matches sm ON sm.snapshot_id = ? AND sm.match_id = m.id
             LEFT JOIN match_bookmaker_sources s
-              ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id
+              ON s.match_id = o.match_id
+             AND s.bookmaker_id = o.bookmaker_id
+             AND COALESCE(s.snapshot_id, '') = COALESCE(o.snapshot_id, '')
             WHERE o.match_id IN ({placeholders})
               AND {snapshot_filter}
             ORDER BY COALESCE(sm.start_time, m.start_time) ASC, o.match_id ASC, o.bookmaker_id ASC,
@@ -2533,7 +2583,7 @@ async def _get_normalized_outcome_offers_for_matches_snapshot(
                    COALESCE(sm.away_team_id, m.away_team_id, 0) AS away_team_id,
                    COALESCE(sm.home_team, m.home_team) AS home_team,
                    COALESCE(sm.away_team, m.away_team) AS away_team,
-                   s.source_url,
+                   s.source_url AS source_url,
                    o.market_type,
                    o.outcome_code,
                    o.odds,
@@ -2545,7 +2595,9 @@ async def _get_normalized_outcome_offers_for_matches_snapshot(
             JOIN matches m ON m.id = o.match_id
             LEFT JOIN snapshot_matches sm ON sm.snapshot_id = ? AND sm.match_id = m.id
             LEFT JOIN match_bookmaker_sources s
-              ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id
+              ON s.match_id = o.match_id
+             AND s.bookmaker_id = o.bookmaker_id
+             AND COALESCE(s.snapshot_id, '') = COALESCE(o.snapshot_id, '')
             WHERE o.match_id IN ({placeholders})
               AND {snapshot_filter}
             ORDER BY COALESCE(sm.start_time, m.start_time) ASC, o.match_id ASC, o.bookmaker_id ASC,
@@ -2706,6 +2758,7 @@ async def upsert_odds(odds: NormalizedOdds, *, scraped_at: str) -> int:
     )
     await _upsert_match_bookmaker_source_tx(
         db,
+        snapshot_id=snapshot_id,
         match_id=odds.match_id,
         bookmaker_id=odds.bookmaker_id,
         source_url=odds.source_url,
@@ -2722,11 +2775,14 @@ async def get_odds_for_match(match_id: str) -> list[OddsOut]:
     if snapshot_filter is None:
         return []
     rows = await db.execute_fetchall(
-        f"""SELECT o.*, b.name as bookmaker_name, s.source_url as source_url
+        f"""SELECT o.*,
+                   b.name as bookmaker_name,
+                   s.source_url as source_url
             FROM odds o
             LEFT JOIN bookmakers b ON o.bookmaker_id = b.id
             LEFT JOIN match_bookmaker_sources s
-              ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id
+               ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id
+              AND COALESCE(s.snapshot_id, '') = COALESCE(o.snapshot_id, '')
             WHERE o.match_id = ? AND {snapshot_filter}
             ORDER BY o.market_type, o.player_name, o.threshold""",
         [match_id, *snapshot_params],
@@ -2736,10 +2792,22 @@ async def get_odds_for_match(match_id: str) -> list[OddsOut]:
 
 async def get_odds_history_for_match(match_id: str) -> list[OddsOut]:
     db = await get_db()
-    rows = await db.execute_fetchall(
-        "SELECT * FROM odds_history WHERE match_id = ? ORDER BY scraped_at DESC",
-        (match_id,),
-    )
+    if await _has_scrape_snapshots(db):
+        rows = await db.execute_fetchall(
+            """SELECT h.*
+               FROM odds_history h
+               JOIN scrape_snapshots ss
+                 ON ss.id = COALESCE(h.snapshot_id, h.scraped_at)
+                AND ss.status = 'published'
+               WHERE h.match_id = ?
+               ORDER BY h.scraped_at DESC""",
+            (match_id,),
+        )
+    else:
+        rows = await db.execute_fetchall(
+            "SELECT * FROM odds_history WHERE match_id = ? ORDER BY scraped_at DESC",
+            (match_id,),
+        )
     return [OddsOut(**_row_to_dict(r)) for r in rows]
 
 
@@ -2776,6 +2844,7 @@ async def upsert_outcome_offer(
     )
     await _upsert_match_bookmaker_source_tx(
         db,
+        snapshot_id=snapshot_id,
         match_id=offer.match_id,
         bookmaker_id=offer.bookmaker_id,
         source_url=offer.source_url,
@@ -2816,13 +2885,18 @@ async def get_outcome_offers(
     if snapshot_filter is None:
         return []
 
-    q = """SELECT o.*, b.name AS bookmaker_name, s.source_url AS source_url
+    q = """SELECT o.*,
+                  b.name AS bookmaker_name,
+                  s.source_url AS source_url
            FROM outcome_offers o
            JOIN matches m ON m.id = o.match_id
            LEFT JOIN snapshot_matches sm ON sm.snapshot_id = ? AND sm.match_id = m.id
            LEFT JOIN bookmakers b ON b.id = o.bookmaker_id
            LEFT JOIN match_bookmaker_sources s
-              ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id"""
+              ON s.match_id = o.match_id
+             AND s.bookmaker_id = o.bookmaker_id
+             AND COALESCE(s.snapshot_id, '') = COALESCE(o.snapshot_id, '')
+           """
     conditions = [snapshot_filter]
     params: list[object] = [current_snapshot_id, *snapshot_params]
 
@@ -3089,13 +3163,19 @@ async def get_opportunities(
     params.extend([limit, offset])
     rows = await db.execute_fetchall(q, params)
     opportunities = [_row_to_opportunity(row) for row in rows]
-    await _enrich_opportunity_legs(db, opportunities)
+    await _enrich_opportunity_legs(
+        db,
+        opportunities,
+        snapshot_id=current_snapshot_id,
+    )
     return opportunities
 
 
 async def _enrich_opportunity_legs(
     db: aiosqlite.Connection,
     opportunities: list[OpportunityOut],
+    *,
+    snapshot_id: str | None = None,
 ) -> None:
     bookmaker_ids = sorted(
         {
@@ -3133,18 +3213,35 @@ async def _enrich_opportunity_legs(
     source_urls: dict[tuple[str, str], str] = {}
     if match_ids:
         match_placeholders = _sql_placeholders(match_ids)
-        source_rows = await db.execute_fetchall(
-            f"""SELECT match_id, bookmaker_id, source_url
-                FROM match_bookmaker_sources
-                WHERE match_id IN ({match_placeholders})
-                  AND bookmaker_id IN ({bookmaker_placeholders})""",
-            [*match_ids, *bookmaker_ids],
-        )
-        source_urls = {
-            (row["match_id"], row["bookmaker_id"]): row["source_url"]
-            for row in source_rows
-            if row["source_url"] is not None
-        }
+        if snapshot_id is not None:
+            source_rows = await db.execute_fetchall(
+                f"""SELECT match_id, bookmaker_id, source_url
+                    FROM match_bookmaker_sources
+                    WHERE match_id IN ({match_placeholders})
+                      AND bookmaker_id IN ({bookmaker_placeholders})
+                      AND snapshot_id = ?
+                    ORDER BY id ASC""",
+                [*match_ids, *bookmaker_ids, snapshot_id],
+            )
+        elif not await _has_scrape_snapshots(db):
+            source_rows = await db.execute_fetchall(
+                f"""SELECT match_id, bookmaker_id, source_url
+                    FROM match_bookmaker_sources
+                    WHERE match_id IN ({match_placeholders})
+                      AND bookmaker_id IN ({bookmaker_placeholders})
+                      AND snapshot_id IS NULL
+                    ORDER BY id ASC""",
+                [*match_ids, *bookmaker_ids],
+            )
+        else:
+            source_rows = []
+        for row in source_rows:
+            if row["source_url"] is None:
+                continue
+            source_urls.setdefault(
+                (row["match_id"], row["bookmaker_id"]),
+                row["source_url"],
+            )
 
     for opportunity in opportunities:
         for leg in opportunity.legs:
@@ -3540,6 +3637,12 @@ async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
                   OR snapshot_id != ?""",
             (preserved_snapshot_id,),
         )
+        deleted_match_sources_cur = await db.execute(
+            """DELETE FROM match_bookmaker_sources
+               WHERE snapshot_id IS NOT NULL
+                 AND snapshot_id != ?""",
+            (preserved_snapshot_id,),
+        )
         deleted_resolved_event_members_cur = await db.execute(
             """DELETE FROM resolved_event_members
                WHERE snapshot_id IS NOT NULL
@@ -3564,10 +3667,6 @@ async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
             deleted_opportunity_publishes_cur = await db.execute(
                 "DELETE FROM opportunity_publishes"
             )
-        deleted_scrape_snapshots_cur = await db.execute(
-            "DELETE FROM scrape_snapshots WHERE id != ?",
-            (preserved_snapshot_id,),
-        )
         if settings.odds_history_retention_days > 0:
             odds_history_cutoff = _retention_cutoff(
                 retention_anchor_at, settings.odds_history_retention_days
@@ -3591,6 +3690,16 @@ async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
                       OR COALESCE(snapshot_id, scraped_at) != ?""",
                 (preserved_snapshot_id,),
             )
+        deleted_scrape_snapshots_cur = await db.execute(
+            """DELETE FROM scrape_snapshots
+               WHERE id != ?
+                 AND NOT EXISTS (
+                     SELECT 1
+                     FROM odds_history h
+                     WHERE COALESCE(h.snapshot_id, h.scraped_at) = scrape_snapshots.id
+                 )""",
+            (preserved_snapshot_id,),
+        )
 
         if settings.team_review_retention_days > 0:
             team_review_cutoff = _retention_cutoff(
@@ -3643,6 +3752,7 @@ async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
         "deleted_stale_resolved_event_members": (
             deleted_resolved_event_members_cur.rowcount or 0
         ),
+        "deleted_stale_match_bookmaker_sources": deleted_match_sources_cur.rowcount or 0,
         "deleted_stale_opportunities": deleted_opportunities_cur.rowcount or 0,
         "deleted_stale_opportunity_publishes": (
             deleted_opportunity_publishes_cur.rowcount or 0
@@ -3683,31 +3793,36 @@ async def get_system_status(
         odds_count = odds_row[0][0]
         last_scrape_at = current_snapshot_at or current_snapshot_id
     else:
-        legacy_window = await _get_legacy_snapshot_cutoff(db)
-        if legacy_window is None:
+        if await _has_scrape_snapshots(db):
             matches_count = 0
             odds_count = 0
             last_scrape_at = None
         else:
-            last_scrape_at, cutoff_at = legacy_window
-            matches_row = await db.execute_fetchall(
-                """SELECT COUNT(DISTINCT match_id) as c
-                   FROM (
-                       SELECT match_id FROM odds WHERE scraped_at >= ?
-                       UNION
-                       SELECT match_id FROM outcome_offers WHERE scraped_at >= ?
-                   )""",
-                (cutoff_at, cutoff_at),
-            )
-            odds_row = await db.execute_fetchall(
-                """SELECT (
-                       (SELECT COUNT(*) FROM odds WHERE scraped_at >= ?)
-                       + (SELECT COUNT(*) FROM outcome_offers WHERE scraped_at >= ?)
-                   ) as c""",
-                (cutoff_at, cutoff_at),
-            )
-            matches_count = matches_row[0][0]
-            odds_count = odds_row[0][0]
+            legacy_window = await _get_legacy_snapshot_cutoff(db)
+            if legacy_window is None:
+                matches_count = 0
+                odds_count = 0
+                last_scrape_at = None
+            else:
+                last_scrape_at, cutoff_at = legacy_window
+                matches_row = await db.execute_fetchall(
+                    """SELECT COUNT(DISTINCT match_id) as c
+                       FROM (
+                           SELECT match_id FROM odds WHERE scraped_at >= ?
+                           UNION
+                           SELECT match_id FROM outcome_offers WHERE scraped_at >= ?
+                       )""",
+                    (cutoff_at, cutoff_at),
+                )
+                odds_row = await db.execute_fetchall(
+                    """SELECT (
+                           (SELECT COUNT(*) FROM odds WHERE scraped_at >= ?)
+                           + (SELECT COUNT(*) FROM outcome_offers WHERE scraped_at >= ?)
+                       ) as c""",
+                    (cutoff_at, cutoff_at),
+                )
+                matches_count = matches_row[0][0]
+                odds_count = odds_row[0][0]
     current_publish_id = await _get_current_opportunity_publish_id(db)
     if current_publish_id is not None:
         opportunity_row = await db.execute_fetchall(

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -44,6 +44,7 @@ from ..services.canonical_offers import (
     canonical_offers_from_normalized_odds,
 )
 from ..services.event_player_resolver import build_event_scoped_player_odds
+from ..services.league_registry import league_country, league_display_name
 
 
 def _row_to_dict(row: aiosqlite.Row) -> dict:
@@ -244,22 +245,125 @@ async def get_leagues(sport: str | None = None) -> list[LeagueOut]:
 # ── Snapshot state ──────────────────────────────────────────
 
 
+def _snapshot_id_from_scraped_at(snapshot_at: str) -> str:
+    return snapshot_at
+
+
+def _new_opportunity_publish_id(detected_at: str) -> str:
+    return f"{detected_at}:{uuid.uuid4().hex[:8]}"
+
+
+async def _upsert_scrape_snapshot_tx(
+    db: aiosqlite.Connection,
+    *,
+    snapshot_id: str,
+    scraped_at: str,
+    status: str = "persisted",
+    matches_count: int = 0,
+    odds_count: int = 0,
+    outcome_offers_count: int = 0,
+    unresolved_odds_count: int = 0,
+    team_review_cases_count: int = 0,
+    error: str | None = None,
+) -> None:
+    await db.execute(
+        """INSERT INTO scrape_snapshots (
+               id,
+               scraped_at,
+               completed_at,
+               status,
+               matches_count,
+               odds_count,
+               outcome_offers_count,
+               unresolved_odds_count,
+               team_review_cases_count,
+               error
+           )
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+               scraped_at = excluded.scraped_at,
+               completed_at = excluded.completed_at,
+               status = excluded.status,
+               matches_count = excluded.matches_count,
+               odds_count = excluded.odds_count,
+               outcome_offers_count = excluded.outcome_offers_count,
+               unresolved_odds_count = excluded.unresolved_odds_count,
+               team_review_cases_count = excluded.team_review_cases_count,
+               error = excluded.error,
+               updated_at = CURRENT_TIMESTAMP""",
+        (
+            snapshot_id,
+            scraped_at,
+            scraped_at if status in {"persisted", "published"} else None,
+            status,
+            matches_count,
+            odds_count,
+            outcome_offers_count,
+            unresolved_odds_count,
+            team_review_cases_count,
+            error,
+        ),
+    )
+
+
 async def set_current_snapshot(snapshot_at: str) -> None:
     db = await get_db()
+    snapshot_id = _snapshot_id_from_scraped_at(snapshot_at)
+    await _upsert_scrape_snapshot_tx(
+        db,
+        snapshot_id=snapshot_id,
+        scraped_at=snapshot_at,
+        status="published",
+    )
     await db.execute(
-        """INSERT INTO scrape_state (id, current_snapshot_at, updated_at)
-           VALUES (1, ?, CURRENT_TIMESTAMP)
+        """INSERT INTO scrape_state (
+               id,
+               current_snapshot_id,
+               current_snapshot_at,
+               updated_at
+           )
+           VALUES (1, ?, ?, CURRENT_TIMESTAMP)
            ON CONFLICT(id) DO UPDATE SET
+               current_snapshot_id = excluded.current_snapshot_id,
                current_snapshot_at = excluded.current_snapshot_at,
                updated_at = CURRENT_TIMESTAMP""",
-        (snapshot_at,),
+        (snapshot_id, snapshot_at),
     )
     await db.commit()
 
 
-async def _get_current_snapshot_at(db: aiosqlite.Connection) -> str | None:
+async def _get_current_snapshot(
+    db: aiosqlite.Connection,
+) -> tuple[str | None, str | None]:
     row = await db.execute_fetchall(
-        "SELECT current_snapshot_at FROM scrape_state WHERE id = 1"
+        "SELECT current_snapshot_id, current_snapshot_at FROM scrape_state WHERE id = 1"
+    )
+    if not row:
+        return None, None
+    snapshot_id = row[0]["current_snapshot_id"]
+    snapshot_at = row[0]["current_snapshot_at"]
+    if snapshot_id:
+        return snapshot_id, snapshot_at or snapshot_id
+    if snapshot_at:
+        return _snapshot_id_from_scraped_at(snapshot_at), snapshot_at
+    return None, None
+
+
+async def _get_current_snapshot_id(db: aiosqlite.Connection) -> str | None:
+    snapshot_id, _ = await _get_current_snapshot(db)
+    return snapshot_id
+
+
+async def _get_current_snapshot_at(db: aiosqlite.Connection) -> str | None:
+    _, snapshot_at = await _get_current_snapshot(db)
+    return snapshot_at
+
+
+async def _get_current_opportunity_publish_id(
+    db: aiosqlite.Connection,
+) -> str | None:
+    row = await db.execute_fetchall(
+        "SELECT current_opportunity_publish_id FROM scrape_state WHERE id = 1"
     )
     if not row or not row[0][0]:
         return None
@@ -267,7 +371,14 @@ async def _get_current_snapshot_at(db: aiosqlite.Connection) -> str | None:
 
 
 async def _get_legacy_snapshot_cutoff(db: aiosqlite.Connection) -> tuple[str, str] | None:
-    row = await db.execute_fetchall("SELECT MAX(scraped_at) AS t FROM odds")
+    row = await db.execute_fetchall(
+        """SELECT MAX(t) AS t
+           FROM (
+               SELECT MAX(scraped_at) AS t FROM odds
+               UNION ALL
+               SELECT MAX(scraped_at) AS t FROM outcome_offers
+           )"""
+    )
     if not row or not row[0][0]:
         return None
 
@@ -302,7 +413,16 @@ async def _get_team_review_snapshot_at(db: aiosqlite.Connection) -> str | None:
 async def _current_or_legacy_snapshot_filter(
     db: aiosqlite.Connection,
     alias: str,
+    *,
+    snapshot_id: str | None = None,
 ) -> tuple[str | None, list[object]]:
+    if snapshot_id is not None:
+        return f"{alias}.snapshot_id = ?", [snapshot_id]
+
+    current_snapshot_id = await _get_current_snapshot_id(db)
+    if current_snapshot_id is not None:
+        return f"{alias}.snapshot_id = ?", [current_snapshot_id]
+
     current_snapshot_at = await _get_current_snapshot_at(db)
     if current_snapshot_at is not None:
         return f"{alias}.scraped_at = ?", [current_snapshot_at]
@@ -391,6 +511,329 @@ async def upsert_match_bookmaker_source(
     await db.commit()
 
 
+def _match_row_from_offer_row(row: NormalizedOdds | NormalizedOutcomeOffer) -> tuple:
+    normalized_home_team_id = row.home_team_id if row.home_team_id and row.home_team_id > 0 else None
+    normalized_away_team_id = row.away_team_id if row.away_team_id and row.away_team_id > 0 else None
+    return (
+        row.match_id,
+        row.league_id,
+        row.sport,
+        normalized_home_team_id,
+        normalized_away_team_id,
+        row.home_team,
+        row.away_team,
+        row.start_time,
+        "upcoming",
+    )
+
+
+def _team_review_values(
+    case: TeamReviewDiagnostic,
+    *,
+    snapshot_id: str,
+    scraped_at: str,
+) -> tuple:
+    return (
+        snapshot_id,
+        case.bookmaker_id,
+        case.raw_league_id,
+        case.normalized_raw_league_id,
+        case.sport,
+        case.scope_league_id,
+        case.raw_team_name,
+        case.normalized_raw_team_name,
+        case.suggested_team_id,
+        case.suggested_team_name,
+        case.start_time,
+        case.review_kind,
+        case.reason_code,
+        case.confidence,
+        case.similarity_score,
+        json.dumps([candidate.model_dump() for candidate in case.candidate_teams]),
+        case.matched_counterpart_team,
+        case.canonical_home_team,
+        case.canonical_away_team,
+        json.dumps(case.evidence),
+        case.status,
+        scraped_at,
+    )
+
+
+async def persist_scrape_snapshot_batch(
+    *,
+    snapshot_at: str,
+    odds: list[NormalizedOdds],
+    outcome_offers: list[NormalizedOutcomeOffer],
+    unresolved_odds: list[UnresolvedOddsDiagnostic],
+    team_review_cases: list[TeamReviewDiagnostic],
+    auto_approved_team_reviews: list[TeamReviewDiagnostic] | None = None,
+) -> dict[str, object]:
+    snapshot_id = _snapshot_id_from_scraped_at(snapshot_at)
+    auto_approved_team_reviews = auto_approved_team_reviews or []
+    rows: list[NormalizedOdds | NormalizedOutcomeOffer] = [*odds, *outcome_offers]
+    seen_match_rows = {row.match_id: row for row in rows}
+    league_ids = sorted({row.league_id for row in rows})
+
+    db = await get_db()
+    auto_approved_case_ids: list[int] = []
+    try:
+        await db.execute("BEGIN IMMEDIATE")
+        await _upsert_scrape_snapshot_tx(
+            db,
+            snapshot_id=snapshot_id,
+            scraped_at=snapshot_at,
+            status="persisting",
+            matches_count=len(seen_match_rows),
+            odds_count=len(odds),
+            outcome_offers_count=len(outcome_offers),
+            unresolved_odds_count=len(unresolved_odds),
+            team_review_cases_count=len(team_review_cases)
+            + len(auto_approved_team_reviews),
+        )
+        await db.executemany(
+            "INSERT OR REPLACE INTO leagues (id, name, sport, country) VALUES (?, ?, ?, ?)",
+            [
+                (
+                    league_id,
+                    league_display_name(league_id),
+                    next(row.sport for row in rows if row.league_id == league_id),
+                    league_country(league_id),
+                )
+                for league_id in league_ids
+            ],
+        )
+        await db.executemany(
+            """INSERT OR REPLACE INTO matches (
+                   id,
+                   league_id,
+                   sport,
+                   home_team_id,
+                   away_team_id,
+                   home_team,
+                   away_team,
+                   start_time,
+                   status
+               )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [_match_row_from_offer_row(row) for row in seen_match_rows.values()],
+        )
+        await db.executemany(
+            """INSERT OR REPLACE INTO snapshot_matches (
+                   snapshot_id,
+                   match_id,
+                   league_id,
+                   sport,
+                   home_team_id,
+                   away_team_id,
+                   home_team,
+                   away_team,
+                   start_time,
+                   status
+               )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                (
+                    snapshot_id,
+                    *_match_row_from_offer_row(row),
+                )
+                for row in seen_match_rows.values()
+            ],
+        )
+        source_rows = [
+            (row.match_id, row.bookmaker_id, row.source_url)
+            for row in rows
+            if row.source_url is not None
+        ]
+        await db.executemany(
+            """INSERT INTO match_bookmaker_sources (match_id, bookmaker_id, source_url)
+               VALUES (?, ?, ?)
+               ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
+                    source_url = COALESCE(excluded.source_url, match_bookmaker_sources.source_url),
+                    updated_at = CURRENT_TIMESTAMP""",
+            source_rows,
+        )
+        await db.executemany(
+            """INSERT OR REPLACE INTO odds
+               (snapshot_id, match_id, bookmaker_id, market_type, player_name, threshold,
+                over_odds, under_odds, scraped_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                (
+                    snapshot_id,
+                    item.match_id,
+                    item.bookmaker_id,
+                    item.market_type,
+                    item.player_name,
+                    item.threshold,
+                    item.over_odds,
+                    item.under_odds,
+                    snapshot_at,
+                )
+                for item in odds
+            ],
+        )
+        await db.executemany(
+            """INSERT INTO odds_history
+               (snapshot_id, match_id, bookmaker_id, market_type, player_name, threshold,
+                over_odds, under_odds, scraped_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                (
+                    snapshot_id,
+                    item.match_id,
+                    item.bookmaker_id,
+                    item.market_type,
+                    item.player_name,
+                    item.threshold,
+                    item.over_odds,
+                    item.under_odds,
+                    snapshot_at,
+                )
+                for item in odds
+            ],
+        )
+        await db.executemany(
+            """INSERT OR REPLACE INTO outcome_offers
+               (snapshot_id, match_id, bookmaker_id, market_type, outcome_code, line,
+                odds, raw_label, scraped_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                (
+                    snapshot_id,
+                    item.match_id,
+                    item.bookmaker_id,
+                    item.market_type,
+                    item.outcome_code,
+                    item.line,
+                    item.odds,
+                    item.raw_label,
+                    snapshot_at,
+                )
+                for item in outcome_offers
+            ],
+        )
+        await db.executemany(
+            """INSERT INTO unresolved_odds
+               (snapshot_id, bookmaker_id, raw_league_id, league_id, sport, market_type,
+                player_name, raw_team_name, normalized_team_name, start_time, threshold,
+                over_odds, under_odds, reason_code, candidate_count, candidate_matchups,
+                available_matchups_same_slot, scraped_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                (
+                    snapshot_id,
+                    item.bookmaker_id,
+                    item.raw_league_id,
+                    item.league_id,
+                    item.sport,
+                    item.market_type,
+                    item.player_name,
+                    item.raw_team_name,
+                    item.normalized_team_name,
+                    item.start_time,
+                    item.threshold,
+                    item.over_odds,
+                    item.under_odds,
+                    item.reason_code,
+                    item.candidate_count,
+                    json.dumps(item.candidate_matchups),
+                    json.dumps(item.available_matchups_same_slot),
+                    snapshot_at,
+                )
+                for item in unresolved_odds
+            ],
+        )
+        team_review_sql = """INSERT INTO team_review_cases
+               (snapshot_id, bookmaker_id, raw_league_id, normalized_raw_league_id, sport,
+                scope_league_id, raw_team_name, normalized_raw_team_name, suggested_team_id,
+                suggested_team_name, start_time, review_kind, reason_code, confidence,
+                similarity_score, candidate_teams, matched_counterpart_team,
+                canonical_home_team, canonical_away_team, evidence, status, scraped_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+        await db.executemany(
+            team_review_sql,
+            [
+                _team_review_values(item, snapshot_id=snapshot_id, scraped_at=snapshot_at)
+                for item in team_review_cases
+            ],
+        )
+        for item in auto_approved_team_reviews:
+            cursor = await db.execute(
+                team_review_sql,
+                _team_review_values(item, snapshot_id=snapshot_id, scraped_at=snapshot_at),
+            )
+            case_id = cursor.lastrowid or 0
+            auto_approved_case_ids.append(case_id)
+            await db.execute(
+                """UPDATE team_review_cases
+                   SET status = 'approved',
+                       approved_at = COALESCE(approved_at, CURRENT_TIMESTAMP)
+                   WHERE id = ?""",
+                (case_id,),
+            )
+        await _upsert_scrape_snapshot_tx(
+            db,
+            snapshot_id=snapshot_id,
+            scraped_at=snapshot_at,
+            status="persisted",
+            matches_count=len(seen_match_rows),
+            odds_count=len(odds),
+            outcome_offers_count=len(outcome_offers),
+            unresolved_odds_count=len(unresolved_odds),
+            team_review_cases_count=len(team_review_cases)
+            + len(auto_approved_team_reviews),
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    return {
+        "snapshot_id": snapshot_id,
+        "snapshot_at": snapshot_at,
+        "seen_match_ids": set(seen_match_rows),
+        "auto_approved_team_review_case_ids": auto_approved_case_ids,
+        "matches_count": len(seen_match_rows),
+        "odds_count": len(odds),
+        "outcome_offers_count": len(outcome_offers),
+        "unresolved_odds_count": len(unresolved_odds),
+        "team_review_cases_count": len(team_review_cases)
+        + len(auto_approved_team_reviews),
+    }
+
+
+async def publish_scrape_snapshot(*, snapshot_id: str, snapshot_at: str) -> None:
+    db = await get_db()
+    try:
+        await db.execute("BEGIN IMMEDIATE")
+        await db.execute(
+            """UPDATE scrape_snapshots
+               SET status = 'published',
+                   completed_at = ?,
+                   updated_at = CURRENT_TIMESTAMP
+               WHERE id = ?""",
+            (snapshot_at, snapshot_id),
+        )
+        await db.execute(
+            """INSERT INTO scrape_state (
+                   id,
+                   current_snapshot_id,
+                   current_snapshot_at,
+                   updated_at
+               )
+               VALUES (1, ?, ?, CURRENT_TIMESTAMP)
+               ON CONFLICT(id) DO UPDATE SET
+                   current_snapshot_id = excluded.current_snapshot_id,
+                   current_snapshot_at = excluded.current_snapshot_at,
+                   updated_at = CURRENT_TIMESTAMP""",
+            (snapshot_id, snapshot_at),
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+
 async def get_matches(
     league_id: str | None = None,
     sport: str | None = None,
@@ -400,32 +843,66 @@ async def get_matches(
     offset: int = 0,
 ) -> list[MatchOut]:
     db = await get_db()
-    current_snapshot_at = await _get_current_snapshot_at(db)
-    snapshot_at: str | None = current_snapshot_at
+    current_snapshot_id = await _get_current_snapshot_id(db)
+    snapshot_at: str | None = await _get_current_snapshot_at(db)
     cutoff_at: str | None = None
     bookmaker_filter = ""
     if bookmaker_ids:
         bookmaker_filter = f" AND {{alias}}.bookmaker_id IN ({_sql_placeholders(bookmaker_ids)})"
 
-    if current_snapshot_at is not None:
-        odds_filter = "o.scraped_at = ?" + bookmaker_filter.format(alias="o")
-        offers_filter = "oo.scraped_at = ?" + bookmaker_filter.format(alias="oo")
-        params: list[object] = [current_snapshot_at]
+    if current_snapshot_id is not None:
+        odds_filter = "o.snapshot_id = ?" + bookmaker_filter.format(alias="o")
+        offers_filter = "oo.snapshot_id = ?" + bookmaker_filter.format(alias="oo")
+        params: list[object] = [
+            current_snapshot_id,
+            current_snapshot_id,
+            current_snapshot_id,
+            current_snapshot_id,
+        ]
         if bookmaker_ids:
             params.extend(bookmaker_ids)
-        params.append(current_snapshot_at)
+        params.append(current_snapshot_id)
         if bookmaker_ids:
             params.extend(bookmaker_ids)
-        q = f"""SELECT m.*, l.name as league_name,
-                      (
-                          SELECT rem.resolved_event_id
-                          FROM resolved_event_members rem
-                          WHERE rem.match_id = m.id AND rem.status = 'active'
-                          ORDER BY rem.resolved_event_id ASC
-                          LIMIT 1
-                      ) AS resolved_event_id
+        q = f"""SELECT m.id,
+                       COALESCE(sm.league_id, m.league_id) AS league_id,
+                       l.name as league_name,
+                       COALESCE(sm.sport, m.sport) AS sport,
+                       COALESCE(sm.home_team_id, m.home_team_id) AS home_team_id,
+                       COALESCE(sm.away_team_id, m.away_team_id) AS away_team_id,
+                       COALESCE(sm.home_team, m.home_team) AS home_team,
+                       COALESCE(sm.away_team, m.away_team) AS away_team,
+                       COALESCE(sm.start_time, m.start_time) AS start_time,
+                       COALESCE(sm.status, m.status) AS status,
+                        (
+                            SELECT rem.resolved_event_id
+                            FROM resolved_event_members rem
+                           WHERE rem.match_id = m.id
+                             AND rem.status = 'active'
+                             AND (
+                                 rem.snapshot_id = ?
+                                 OR rem.snapshot_id IS NULL
+                             )
+                           ORDER BY CASE
+                               WHEN EXISTS (
+                                   SELECT 1
+                                   FROM resolved_events re
+                                   WHERE re.id = rem.resolved_event_id
+                                     AND re.method IN ('manual', 'manual_review')
+                               ) THEN 0
+                               ELSE 1
+                           END,
+                           CASE
+                               WHEN rem.snapshot_id = ? THEN 0
+                               ELSE 1
+                           END,
+                           rem.resolved_event_id ASC
+                           LIMIT 1
+                       ) AS resolved_event_id
                FROM matches m
-               LEFT JOIN leagues l ON m.league_id = l.id
+               LEFT JOIN snapshot_matches sm
+                 ON sm.snapshot_id = ? AND sm.match_id = m.id
+               LEFT JOIN leagues l ON COALESCE(sm.league_id, m.league_id) = l.id
                WHERE m.id IN (
                    SELECT o.match_id
                    FROM odds o
@@ -451,11 +928,13 @@ async def get_matches(
             params.extend(bookmaker_ids)
         q = f"""SELECT m.*, l.name as league_name,
                       (
-                          SELECT rem.resolved_event_id
-                          FROM resolved_event_members rem
-                          WHERE rem.match_id = m.id AND rem.status = 'active'
-                          ORDER BY rem.resolved_event_id ASC
-                          LIMIT 1
+                           SELECT rem.resolved_event_id
+                           FROM resolved_event_members rem
+                           WHERE rem.match_id = m.id
+                             AND rem.status = 'active'
+                             AND rem.snapshot_id IS NULL
+                           ORDER BY rem.resolved_event_id ASC
+                           LIMIT 1
                       ) AS resolved_event_id
                FROM matches m
                LEFT JOIN leagues l ON m.league_id = l.id
@@ -469,15 +948,27 @@ async def get_matches(
                    WHERE {offers_filter}
                )"""
     if league_id:
-        q += " AND m.league_id = ?"
+        if current_snapshot_id is not None:
+            q += " AND COALESCE(sm.league_id, m.league_id) = ?"
+        else:
+            q += " AND m.league_id = ?"
         params.append(league_id)
     if sport:
-        q += " AND m.sport = ?"
+        if current_snapshot_id is not None:
+            q += " AND COALESCE(sm.sport, m.sport) = ?"
+        else:
+            q += " AND m.sport = ?"
         params.append(sport)
     if status:
-        q += " AND m.status = ?"
+        if current_snapshot_id is not None:
+            q += " AND COALESCE(sm.status, m.status) = ?"
+        else:
+            q += " AND m.status = ?"
         params.append(status)
-    q += " ORDER BY m.start_time ASC LIMIT ? OFFSET ?"
+    if current_snapshot_id is not None:
+        q += " ORDER BY COALESCE(sm.start_time, m.start_time) ASC LIMIT ? OFFSET ?"
+    else:
+        q += " ORDER BY m.start_time ASC LIMIT ? OFFSET ?"
     params.extend([limit, offset])
     rows = await db.execute_fetchall(q, params)
 
@@ -485,6 +976,7 @@ async def get_matches(
     bookmaker_map = await _get_match_bookmaker_map(
         db,
         [row["id"] for row in match_rows],
+        snapshot_id=current_snapshot_id,
         snapshot_at=snapshot_at,
         cutoff_at=cutoff_at,
     )
@@ -495,22 +987,94 @@ async def get_matches(
     return [MatchOut(**row) for row in match_rows]
 
 
-async def get_match(match_id: str) -> MatchOut | None:
+async def get_match(
+    match_id: str,
+    *,
+    require_current_snapshot: bool = False,
+) -> MatchOut | None:
     db = await get_db()
-    row = await db.execute_fetchall(
-        """SELECT m.*, l.name as league_name,
-                  (
-                      SELECT rem.resolved_event_id
-                      FROM resolved_event_members rem
-                      WHERE rem.match_id = m.id AND rem.status = 'active'
-                      ORDER BY rem.resolved_event_id ASC
-                      LIMIT 1
-                  ) AS resolved_event_id
-           FROM matches m
-           LEFT JOIN leagues l ON m.league_id = l.id
-           WHERE m.id = ?""",
-        (match_id,),
-    )
+    current_snapshot_id = await _get_current_snapshot_id(db)
+    if current_snapshot_id is not None:
+        visibility_clause = ""
+        params: list[object] = [
+            current_snapshot_id,
+            current_snapshot_id,
+            current_snapshot_id,
+            match_id,
+        ]
+        if require_current_snapshot:
+            visibility_clause = """
+                 AND (
+                     EXISTS (
+                         SELECT 1 FROM odds o
+                         WHERE o.snapshot_id = ? AND o.match_id = m.id
+                     )
+                     OR EXISTS (
+                         SELECT 1 FROM outcome_offers oo
+                         WHERE oo.snapshot_id = ? AND oo.match_id = m.id
+                     )
+                 )"""
+            params.extend([current_snapshot_id, current_snapshot_id])
+        row = await db.execute_fetchall(
+            f"""SELECT m.id,
+                      COALESCE(sm.league_id, m.league_id) AS league_id,
+                      l.name as league_name,
+                      COALESCE(sm.sport, m.sport) AS sport,
+                      COALESCE(sm.home_team_id, m.home_team_id) AS home_team_id,
+                      COALESCE(sm.away_team_id, m.away_team_id) AS away_team_id,
+                      COALESCE(sm.home_team, m.home_team) AS home_team,
+                      COALESCE(sm.away_team, m.away_team) AS away_team,
+                      COALESCE(sm.start_time, m.start_time) AS start_time,
+                      COALESCE(sm.status, m.status) AS status,
+                      (
+                          SELECT rem.resolved_event_id
+                          FROM resolved_event_members rem
+                          WHERE rem.match_id = m.id
+                            AND rem.status = 'active'
+                            AND (
+                                rem.snapshot_id = ?
+                                OR rem.snapshot_id IS NULL
+                            )
+                          ORDER BY CASE
+                              WHEN EXISTS (
+                                  SELECT 1
+                                  FROM resolved_events re
+                                  WHERE re.id = rem.resolved_event_id
+                                    AND re.method IN ('manual', 'manual_review')
+                              ) THEN 0
+                              ELSE 1
+                          END,
+                          CASE
+                              WHEN rem.snapshot_id = ? THEN 0
+                              ELSE 1
+                          END,
+                          rem.resolved_event_id ASC
+                          LIMIT 1
+                      ) AS resolved_event_id
+               FROM matches m
+               LEFT JOIN snapshot_matches sm
+                 ON sm.snapshot_id = ? AND sm.match_id = m.id
+               LEFT JOIN leagues l ON COALESCE(sm.league_id, m.league_id) = l.id
+               WHERE m.id = ?{visibility_clause}""",
+            params,
+        )
+    else:
+        row = await db.execute_fetchall(
+            """SELECT m.*, l.name as league_name,
+                      (
+                          SELECT rem.resolved_event_id
+                          FROM resolved_event_members rem
+                          WHERE rem.match_id = m.id
+                            AND rem.status = 'active'
+                            AND rem.snapshot_id IS NULL
+                          ORDER BY rem.resolved_event_id ASC
+                          LIMIT 1
+                      ) AS resolved_event_id
+               FROM matches m
+               LEFT JOIN leagues l ON m.league_id = l.id
+               WHERE m.id = ?""",
+            (match_id,),
+        )
     if not row:
         return None
     return MatchOut(**_row_to_dict(row[0]))
@@ -572,6 +1136,7 @@ async def link_resolved_event_member(member: ResolvedEventMemberIn) -> int:
     try:
         await db.execute(
             """INSERT INTO resolved_event_members (
+                   snapshot_id,
                    resolved_event_id,
                    match_id,
                    bookmaker_id,
@@ -586,11 +1151,15 @@ async def link_resolved_event_member(member: ResolvedEventMemberIn) -> int:
                    source_start_time,
                    evidence,
                    metadata
-               )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
-                    resolved_event_id = excluded.resolved_event_id,
-                    orientation = excluded.orientation,
+                )
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(
+                     COALESCE(snapshot_id, ''),
+                     match_id,
+                     bookmaker_id
+                 ) DO UPDATE SET
+                     resolved_event_id = excluded.resolved_event_id,
+                     orientation = excluded.orientation,
                     confidence = excluded.confidence,
                    status = excluded.status,
                    source_url = COALESCE(excluded.source_url, resolved_event_members.source_url),
@@ -633,6 +1202,7 @@ async def link_resolved_event_member(member: ResolvedEventMemberIn) -> int:
                     )
                 )""",
             (
+                member.snapshot_id,
                 member.resolved_event_id,
                 member.match_id,
                 member.bookmaker_id,
@@ -658,8 +1228,10 @@ async def link_resolved_event_member(member: ResolvedEventMemberIn) -> int:
         rows = await db.execute_fetchall(
             """SELECT id
                FROM resolved_event_members
-               WHERE match_id = ? AND bookmaker_id = ?""",
-            (member.match_id, member.bookmaker_id),
+               WHERE COALESCE(snapshot_id, '') = COALESCE(?, '')
+                 AND match_id = ?
+                 AND bookmaker_id = ?""",
+            (member.snapshot_id, member.match_id, member.bookmaker_id),
         )
         await db.commit()
     except Exception:
@@ -672,8 +1244,12 @@ async def get_resolved_event_members(
     resolved_event_id: str,
     *,
     status: str | None = None,
+    snapshot_id: str | None = None,
 ) -> list[ResolvedEventMemberOut]:
     db = await get_db()
+    effective_snapshot_id = (
+        snapshot_id if snapshot_id is not None else await _get_current_snapshot_id(db)
+    )
     q = """SELECT m.*, b.name AS bookmaker_name
            FROM resolved_event_members m
            LEFT JOIN bookmakers b ON b.id = m.bookmaker_id
@@ -682,15 +1258,35 @@ async def get_resolved_event_members(
     if status:
         q += " AND m.status = ?"
         params.append(status)
-    q += " ORDER BY m.id ASC"
+    order_params: list[object] = []
+    if effective_snapshot_id is not None:
+        q += " AND (m.snapshot_id = ? OR m.snapshot_id IS NULL)"
+        params.append(effective_snapshot_id)
+        snapshot_order = "CASE WHEN m.snapshot_id = ? THEN 0 ELSE 1 END, "
+        order_params.append(effective_snapshot_id)
+    else:
+        q += " AND m.snapshot_id IS NULL"
+        snapshot_order = ""
+    q += f" ORDER BY {snapshot_order}m.id ASC"
+    params.extend(order_params)
     rows = await db.execute_fetchall(q, params)
-    return [_row_to_resolved_event_member(row) for row in rows]
+    members: list[ResolvedEventMemberOut] = []
+    seen_keys: set[tuple[str, str]] = set()
+    for row in rows:
+        member = _row_to_resolved_event_member(row)
+        key = (member.match_id, member.bookmaker_id)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        members.append(member)
+    return members
 
 
 async def get_eligible_resolved_event_members_for_matches(
     match_ids: list[str],
     *,
     bookmaker_ids: list[str] | None = None,
+    snapshot_id: str | None = None,
     event_methods: tuple[str, ...] = (
         "exact",
         "auto_fuzzy_high",
@@ -702,9 +1298,12 @@ async def get_eligible_resolved_event_members_for_matches(
         return []
 
     db = await get_db()
+    effective_snapshot_id = (
+        snapshot_id if snapshot_id is not None else await _get_current_snapshot_id(db)
+    )
     match_placeholders = _sql_placeholders(match_ids)
     method_placeholders = _sql_placeholders(list(event_methods))
-    q = f"""SELECT rem.*, b.name AS bookmaker_name
+    q = f"""SELECT rem.*, b.name AS bookmaker_name, re.method AS event_method
             FROM resolved_event_members rem
             JOIN resolved_events re ON re.id = rem.resolved_event_id
             LEFT JOIN bookmakers b ON b.id = rem.bookmaker_id
@@ -719,14 +1318,46 @@ async def get_eligible_resolved_event_members_for_matches(
         q += f" AND rem.bookmaker_id IN ({bookmaker_placeholders})"
         params.extend(bookmaker_ids)
 
-    q += " ORDER BY re.start_time ASC, rem.resolved_event_id ASC, rem.id ASC"
+    order_params: list[object] = []
+    if effective_snapshot_id is not None:
+        q += " AND (rem.snapshot_id = ? OR rem.snapshot_id IS NULL)"
+        params.append(effective_snapshot_id)
+        snapshot_order = "CASE WHEN rem.snapshot_id = ? THEN 0 ELSE 1 END, "
+        order_params.append(effective_snapshot_id)
+    else:
+        q += " AND rem.snapshot_id IS NULL"
+        snapshot_order = ""
+
+    q += f" ORDER BY {snapshot_order}re.start_time ASC, rem.resolved_event_id ASC, rem.id ASC"
+    params.extend(order_params)
     rows = await db.execute_fetchall(q, params)
-    return [_row_to_resolved_event_member(row) for row in rows]
+    chosen_by_key: dict[tuple[str, str], tuple[tuple[int, int, int], ResolvedEventMemberOut]] = {}
+    key_order: dict[tuple[str, str], int] = {}
+    for index, row in enumerate(rows):
+        member = _row_to_resolved_event_member(row)
+        key = (member.match_id, member.bookmaker_id)
+        key_order.setdefault(key, index)
+        rank = (
+            0 if row["event_method"] in {"manual", "manual_review"} else 1,
+            0
+            if effective_snapshot_id is not None
+            and member.snapshot_id == effective_snapshot_id
+            else 1,
+            index,
+        )
+        current = chosen_by_key.get(key)
+        if current is None or rank < current[0]:
+            chosen_by_key[key] = (rank, member)
+    return [
+        chosen_by_key[key][1]
+        for key in sorted(key_order, key=lambda item: key_order[item])
+    ]
 
 
 async def get_eligible_resolved_event_members_for_odds(
     odds_list: list[NormalizedOdds],
     *,
+    snapshot_id: str | None = None,
     event_methods: tuple[str, ...] = (
         "exact",
         "auto_fuzzy_high",
@@ -739,6 +1370,7 @@ async def get_eligible_resolved_event_members_for_odds(
     return await get_eligible_resolved_event_members_for_matches(
         match_ids,
         bookmaker_ids=bookmaker_ids,
+        snapshot_id=snapshot_id,
         event_methods=event_methods,
     )
 
@@ -746,6 +1378,7 @@ async def get_eligible_resolved_event_members_for_odds(
 async def get_eligible_resolved_event_members_for_outcome_offers(
     offers: list[NormalizedOutcomeOffer],
     *,
+    snapshot_id: str | None = None,
     event_methods: tuple[str, ...] = (
         "exact",
         "auto_fuzzy_high",
@@ -758,6 +1391,7 @@ async def get_eligible_resolved_event_members_for_outcome_offers(
     return await get_eligible_resolved_event_members_for_matches(
         match_ids,
         bookmaker_ids=bookmaker_ids,
+        snapshot_id=snapshot_id,
         event_methods=event_methods,
     )
 
@@ -784,14 +1418,33 @@ async def get_resolved_event_member(
     *,
     match_id: str,
     bookmaker_id: str,
+    snapshot_id: str | None = None,
 ) -> ResolvedEventMemberOut | None:
     db = await get_db()
+    effective_snapshot_id = (
+        snapshot_id if snapshot_id is not None else await _get_current_snapshot_id(db)
+    )
+    order_params: list[object] = []
+    if effective_snapshot_id is not None:
+        snapshot_filter = "AND (m.snapshot_id = ? OR m.snapshot_id IS NULL)"
+        snapshot_params: list[object] = [effective_snapshot_id]
+        snapshot_order = "CASE WHEN m.snapshot_id = ? THEN 0 ELSE 1 END, "
+        order_params.append(effective_snapshot_id)
+    else:
+        snapshot_filter = "AND m.snapshot_id IS NULL"
+        snapshot_params = []
+        snapshot_order = ""
     rows = await db.execute_fetchall(
-        """SELECT m.*, b.name AS bookmaker_name
+        f"""SELECT m.*, b.name AS bookmaker_name
            FROM resolved_event_members m
+           JOIN resolved_events re ON re.id = m.resolved_event_id
            LEFT JOIN bookmakers b ON b.id = m.bookmaker_id
-           WHERE m.match_id = ? AND m.bookmaker_id = ?""",
-        (match_id, bookmaker_id),
+           WHERE m.match_id = ? AND m.bookmaker_id = ?
+             {snapshot_filter}
+           ORDER BY CASE WHEN re.method IN ('manual', 'manual_review') THEN 0 ELSE 1 END,
+                    {snapshot_order}m.id ASC
+           LIMIT 1""",
+        [match_id, bookmaker_id, *snapshot_params, *order_params],
     )
     if not rows:
         return None
@@ -913,6 +1566,229 @@ async def upsert_event_review_case(case: EventReviewCaseIn) -> int:
         (case.fingerprint,),
     )
     return int(rows[0]["id"]) if rows else 0
+
+
+def _event_review_case_values(case: EventReviewCaseIn) -> tuple:
+    return (
+        case.fingerprint,
+        case.sport,
+        case.start_time,
+        case.primary_match_id,
+        case.candidate_resolved_event_id,
+        json.dumps(case.candidate_match_ids),
+        case.reason_code,
+        case.confidence,
+        case.method,
+        json.dumps(case.source_bookmaker_ids),
+        json.dumps(case.source_league_labels),
+        json.dumps(case.evidence),
+        json.dumps(case.metadata),
+        case.status,
+    )
+
+
+async def persist_event_resolution_batch(
+    *,
+    snapshot_id: str | None = None,
+    events: list[ResolvedEventIn],
+    members: list[ResolvedEventMemberIn],
+    review_cases: list[EventReviewCaseIn],
+) -> dict[str, int]:
+    db = await get_db()
+    try:
+        await db.execute("BEGIN IMMEDIATE")
+        await db.executemany(
+            """INSERT INTO resolved_events (
+                   id,
+                   sport,
+                   start_time,
+                   primary_match_id,
+                   status,
+                   confidence,
+                   method,
+                   display_home_team,
+                   display_away_team,
+                   display_league_name,
+                   metadata
+               )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                   sport = excluded.sport,
+                   start_time = excluded.start_time,
+                   primary_match_id = excluded.primary_match_id,
+                   status = excluded.status,
+                   confidence = excluded.confidence,
+                   method = excluded.method,
+                   display_home_team = excluded.display_home_team,
+                   display_away_team = excluded.display_away_team,
+                   display_league_name = excluded.display_league_name,
+                   metadata = excluded.metadata,
+                   updated_at = CURRENT_TIMESTAMP""",
+            [
+                (
+                    event.id or f"evt_{uuid.uuid4().hex}",
+                    event.sport,
+                    event.start_time,
+                    event.primary_match_id,
+                    event.status,
+                    event.confidence,
+                    event.method,
+                    event.display_home_team,
+                    event.display_away_team,
+                    event.display_league_name,
+                    json.dumps(event.metadata),
+                )
+                for event in events
+            ],
+        )
+        await db.executemany(
+            """INSERT INTO resolved_event_members (
+                   snapshot_id,
+                   resolved_event_id,
+                   match_id,
+                   bookmaker_id,
+                   orientation,
+                   confidence,
+                   status,
+                   source_url,
+                   source_league_id,
+                   source_league_name,
+                   source_home_team,
+                   source_away_team,
+                   source_start_time,
+                   evidence,
+                   metadata
+                )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(
+                   COALESCE(snapshot_id, ''),
+                   match_id,
+                   bookmaker_id
+               ) DO UPDATE SET
+                   resolved_event_id = excluded.resolved_event_id,
+                   orientation = excluded.orientation,
+                   confidence = excluded.confidence,
+                   status = excluded.status,
+                   source_url = COALESCE(excluded.source_url, resolved_event_members.source_url),
+                   source_league_id = COALESCE(
+                       excluded.source_league_id,
+                       resolved_event_members.source_league_id
+                   ),
+                   source_league_name = COALESCE(
+                       excluded.source_league_name,
+                       resolved_event_members.source_league_name
+                   ),
+                   source_home_team = COALESCE(
+                       excluded.source_home_team,
+                       resolved_event_members.source_home_team
+                   ),
+                   source_away_team = COALESCE(
+                       excluded.source_away_team,
+                       resolved_event_members.source_away_team
+                   ),
+                   source_start_time = COALESCE(
+                       excluded.source_start_time,
+                       resolved_event_members.source_start_time
+                   ),
+                   evidence = excluded.evidence,
+                   metadata = excluded.metadata,
+                   updated_at = CURRENT_TIMESTAMP
+               WHERE NOT (
+                   EXISTS (
+                       SELECT 1
+                       FROM resolved_events existing_event
+                       WHERE existing_event.id = resolved_event_members.resolved_event_id
+                         AND existing_event.status = 'active'
+                         AND existing_event.method IN ('manual', 'manual_review')
+                   )
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM resolved_events incoming_event
+                       WHERE incoming_event.id = excluded.resolved_event_id
+                         AND incoming_event.method IN ('manual', 'manual_review')
+                   )
+               )""",
+            [
+                (
+                    member.snapshot_id or snapshot_id,
+                    member.resolved_event_id,
+                    member.match_id,
+                    member.bookmaker_id,
+                    member.orientation,
+                    member.confidence,
+                    member.status,
+                    member.source_url,
+                    member.source_league_id,
+                    member.source_league_name,
+                    member.source_home_team,
+                    member.source_away_team,
+                    member.source_start_time,
+                    json.dumps(member.evidence),
+                    json.dumps(member.metadata),
+                )
+                for member in members
+            ],
+        )
+        await db.executemany(
+            """INSERT INTO match_bookmaker_sources (match_id, bookmaker_id, source_url)
+               VALUES (?, ?, ?)
+               ON CONFLICT(match_id, bookmaker_id) DO UPDATE SET
+                    source_url = COALESCE(excluded.source_url, match_bookmaker_sources.source_url),
+                    updated_at = CURRENT_TIMESTAMP""",
+            [
+                (member.match_id, member.bookmaker_id, member.source_url)
+                for member in members
+                if member.source_url is not None
+            ],
+        )
+        await db.executemany(
+            """INSERT INTO event_review_cases (
+                   fingerprint,
+                   sport,
+                   start_time,
+                   primary_match_id,
+                   candidate_resolved_event_id,
+                   candidate_match_ids,
+                   reason_code,
+                   confidence,
+                   method,
+                   source_bookmaker_ids,
+                   source_league_labels,
+                   evidence,
+                   metadata,
+                   status
+               )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(fingerprint) DO UPDATE SET
+                   sport = excluded.sport,
+                   start_time = excluded.start_time,
+                   primary_match_id = excluded.primary_match_id,
+                   candidate_resolved_event_id = excluded.candidate_resolved_event_id,
+                   candidate_match_ids = excluded.candidate_match_ids,
+                   reason_code = excluded.reason_code,
+                   confidence = excluded.confidence,
+                   method = excluded.method,
+                   source_bookmaker_ids = excluded.source_bookmaker_ids,
+                   source_league_labels = excluded.source_league_labels,
+                   evidence = excluded.evidence,
+                   metadata = excluded.metadata,
+                   status = CASE
+                       WHEN event_review_cases.status IN ('accepted', 'declined')
+                       THEN event_review_cases.status
+                       ELSE excluded.status
+                   END,
+                   updated_at = CURRENT_TIMESTAMP""",
+            [_event_review_case_values(case) for case in review_cases],
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return {
+        "resolved_events": len(events),
+        "resolved_event_members": len(members),
+        "review_cases": len(review_cases),
+    }
 
 
 async def get_event_review_case(
@@ -1251,7 +2127,12 @@ async def merge_matches(
         all_placeholders = _sql_placeholders(all_match_ids)
         rows = await db.execute_fetchall(
             f"""
-            SELECT id, bookmaker_id, market_type, player_name, threshold
+            SELECT id,
+                   COALESCE(snapshot_id, '') AS snapshot_key,
+                   bookmaker_id,
+                   market_type,
+                   player_name,
+                   threshold
             FROM odds
             WHERE match_id IN ({all_placeholders})
             """,
@@ -1261,6 +2142,7 @@ async def merge_matches(
         groups: dict[tuple, list[int]] = {}
         for row in rows:
             key = (
+                row["snapshot_key"],
                 row["bookmaker_id"],
                 row["market_type"],
                 row["player_name"],
@@ -1301,7 +2183,11 @@ async def merge_matches(
         #    Dedupe source↔target and source↔source collisions before updating.
         outcome_rows = await db.execute_fetchall(
             f"""
-            SELECT id, bookmaker_id, market_type, outcome_code,
+            SELECT id,
+                   COALESCE(snapshot_id, '') AS snapshot_key,
+                   bookmaker_id,
+                   market_type,
+                   outcome_code,
                    COALESCE(line, -999999.0) AS line_key
             FROM outcome_offers
             WHERE match_id IN ({all_placeholders})
@@ -1312,6 +2198,7 @@ async def merge_matches(
         outcome_groups: dict[tuple, list[int]] = {}
         for row in outcome_rows:
             key = (
+                row["snapshot_key"],
                 row["bookmaker_id"],
                 row["market_type"],
                 row["outcome_code"],
@@ -1382,7 +2269,58 @@ async def merge_matches(
             [target_match_id, *params],
         )
 
-        # 6. opportunities: bulk update; no UNIQUE constraint. Active duplicates
+        # 6. Snapshot match metadata is keyed by (snapshot_id, match_id), so source
+        #    rows need the same dedupe-before-update treatment before deleting
+        #    source matches.
+        await db.execute(
+            f"""DELETE FROM snapshot_matches
+                WHERE match_id IN ({placeholders})
+                  AND EXISTS (
+                      SELECT 1
+                      FROM snapshot_matches target
+                      WHERE target.snapshot_id = snapshot_matches.snapshot_id
+                        AND target.match_id = ?
+                  )""",
+            [*params, target_match_id],
+        )
+        await db.execute(
+            f"""DELETE FROM snapshot_matches
+                WHERE match_id IN ({placeholders})
+                  AND rowid NOT IN (
+                      SELECT MAX(rowid)
+                      FROM snapshot_matches
+                      WHERE match_id IN ({placeholders})
+                      GROUP BY snapshot_id
+                  )""",
+            [*params, *params],
+        )
+        await db.execute(
+            f"""UPDATE snapshot_matches
+                SET match_id = ?,
+                    league_id = (SELECT league_id FROM matches WHERE id = ?),
+                    sport = (SELECT sport FROM matches WHERE id = ?),
+                    home_team_id = (SELECT home_team_id FROM matches WHERE id = ?),
+                    away_team_id = (SELECT away_team_id FROM matches WHERE id = ?),
+                    home_team = (SELECT home_team FROM matches WHERE id = ?),
+                    away_team = (SELECT away_team FROM matches WHERE id = ?),
+                    start_time = (SELECT start_time FROM matches WHERE id = ?),
+                    status = (SELECT status FROM matches WHERE id = ?)
+                WHERE match_id IN ({placeholders})""",
+            [
+                target_match_id,
+                target_match_id,
+                target_match_id,
+                target_match_id,
+                target_match_id,
+                target_match_id,
+                target_match_id,
+                target_match_id,
+                target_match_id,
+                *params,
+            ],
+        )
+
+        # 7. opportunities: bulk update; no UNIQUE constraint. Active duplicates
         #    are deactivated on the next opportunity analysis cycle.
         reassigned_opportunities_cur = await db.execute(
             f"UPDATE opportunities SET match_id = ? WHERE match_id IN ({placeholders})",
@@ -1390,7 +2328,7 @@ async def merge_matches(
         )
         reassigned_opportunities = reassigned_opportunities_cur.rowcount or 0
 
-        # 7. Delete the now-empty source match rows.
+        # 8. Delete the now-empty source match rows.
         deleted_cur = await db.execute(
             f"DELETE FROM matches WHERE id IN ({placeholders})",
             params,
@@ -1415,6 +2353,7 @@ async def _get_match_bookmaker_map(
     db: aiosqlite.Connection,
     match_ids: list[str],
     *,
+    snapshot_id: str | None,
     snapshot_at: str | None,
     cutoff_at: str | None,
 ) -> dict[str, list[MatchBookmakerOut]]:
@@ -1426,7 +2365,10 @@ async def _get_match_bookmaker_map(
 
     odds_filter = ""
     offers_filter = ""
-    if snapshot_at is not None:
+    if snapshot_id is not None:
+        odds_filter = " AND o.snapshot_id = ?"
+        offers_filter = " AND oo.snapshot_id = ?"
+    elif snapshot_at is not None:
         odds_filter = " AND o.scraped_at = ?"
         offers_filter = " AND oo.scraped_at = ?"
     elif cutoff_at is not None:
@@ -1446,12 +2388,16 @@ async def _get_match_bookmaker_map(
             LEFT JOIN bookmakers b ON src.bookmaker_id = b.id
             ORDER BY b.name ASC"""
 
-    if snapshot_at is not None:
+    if snapshot_id is not None:
+        params.append(snapshot_id)
+    elif snapshot_at is not None:
         params.append(snapshot_at)
     elif cutoff_at is not None:
         params.append(cutoff_at)
     params.extend(match_ids)
-    if snapshot_at is not None:
+    if snapshot_id is not None:
+        params.append(snapshot_id)
+    elif snapshot_at is not None:
         params.append(snapshot_at)
     elif cutoff_at is not None:
         params.append(cutoff_at)
@@ -1471,13 +2417,21 @@ async def _get_match_bookmaker_map(
 
 async def get_current_normalized_odds_for_matches(
     match_ids: list[str],
+    *,
+    snapshot_id: str | None = None,
 ) -> list[NormalizedOdds]:
     selected_match_ids = list(dict.fromkeys(match_ids))
     if not selected_match_ids:
         return []
 
     db = await get_db()
-    snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(db, "o")
+    metadata_snapshot_id = snapshot_id or await _get_current_snapshot_id(db)
+    if snapshot_id is None:
+        snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(db, "o")
+    else:
+        snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(
+            db, "o", snapshot_id=snapshot_id
+        )
     if snapshot_filter is None:
         return []
 
@@ -1486,6 +2440,7 @@ async def get_current_normalized_odds_for_matches(
         selected_match_ids,
         snapshot_filter=snapshot_filter,
         snapshot_params=snapshot_params,
+        metadata_snapshot_id=metadata_snapshot_id,
     )
 
 
@@ -1495,47 +2450,58 @@ async def _get_normalized_odds_for_matches_snapshot(
     *,
     snapshot_filter: str,
     snapshot_params: list[object],
+    metadata_snapshot_id: str | None = None,
 ) -> list[NormalizedOdds]:
     placeholders = _sql_placeholders(selected_match_ids)
+    metadata_params: list[object] = [metadata_snapshot_id]
     rows = await db.execute_fetchall(
         f"""SELECT o.match_id,
                    o.bookmaker_id,
-                   m.league_id,
-                   m.sport,
-                   COALESCE(m.home_team_id, 0) AS home_team_id,
-                   COALESCE(m.away_team_id, 0) AS away_team_id,
-                   m.home_team,
-                   m.away_team,
+                   COALESCE(sm.league_id, m.league_id) AS league_id,
+                   COALESCE(sm.sport, m.sport) AS sport,
+                   COALESCE(sm.home_team_id, m.home_team_id, 0) AS home_team_id,
+                   COALESCE(sm.away_team_id, m.away_team_id, 0) AS away_team_id,
+                   COALESCE(sm.home_team, m.home_team) AS home_team,
+                   COALESCE(sm.away_team, m.away_team) AS away_team,
                    s.source_url,
                    o.market_type,
                    o.player_name,
                    o.threshold,
                    o.over_odds,
                    o.under_odds,
-                   m.start_time,
+                   COALESCE(sm.start_time, m.start_time) AS start_time,
                    o.scraped_at
             FROM odds o
             JOIN matches m ON m.id = o.match_id
+            LEFT JOIN snapshot_matches sm ON sm.snapshot_id = ? AND sm.match_id = m.id
             LEFT JOIN match_bookmaker_sources s
               ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id
             WHERE o.match_id IN ({placeholders})
               AND {snapshot_filter}
-            ORDER BY m.start_time ASC, o.match_id ASC, o.bookmaker_id ASC,
+            ORDER BY COALESCE(sm.start_time, m.start_time) ASC, o.match_id ASC, o.bookmaker_id ASC,
                      o.market_type ASC, o.player_name ASC, o.threshold ASC""",
-        [*selected_match_ids, *snapshot_params],
+        [*metadata_params, *selected_match_ids, *snapshot_params],
     )
     return [NormalizedOdds(**_row_to_dict(row)) for row in rows]
 
 
 async def get_current_normalized_outcome_offers_for_matches(
     match_ids: list[str],
+    *,
+    snapshot_id: str | None = None,
 ) -> list[NormalizedOutcomeOffer]:
     selected_match_ids = list(dict.fromkeys(match_ids))
     if not selected_match_ids:
         return []
 
     db = await get_db()
-    snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(db, "o")
+    metadata_snapshot_id = snapshot_id or await _get_current_snapshot_id(db)
+    if snapshot_id is None:
+        snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(db, "o")
+    else:
+        snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(
+            db, "o", snapshot_id=snapshot_id
+        )
     if snapshot_filter is None:
         return []
 
@@ -1544,6 +2510,7 @@ async def get_current_normalized_outcome_offers_for_matches(
         selected_match_ids,
         snapshot_filter=snapshot_filter,
         snapshot_params=snapshot_params,
+        metadata_snapshot_id=metadata_snapshot_id,
     )
 
 
@@ -1553,47 +2520,58 @@ async def _get_normalized_outcome_offers_for_matches_snapshot(
     *,
     snapshot_filter: str,
     snapshot_params: list[object],
+    metadata_snapshot_id: str | None = None,
 ) -> list[NormalizedOutcomeOffer]:
     placeholders = _sql_placeholders(selected_match_ids)
+    metadata_params: list[object] = [metadata_snapshot_id]
     rows = await db.execute_fetchall(
         f"""SELECT o.match_id,
                    o.bookmaker_id,
-                   m.league_id,
-                   m.sport,
-                   COALESCE(m.home_team_id, 0) AS home_team_id,
-                   COALESCE(m.away_team_id, 0) AS away_team_id,
-                   m.home_team,
-                   m.away_team,
+                   COALESCE(sm.league_id, m.league_id) AS league_id,
+                   COALESCE(sm.sport, m.sport) AS sport,
+                   COALESCE(sm.home_team_id, m.home_team_id, 0) AS home_team_id,
+                   COALESCE(sm.away_team_id, m.away_team_id, 0) AS away_team_id,
+                   COALESCE(sm.home_team, m.home_team) AS home_team,
+                   COALESCE(sm.away_team, m.away_team) AS away_team,
                    s.source_url,
                    o.market_type,
                    o.outcome_code,
                    o.odds,
                    o.line,
                    o.raw_label,
-                   m.start_time,
+                   COALESCE(sm.start_time, m.start_time) AS start_time,
                    o.scraped_at
             FROM outcome_offers o
             JOIN matches m ON m.id = o.match_id
+            LEFT JOIN snapshot_matches sm ON sm.snapshot_id = ? AND sm.match_id = m.id
             LEFT JOIN match_bookmaker_sources s
               ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id
             WHERE o.match_id IN ({placeholders})
               AND {snapshot_filter}
-            ORDER BY m.start_time ASC, o.match_id ASC, o.bookmaker_id ASC,
+            ORDER BY COALESCE(sm.start_time, m.start_time) ASC, o.match_id ASC, o.bookmaker_id ASC,
                      o.market_type ASC, o.line ASC, o.outcome_code ASC""",
-        [*selected_match_ids, *snapshot_params],
+        [*metadata_params, *selected_match_ids, *snapshot_params],
     )
     return [NormalizedOutcomeOffer(**_row_to_dict(row)) for row in rows]
 
 
 async def get_current_canonical_offers_for_matches(
     match_ids: list[str],
+    *,
+    snapshot_id: str | None = None,
 ) -> list[CanonicalOffer]:
     selected_match_ids = list(dict.fromkeys(match_ids))
     if not selected_match_ids:
         return []
 
     db = await get_db()
-    snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(db, "o")
+    metadata_snapshot_id = snapshot_id or await _get_current_snapshot_id(db)
+    if snapshot_id is None:
+        snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(db, "o")
+    else:
+        snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(
+            db, "o", snapshot_id=snapshot_id
+        )
     if snapshot_filter is None:
         return []
 
@@ -1602,15 +2580,18 @@ async def get_current_canonical_offers_for_matches(
         selected_match_ids,
         snapshot_filter=snapshot_filter,
         snapshot_params=snapshot_params,
+        metadata_snapshot_id=metadata_snapshot_id,
     )
     outcome_offer_rows = await _get_normalized_outcome_offers_for_matches_snapshot(
         db,
         selected_match_ids,
         snapshot_filter=snapshot_filter,
         snapshot_params=snapshot_params,
+        metadata_snapshot_id=metadata_snapshot_id,
     )
     resolved_event_members = await _eligible_resolved_event_members_for_offer_rows(
-        [*odds_rows, *outcome_offer_rows]
+        [*odds_rows, *outcome_offer_rows],
+        snapshot_id=metadata_snapshot_id,
     )
     resolved_event_ids = _resolved_event_ids_for_offer_rows(
         [*odds_rows, *outcome_offer_rows],
@@ -1651,6 +2632,8 @@ async def get_current_canonical_offers_for_matches(
 
 async def _eligible_resolved_event_members_for_offer_rows(
     rows: list[NormalizedOdds | NormalizedOutcomeOffer],
+    *,
+    snapshot_id: str | None,
 ) -> list[ResolvedEventMemberOut]:
     row_keys = {(row.match_id, row.bookmaker_id) for row in rows}
     if not row_keys:
@@ -1659,6 +2642,7 @@ async def _eligible_resolved_event_members_for_offer_rows(
     return await get_eligible_resolved_event_members_for_matches(
         sorted({match_id for match_id, _ in row_keys}),
         bookmaker_ids=sorted({bookmaker_id for _, bookmaker_id in row_keys}),
+        snapshot_id=snapshot_id,
     )
 
 
@@ -1679,11 +2663,19 @@ def _resolved_event_ids_for_offer_rows(
 
 async def upsert_odds(odds: NormalizedOdds, *, scraped_at: str) -> int:
     db = await get_db()
+    snapshot_id = _snapshot_id_from_scraped_at(scraped_at)
+    await _upsert_scrape_snapshot_tx(
+        db,
+        snapshot_id=snapshot_id,
+        scraped_at=scraped_at,
+    )
     await db.execute(
         """INSERT OR REPLACE INTO odds
-           (match_id, bookmaker_id, market_type, player_name, threshold, over_odds, under_odds, scraped_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+           (snapshot_id, match_id, bookmaker_id, market_type, player_name, threshold,
+            over_odds, under_odds, scraped_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
+            snapshot_id,
             odds.match_id,
             odds.bookmaker_id,
             odds.market_type,
@@ -1697,9 +2689,11 @@ async def upsert_odds(odds: NormalizedOdds, *, scraped_at: str) -> int:
     # Also insert into history
     await db.execute(
         """INSERT INTO odds_history
-           (match_id, bookmaker_id, market_type, player_name, threshold, over_odds, under_odds, scraped_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+           (snapshot_id, match_id, bookmaker_id, market_type, player_name, threshold,
+            over_odds, under_odds, scraped_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
+            snapshot_id,
             odds.match_id,
             odds.bookmaker_id,
             odds.market_type,
@@ -1724,33 +2718,19 @@ async def upsert_odds(odds: NormalizedOdds, *, scraped_at: str) -> int:
 
 async def get_odds_for_match(match_id: str) -> list[OddsOut]:
     db = await get_db()
-    current_snapshot_at = await _get_current_snapshot_at(db)
-    if current_snapshot_at is not None:
-        rows = await db.execute_fetchall(
-            """SELECT o.*, b.name as bookmaker_name, s.source_url as source_url
-               FROM odds o
-               LEFT JOIN bookmakers b ON o.bookmaker_id = b.id
-               LEFT JOIN match_bookmaker_sources s
-                 ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id
-               WHERE o.match_id = ? AND o.scraped_at = ?
-               ORDER BY o.market_type, o.player_name, o.threshold""",
-            (match_id, current_snapshot_at),
-        )
-    else:
-        legacy_window = await _get_legacy_snapshot_cutoff(db)
-        if legacy_window is None:
-            return []
-        _, cutoff_at = legacy_window
-        rows = await db.execute_fetchall(
-            """SELECT o.*, b.name as bookmaker_name, s.source_url as source_url
-               FROM odds o
-               LEFT JOIN bookmakers b ON o.bookmaker_id = b.id
-               LEFT JOIN match_bookmaker_sources s
-                 ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id
-               WHERE o.match_id = ? AND o.scraped_at >= ?
-               ORDER BY o.market_type, o.player_name, o.threshold""",
-            (match_id, cutoff_at),
-        )
+    snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(db, "o")
+    if snapshot_filter is None:
+        return []
+    rows = await db.execute_fetchall(
+        f"""SELECT o.*, b.name as bookmaker_name, s.source_url as source_url
+            FROM odds o
+            LEFT JOIN bookmakers b ON o.bookmaker_id = b.id
+            LEFT JOIN match_bookmaker_sources s
+              ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id
+            WHERE o.match_id = ? AND {snapshot_filter}
+            ORDER BY o.market_type, o.player_name, o.threshold""",
+        [match_id, *snapshot_params],
+    )
     return [OddsOut(**_row_to_dict(r)) for r in rows]
 
 
@@ -1771,11 +2751,19 @@ async def upsert_outcome_offer(
     scraped_at: str,
 ) -> int:
     db = await get_db()
+    snapshot_id = _snapshot_id_from_scraped_at(scraped_at)
+    await _upsert_scrape_snapshot_tx(
+        db,
+        snapshot_id=snapshot_id,
+        scraped_at=scraped_at,
+    )
     await db.execute(
         """INSERT OR REPLACE INTO outcome_offers
-           (match_id, bookmaker_id, market_type, outcome_code, line, odds, raw_label, scraped_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+           (snapshot_id, match_id, bookmaker_id, market_type, outcome_code, line,
+            odds, raw_label, scraped_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
+            snapshot_id,
             offer.match_id,
             offer.bookmaker_id,
             offer.market_type,
@@ -1795,12 +2783,14 @@ async def upsert_outcome_offer(
     await db.commit()
     row = await db.execute_fetchall(
         """SELECT id FROM outcome_offers
-           WHERE match_id = ?
+           WHERE snapshot_id = ?
+             AND match_id = ?
              AND bookmaker_id = ?
              AND market_type = ?
              AND outcome_code = ?
              AND COALESCE(line, -999999.0) = COALESCE(?, -999999.0)""",
         (
+            snapshot_id,
             offer.match_id,
             offer.bookmaker_id,
             offer.market_type,
@@ -1821,21 +2811,23 @@ async def get_outcome_offers(
     offset: int = 0,
 ) -> list[OutcomeOfferOut]:
     db = await get_db()
-    snapshot_at = await _get_current_snapshot_at(db)
-    if snapshot_at is None:
+    current_snapshot_id = await _get_current_snapshot_id(db)
+    snapshot_filter, snapshot_params = await _current_or_legacy_snapshot_filter(db, "o")
+    if snapshot_filter is None:
         return []
 
     q = """SELECT o.*, b.name AS bookmaker_name, s.source_url AS source_url
            FROM outcome_offers o
            JOIN matches m ON m.id = o.match_id
+           LEFT JOIN snapshot_matches sm ON sm.snapshot_id = ? AND sm.match_id = m.id
            LEFT JOIN bookmakers b ON b.id = o.bookmaker_id
            LEFT JOIN match_bookmaker_sources s
-             ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id"""
-    conditions = ["o.scraped_at = ?"]
-    params: list[object] = [snapshot_at]
+              ON s.match_id = o.match_id AND s.bookmaker_id = o.bookmaker_id"""
+    conditions = [snapshot_filter]
+    params: list[object] = [current_snapshot_id, *snapshot_params]
 
     if sport:
-        conditions.append("m.sport = ?")
+        conditions.append("COALESCE(sm.sport, m.sport) = ?")
         params.append(sport)
     if match_id:
         conditions.append("o.match_id = ?")
@@ -1849,7 +2841,10 @@ async def get_outcome_offers(
         params.append(market_type)
 
     q += " WHERE " + " AND ".join(conditions)
-    q += " ORDER BY m.start_time ASC, o.market_type ASC, o.line ASC, o.outcome_code ASC LIMIT ? OFFSET ?"
+    q += (
+        " ORDER BY COALESCE(sm.start_time, m.start_time) ASC, "
+        "o.market_type ASC, o.line ASC, o.outcome_code ASC LIMIT ? OFFSET ?"
+    )
     params.extend([limit, offset])
     rows = await db.execute_fetchall(q, params)
     return [OutcomeOfferOut(**_row_to_dict(row)) for row in rows]
@@ -1925,6 +2920,102 @@ async def insert_opportunity(opportunity, *, detected_at: str) -> int:
     return cursor.lastrowid or 0
 
 
+async def publish_opportunities(
+    *,
+    snapshot_id: str,
+    snapshot_at: str,
+    opportunities: list,
+    detected_at: str,
+) -> str:
+    publish_id = _new_opportunity_publish_id(detected_at)
+    db = await get_db()
+    try:
+        await db.execute("BEGIN IMMEDIATE")
+        await db.execute(
+            """INSERT INTO opportunity_publishes (
+                   id,
+                   snapshot_id,
+                   detected_at,
+                   status,
+                   opportunity_count
+               )
+               VALUES (?, ?, ?, 'publishing', ?)""",
+            (publish_id, snapshot_id, detected_at, len(opportunities)),
+        )
+        await db.executemany(
+            """INSERT INTO opportunities
+               (publish_id, sport, match_id, resolved_event_id, opportunity_type,
+                market_type, subject_type, subject_key, subject_name, line,
+                profit_margin, middle_profit_margin, market_keys, legs,
+                detected_at, is_active)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE)""",
+            [
+                (
+                    publish_id,
+                    opportunity.sport,
+                    opportunity.match_id,
+                    opportunity.resolved_event_id,
+                    opportunity.opportunity_type,
+                    opportunity.market_type,
+                    opportunity.subject_type,
+                    opportunity.subject_key,
+                    opportunity.subject_name,
+                    opportunity.line,
+                    opportunity.profit_margin,
+                    opportunity.middle_profit_margin,
+                    json.dumps(list(opportunity.market_keys)),
+                    json.dumps([leg.model_dump() for leg in opportunity.legs]),
+                    detected_at,
+                )
+                for opportunity in opportunities
+            ],
+        )
+        await db.execute(
+            """UPDATE opportunity_publishes
+               SET status = 'published',
+                   opportunity_count = ?,
+                   updated_at = CURRENT_TIMESTAMP
+               WHERE id = ?""",
+            (len(opportunities), publish_id),
+        )
+        await db.execute(
+            """UPDATE opportunities
+               SET is_active = FALSE
+               WHERE publish_id IS NOT NULL
+                 AND publish_id != ?""",
+            (publish_id,),
+        )
+        await db.execute(
+            """INSERT INTO scrape_state (
+                   id,
+                   current_snapshot_id,
+                   current_snapshot_at,
+                   current_opportunity_publish_id,
+                   updated_at
+               )
+               VALUES (1, ?, ?, ?, CURRENT_TIMESTAMP)
+               ON CONFLICT(id) DO UPDATE SET
+                   current_snapshot_id = excluded.current_snapshot_id,
+                   current_snapshot_at = excluded.current_snapshot_at,
+                   current_opportunity_publish_id = excluded.current_opportunity_publish_id,
+                   updated_at = CURRENT_TIMESTAMP""",
+            (snapshot_id, snapshot_at, publish_id),
+        )
+        await db.execute(
+            """UPDATE scrape_snapshots
+               SET status = 'published',
+                   completed_at = ?,
+                   updated_at = CURRENT_TIMESTAMP
+               WHERE id = ?""",
+            (snapshot_at, snapshot_id),
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return publish_id
+
+
 def _row_to_opportunity(row: aiosqlite.Row) -> OpportunityOut:
     data = _row_to_dict(row)
     raw_legs = data.get("legs")
@@ -1953,12 +3044,26 @@ async def get_opportunities(
     offset: int = 0,
 ) -> list[OpportunityOut]:
     db = await get_db()
-    q = """SELECT op.*, m.home_team, m.away_team, m.start_time, l.name AS league_name
+    current_publish_id = await _get_current_opportunity_publish_id(db)
+    current_snapshot_id = await _get_current_snapshot_id(db)
+    q = """SELECT op.*,
+                  COALESCE(sm.home_team, m.home_team) AS home_team,
+                  COALESCE(sm.away_team, m.away_team) AS away_team,
+                  COALESCE(sm.start_time, m.start_time) AS start_time,
+                  l.name AS league_name
            FROM opportunities op
+           LEFT JOIN opportunity_publishes pub ON pub.id = op.publish_id
            LEFT JOIN matches m ON m.id = op.match_id
-           LEFT JOIN leagues l ON l.id = m.league_id"""
-    conditions = ["op.is_active = TRUE"]
-    params: list[object] = []
+           LEFT JOIN snapshot_matches sm
+             ON sm.snapshot_id = COALESCE(pub.snapshot_id, ?)
+            AND sm.match_id = op.match_id
+           LEFT JOIN leagues l ON l.id = COALESCE(sm.league_id, m.league_id)"""
+    if current_publish_id is not None:
+        conditions = ["op.publish_id = ?", "op.is_active = TRUE"]
+        params: list[object] = [current_snapshot_id, current_publish_id]
+    else:
+        conditions = ["op.is_active = TRUE"]
+        params = [current_snapshot_id]
     if sport:
         conditions.append("op.sport = ?")
         params.append(sport)
@@ -1978,7 +3083,7 @@ async def get_opportunities(
         params.extend(bookmaker_ids)
     q += " WHERE " + " AND ".join(conditions)
     q += """ ORDER BY COALESCE(op.profit_margin, -999) DESC,
-                    m.start_time ASC,
+                    COALESCE(sm.start_time, m.start_time) ASC,
                     op.id ASC
              LIMIT ? OFFSET ?"""
     params.extend([limit, offset])
@@ -2058,14 +3163,21 @@ async def insert_unresolved_odds(
     scraped_at: str,
 ) -> int:
     db = await get_db()
+    snapshot_id = _snapshot_id_from_scraped_at(scraped_at)
+    await _upsert_scrape_snapshot_tx(
+        db,
+        snapshot_id=snapshot_id,
+        scraped_at=scraped_at,
+    )
     cursor = await db.execute(
         """INSERT INTO unresolved_odds
-           (bookmaker_id, raw_league_id, league_id, sport, market_type, player_name,
+           (snapshot_id, bookmaker_id, raw_league_id, league_id, sport, market_type, player_name,
             raw_team_name, normalized_team_name, start_time, threshold, over_odds,
             under_odds, reason_code, candidate_count, candidate_matchups,
             available_matchups_same_slot, scraped_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
+            snapshot_id,
             unresolved.bookmaker_id,
             unresolved.raw_league_id,
             unresolved.league_id,
@@ -2099,9 +3211,11 @@ async def get_unresolved_odds(
     offset: int = 0,
 ) -> list[UnresolvedOddsOut]:
     db = await get_db()
+    snapshot_id = await _get_current_snapshot_id(db)
     snapshot_at = await _get_current_snapshot_at(db)
-    if snapshot_at is None:
+    if snapshot_id is None:
         snapshot_at = await _get_latest_unresolved_snapshot_at(db)
+        snapshot_id = _snapshot_id_from_scraped_at(snapshot_at) if snapshot_at else None
     if snapshot_at is None:
         return []
 
@@ -2109,8 +3223,8 @@ async def get_unresolved_odds(
            FROM unresolved_odds u
            LEFT JOIN bookmakers b ON u.bookmaker_id = b.id
            LEFT JOIN leagues l ON u.league_id = l.id"""
-    conditions = ["u.scraped_at = ?"]
-    params: list = [snapshot_at]
+    conditions = ["u.snapshot_id = ?" if snapshot_id else "u.scraped_at = ?"]
+    params: list = [snapshot_id or snapshot_at]
 
     if bookmaker_ids:
         placeholders = _sql_placeholders(bookmaker_ids)
@@ -2144,9 +3258,16 @@ async def insert_team_review_case(
     scraped_at: str,
 ) -> int:
     db = await get_db()
+    snapshot_id = _snapshot_id_from_scraped_at(scraped_at)
+    await _upsert_scrape_snapshot_tx(
+        db,
+        snapshot_id=snapshot_id,
+        scraped_at=scraped_at,
+    )
     cursor = await db.execute(
         """INSERT INTO team_review_cases
            (
+               snapshot_id,
                bookmaker_id,
                raw_league_id,
                normalized_raw_league_id,
@@ -2169,8 +3290,9 @@ async def insert_team_review_case(
                status,
                scraped_at
            )
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
+            snapshot_id,
             case.bookmaker_id,
             case.raw_league_id,
             case.normalized_raw_league_id,
@@ -2206,6 +3328,7 @@ async def get_team_review_cases(
     offset: int = 0,
 ) -> list[TeamReviewOut]:
     db = await get_db()
+    snapshot_id = await _get_current_snapshot_id(db)
     snapshot_at = await _get_team_review_snapshot_at(db)
     if snapshot_at is None:
         return []
@@ -2214,8 +3337,10 @@ async def get_team_review_cases(
            FROM team_review_cases c
            LEFT JOIN bookmakers b ON c.bookmaker_id = b.id
            LEFT JOIN leagues l ON c.scope_league_id = l.id"""
-    conditions = ["c.scraped_at = ?"]
-    params: list[object] = [snapshot_at]
+    if snapshot_id is None:
+        snapshot_id = _snapshot_id_from_scraped_at(snapshot_at)
+    conditions = ["c.snapshot_id = ?" if snapshot_id else "c.scraped_at = ?"]
+    params: list[object] = [snapshot_id or snapshot_at]
 
     if bookmaker_ids:
         placeholders = _sql_placeholders(bookmaker_ids)
@@ -2382,53 +3507,118 @@ def _retention_cutoff(snapshot_at: str, days: int) -> str:
 
 async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
     db = await aiosqlite.connect(settings.db_path)
+    db.row_factory = aiosqlite.Row
     try:
         await db.execute("BEGIN IMMEDIATE")
+        published_snapshot_id, published_snapshot_at = await _get_current_snapshot(db)
+        current_publish_id = await _get_current_opportunity_publish_id(db)
+        preserved_snapshot_id = published_snapshot_id or _snapshot_id_from_scraped_at(
+            current_snapshot_at
+        )
+        retention_anchor_at = published_snapshot_at or current_snapshot_at
         deleted_stale_odds_cur = await db.execute(
-            "DELETE FROM odds WHERE scraped_at IS NULL OR scraped_at != ?",
-            (current_snapshot_at,),
+            """DELETE FROM odds
+               WHERE COALESCE(snapshot_id, scraped_at) IS NULL
+                   OR COALESCE(snapshot_id, scraped_at) != ?""",
+            (preserved_snapshot_id,),
+        )
+        await db.execute(
+            """DELETE FROM outcome_offers
+               WHERE COALESCE(snapshot_id, scraped_at) IS NULL
+                  OR COALESCE(snapshot_id, scraped_at) != ?""",
+            (preserved_snapshot_id,),
         )
         deleted_unresolved_cur = await db.execute(
-            "DELETE FROM unresolved_odds WHERE scraped_at IS NULL OR scraped_at != ?",
-            (current_snapshot_at,),
+            """DELETE FROM unresolved_odds
+               WHERE COALESCE(snapshot_id, scraped_at) IS NULL
+                  OR COALESCE(snapshot_id, scraped_at) != ?""",
+            (preserved_snapshot_id,),
+        )
+        await db.execute(
+            """DELETE FROM snapshot_matches
+               WHERE snapshot_id IS NULL
+                  OR snapshot_id != ?""",
+            (preserved_snapshot_id,),
+        )
+        deleted_resolved_event_members_cur = await db.execute(
+            """DELETE FROM resolved_event_members
+               WHERE snapshot_id IS NOT NULL
+                 AND snapshot_id != ?""",
+            (preserved_snapshot_id,),
+        )
+        if current_publish_id is not None:
+            deleted_opportunities_cur = await db.execute(
+                """DELETE FROM opportunities
+                   WHERE publish_id IS NOT NULL
+                     AND publish_id != ?""",
+                (current_publish_id,),
+            )
+            deleted_opportunity_publishes_cur = await db.execute(
+                "DELETE FROM opportunity_publishes WHERE id != ?",
+                (current_publish_id,),
+            )
+        else:
+            deleted_opportunities_cur = await db.execute(
+                "DELETE FROM opportunities WHERE publish_id IS NOT NULL"
+            )
+            deleted_opportunity_publishes_cur = await db.execute(
+                "DELETE FROM opportunity_publishes"
+            )
+        deleted_scrape_snapshots_cur = await db.execute(
+            "DELETE FROM scrape_snapshots WHERE id != ?",
+            (preserved_snapshot_id,),
         )
         if settings.odds_history_retention_days > 0:
             odds_history_cutoff = _retention_cutoff(
-                current_snapshot_at, settings.odds_history_retention_days
+                retention_anchor_at, settings.odds_history_retention_days
             )
             deleted_odds_history_cur = await db.execute(
                 """
                 DELETE FROM odds_history
                 WHERE scraped_at IS NOT NULL
                   AND datetime(scraped_at) < datetime(?)
+                  AND (
+                      COALESCE(snapshot_id, scraped_at) IS NULL
+                      OR COALESCE(snapshot_id, scraped_at) != ?
+                  )
                 """,
-                (odds_history_cutoff,),
+                (odds_history_cutoff, preserved_snapshot_id),
             )
         else:
             deleted_odds_history_cur = await db.execute(
-                "DELETE FROM odds_history WHERE scraped_at IS NOT NULL"
+                """DELETE FROM odds_history
+                   WHERE COALESCE(snapshot_id, scraped_at) IS NULL
+                      OR COALESCE(snapshot_id, scraped_at) != ?""",
+                (preserved_snapshot_id,),
             )
 
         if settings.team_review_retention_days > 0:
             team_review_cutoff = _retention_cutoff(
-                current_snapshot_at, settings.team_review_retention_days
+                retention_anchor_at, settings.team_review_retention_days
             )
             deleted_team_reviews_cur = await db.execute(
                 """
                 DELETE FROM team_review_cases
                 WHERE scraped_at IS NOT NULL
                   AND datetime(scraped_at) < datetime(?)
+                  AND (
+                      COALESCE(snapshot_id, scraped_at) IS NULL
+                      OR COALESCE(snapshot_id, scraped_at) != ?
+                  )
                 """,
-                (team_review_cutoff,),
+                (team_review_cutoff, preserved_snapshot_id),
             )
         else:
             deleted_team_reviews_cur = await db.execute(
-                "DELETE FROM team_review_cases WHERE scraped_at IS NOT NULL"
+                """DELETE FROM team_review_cases
+                   WHERE COALESCE(snapshot_id, scraped_at) IS NULL
+                      OR COALESCE(snapshot_id, scraped_at) != ?""",
+                (preserved_snapshot_id,),
             )
 
         if settings.persist_inapp_notifications and settings.notification_retention_days > 0:
             notification_cutoff = _retention_cutoff(
-                current_snapshot_at, settings.notification_retention_days
+                retention_anchor_at, settings.notification_retention_days
             )
             deleted_notifications_cur = await db.execute(
                 """
@@ -2450,6 +3640,14 @@ async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
     return {
         "deleted_stale_odds": deleted_stale_odds_cur.rowcount or 0,
         "deleted_stale_unresolved_odds": deleted_unresolved_cur.rowcount or 0,
+        "deleted_stale_resolved_event_members": (
+            deleted_resolved_event_members_cur.rowcount or 0
+        ),
+        "deleted_stale_opportunities": deleted_opportunities_cur.rowcount or 0,
+        "deleted_stale_opportunity_publishes": (
+            deleted_opportunity_publishes_cur.rowcount or 0
+        ),
+        "deleted_stale_scrape_snapshots": deleted_scrape_snapshots_cur.rowcount or 0,
         "deleted_odds_history": deleted_odds_history_cur.rowcount or 0,
         "deleted_team_review_cases": deleted_team_reviews_cur.rowcount or 0,
         "deleted_notifications": deleted_notifications_cur.rowcount or 0,
@@ -2463,19 +3661,27 @@ async def get_system_status(
     scan_progress: ScanProgressOut | None = None,
 ) -> SystemStatus:
     db = await get_db()
-    current_snapshot_at = await _get_current_snapshot_at(db)
-    if current_snapshot_at is not None:
+    current_snapshot_id, current_snapshot_at = await _get_current_snapshot(db)
+    if current_snapshot_id is not None:
         matches_row = await db.execute_fetchall(
-            "SELECT COUNT(DISTINCT match_id) as c FROM odds WHERE scraped_at = ?",
-            (current_snapshot_at,),
+            """SELECT COUNT(DISTINCT match_id) as c
+               FROM (
+                   SELECT match_id FROM odds WHERE snapshot_id = ?
+                   UNION
+                   SELECT match_id FROM outcome_offers WHERE snapshot_id = ?
+               )""",
+            (current_snapshot_id, current_snapshot_id),
         )
         odds_row = await db.execute_fetchall(
-            "SELECT COUNT(*) as c FROM odds WHERE scraped_at = ?",
-            (current_snapshot_at,),
+            """SELECT (
+                   (SELECT COUNT(*) FROM odds WHERE snapshot_id = ?)
+                   + (SELECT COUNT(*) FROM outcome_offers WHERE snapshot_id = ?)
+               ) as c""",
+            (current_snapshot_id, current_snapshot_id),
         )
         matches_count = matches_row[0][0]
         odds_count = odds_row[0][0]
-        last_scrape_at = current_snapshot_at
+        last_scrape_at = current_snapshot_at or current_snapshot_id
     else:
         legacy_window = await _get_legacy_snapshot_cutoff(db)
         if legacy_window is None:
@@ -2485,16 +3691,33 @@ async def get_system_status(
         else:
             last_scrape_at, cutoff_at = legacy_window
             matches_row = await db.execute_fetchall(
-                "SELECT COUNT(DISTINCT match_id) as c FROM odds WHERE scraped_at >= ?",
-                (cutoff_at,),
+                """SELECT COUNT(DISTINCT match_id) as c
+                   FROM (
+                       SELECT match_id FROM odds WHERE scraped_at >= ?
+                       UNION
+                       SELECT match_id FROM outcome_offers WHERE scraped_at >= ?
+                   )""",
+                (cutoff_at, cutoff_at),
             )
             odds_row = await db.execute_fetchall(
-                "SELECT COUNT(*) as c FROM odds WHERE scraped_at >= ?",
-                (cutoff_at,),
+                """SELECT (
+                       (SELECT COUNT(*) FROM odds WHERE scraped_at >= ?)
+                       + (SELECT COUNT(*) FROM outcome_offers WHERE scraped_at >= ?)
+                   ) as c""",
+                (cutoff_at, cutoff_at),
             )
             matches_count = matches_row[0][0]
             odds_count = odds_row[0][0]
-    opportunity_row = await db.execute_fetchall("SELECT COUNT(*) as c FROM opportunities WHERE is_active = TRUE")
+    current_publish_id = await _get_current_opportunity_publish_id(db)
+    if current_publish_id is not None:
+        opportunity_row = await db.execute_fetchall(
+            "SELECT COUNT(*) as c FROM opportunities WHERE publish_id = ? AND is_active = TRUE",
+            (current_publish_id,),
+        )
+    else:
+        opportunity_row = await db.execute_fetchall(
+            "SELECT COUNT(*) as c FROM opportunities WHERE is_active = TRUE"
+        )
     bm_row = await db.execute_fetchall("SELECT COUNT(*) as c FROM bookmakers WHERE is_active = TRUE")
 
     return SystemStatus(

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -51,6 +51,14 @@ def _row_to_dict(row: aiosqlite.Row) -> dict:
     return dict(row)
 
 
+async def _open_isolated_db_connection() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(settings.db_path)
+    db.row_factory = aiosqlite.Row
+    await db.execute("PRAGMA busy_timeout = 5000")
+    await db.execute("PRAGMA foreign_keys = ON")
+    return db
+
+
 def _json_list(value: object) -> list:
     if not value:
         return []
@@ -414,6 +422,47 @@ async def _get_latest_team_review_snapshot_at(db: aiosqlite.Connection) -> str |
     if not row or not row[0][0]:
         return None
     return row[0][0]
+
+
+async def _get_visible_diagnostic_snapshot(
+    db: aiosqlite.Connection,
+    table_name: str,
+) -> tuple[str | None, str | None]:
+    if table_name not in {"unresolved_odds", "team_review_cases"}:
+        raise ValueError(f"unsupported diagnostic table: {table_name}")
+
+    current_snapshot_id, current_snapshot_at = await _get_current_snapshot(db)
+    newer_than_current = ""
+    params: list[object] = []
+    if current_snapshot_at is not None:
+        newer_than_current = "AND datetime(ss.scraped_at) > datetime(?)"
+        params.append(current_snapshot_at)
+    rows = await db.execute_fetchall(
+        f"""SELECT ss.id, ss.scraped_at
+            FROM scrape_snapshots ss
+            WHERE ss.status = 'analysis_failed'
+              {newer_than_current}
+              AND EXISTS (
+                  SELECT 1
+                  FROM {table_name} d
+                  WHERE d.snapshot_id = ss.id
+              )
+            ORDER BY datetime(ss.scraped_at) DESC, ss.id DESC
+            LIMIT 1""",
+        params,
+    )
+    if rows:
+        return rows[0]["id"], rows[0]["scraped_at"]
+    if current_snapshot_id is not None:
+        return current_snapshot_id, current_snapshot_at
+    if await _has_scrape_snapshots(db):
+        return None, None
+    snapshot_at = (
+        await _get_latest_unresolved_snapshot_at(db)
+        if table_name == "unresolved_odds"
+        else await _get_latest_team_review_snapshot_at(db)
+    )
+    return _snapshot_id_from_scraped_at(snapshot_at) if snapshot_at else None, snapshot_at
 
 
 async def _get_team_review_snapshot_at(db: aiosqlite.Connection) -> str | None:
@@ -822,7 +871,7 @@ async def persist_scrape_snapshot_batch(
 
 
 async def publish_scrape_snapshot(*, snapshot_id: str, snapshot_at: str) -> None:
-    db = await get_db()
+    db = await _open_isolated_db_connection()
     try:
         await db.execute("BEGIN IMMEDIATE")
         await db.execute(
@@ -851,6 +900,31 @@ async def publish_scrape_snapshot(*, snapshot_id: str, snapshot_at: str) -> None
     except Exception:
         await db.rollback()
         raise
+    finally:
+        await db.close()
+
+
+async def mark_scrape_snapshot_analysis_failed(
+    *, snapshot_id: str, snapshot_at: str, error: str | None = None
+) -> None:
+    db = await _open_isolated_db_connection()
+    try:
+        await db.execute("BEGIN IMMEDIATE")
+        await db.execute(
+            """UPDATE scrape_snapshots
+               SET status = 'analysis_failed',
+                   completed_at = ?,
+                   error = ?,
+                   updated_at = CURRENT_TIMESTAMP
+               WHERE id = ?""",
+            (snapshot_at, error, snapshot_id),
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    finally:
+        await db.close()
 
 
 async def get_matches(
@@ -884,15 +958,15 @@ async def get_matches(
         if bookmaker_ids:
             params.extend(bookmaker_ids)
         q = f"""SELECT m.id,
-                       COALESCE(sm.league_id, m.league_id) AS league_id,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END AS league_id,
                        l.name as league_name,
-                       COALESCE(sm.sport, m.sport) AS sport,
-                       COALESCE(sm.home_team_id, m.home_team_id) AS home_team_id,
-                       COALESCE(sm.away_team_id, m.away_team_id) AS away_team_id,
-                       COALESCE(sm.home_team, m.home_team) AS home_team,
-                       COALESCE(sm.away_team, m.away_team) AS away_team,
-                       COALESCE(sm.start_time, m.start_time) AS start_time,
-                       COALESCE(sm.status, m.status) AS status,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.sport ELSE m.sport END AS sport,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team_id ELSE m.home_team_id END AS home_team_id,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team_id ELSE m.away_team_id END AS away_team_id,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team ELSE m.home_team END AS home_team,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team ELSE m.away_team END AS away_team,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END AS start_time,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.status ELSE m.status END AS status,
                         (
                             SELECT rem.resolved_event_id
                             FROM resolved_event_members rem
@@ -918,10 +992,11 @@ async def get_matches(
                            rem.resolved_event_id ASC
                            LIMIT 1
                        ) AS resolved_event_id
-               FROM matches m
-               LEFT JOIN snapshot_matches sm
-                 ON sm.snapshot_id = ? AND sm.match_id = m.id
-               LEFT JOIN leagues l ON COALESCE(sm.league_id, m.league_id) = l.id
+                FROM matches m
+                LEFT JOIN snapshot_matches sm
+                  ON sm.snapshot_id = ? AND sm.match_id = m.id
+                LEFT JOIN leagues l
+                  ON CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END = l.id
                WHERE m.id IN (
                    SELECT o.match_id
                    FROM odds o
@@ -970,24 +1045,27 @@ async def get_matches(
                )"""
     if league_id:
         if current_snapshot_id is not None:
-            q += " AND COALESCE(sm.league_id, m.league_id) = ?"
+            q += " AND CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END = ?"
         else:
             q += " AND m.league_id = ?"
         params.append(league_id)
     if sport:
         if current_snapshot_id is not None:
-            q += " AND COALESCE(sm.sport, m.sport) = ?"
+            q += " AND CASE WHEN sm.match_id IS NOT NULL THEN sm.sport ELSE m.sport END = ?"
         else:
             q += " AND m.sport = ?"
         params.append(sport)
     if status:
         if current_snapshot_id is not None:
-            q += " AND COALESCE(sm.status, m.status) = ?"
+            q += " AND CASE WHEN sm.match_id IS NOT NULL THEN sm.status ELSE m.status END = ?"
         else:
             q += " AND m.status = ?"
         params.append(status)
     if current_snapshot_id is not None:
-        q += " ORDER BY COALESCE(sm.start_time, m.start_time) ASC LIMIT ? OFFSET ?"
+        q += (
+            " ORDER BY CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END ASC "
+            "LIMIT ? OFFSET ?"
+        )
     else:
         q += " ORDER BY m.start_time ASC LIMIT ? OFFSET ?"
     params.extend([limit, offset])
@@ -1038,15 +1116,15 @@ async def get_match(
             params.extend([current_snapshot_id, current_snapshot_id])
         row = await db.execute_fetchall(
             f"""SELECT m.id,
-                      COALESCE(sm.league_id, m.league_id) AS league_id,
-                      l.name as league_name,
-                      COALESCE(sm.sport, m.sport) AS sport,
-                      COALESCE(sm.home_team_id, m.home_team_id) AS home_team_id,
-                      COALESCE(sm.away_team_id, m.away_team_id) AS away_team_id,
-                      COALESCE(sm.home_team, m.home_team) AS home_team,
-                      COALESCE(sm.away_team, m.away_team) AS away_team,
-                      COALESCE(sm.start_time, m.start_time) AS start_time,
-                      COALESCE(sm.status, m.status) AS status,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END AS league_id,
+                       l.name as league_name,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.sport ELSE m.sport END AS sport,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team_id ELSE m.home_team_id END AS home_team_id,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team_id ELSE m.away_team_id END AS away_team_id,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team ELSE m.home_team END AS home_team,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team ELSE m.away_team END AS away_team,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END AS start_time,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.status ELSE m.status END AS status,
                       (
                           SELECT rem.resolved_event_id
                           FROM resolved_event_members rem
@@ -1075,8 +1153,9 @@ async def get_match(
                FROM matches m
                LEFT JOIN snapshot_matches sm
                  ON sm.snapshot_id = ? AND sm.match_id = m.id
-               LEFT JOIN leagues l ON COALESCE(sm.league_id, m.league_id) = l.id
-               WHERE m.id = ?{visibility_clause}""",
+                LEFT JOIN leagues l
+                  ON CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END = l.id
+                WHERE m.id = ?{visibility_clause}""",
             params,
         )
     else:
@@ -1869,6 +1948,8 @@ async def _get_event_review_case_variants_tx(
 ) -> list[EventReviewVariantOut]:
     variants: list[EventReviewVariantOut] = []
     seen: set[tuple[str, str | None]] = set()
+    current_snapshot_id = await _get_current_snapshot_id(db)
+    has_snapshot_mode = await _has_scrape_snapshots(db)
 
     resolved_event_ids = list(
         dict.fromkeys(
@@ -1878,16 +1959,34 @@ async def _get_event_review_case_variants_tx(
         )
     )
     for resolved_event_id in resolved_event_ids:
+        if current_snapshot_id is not None:
+            member_snapshot_clause = "AND rem.snapshot_id = ?"
+            member_params: list[object] = [current_snapshot_id]
+            member_order = ""
+            member_order_params: list[object] = []
+            member_metadata_clause = "AND sm.match_id IS NOT NULL"
+        elif has_snapshot_mode:
+            member_snapshot_clause = "AND 1 = 0"
+            member_params = []
+            member_order = ""
+            member_order_params = []
+            member_metadata_clause = ""
+        else:
+            member_snapshot_clause = "AND rem.snapshot_id IS NULL"
+            member_params = []
+            member_order = ""
+            member_order_params = []
+            member_metadata_clause = ""
         rows = await db.execute_fetchall(
-            """SELECT rem.match_id,
+            f"""SELECT rem.match_id,
                       rem.bookmaker_id,
                       b.name AS bookmaker_name,
-                      m.league_id,
-                      l.name AS league_name,
-                      m.home_team,
-                      m.away_team,
-                      m.start_time,
-                      rem.source_url,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END AS league_id,
+                       l.name AS league_name,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team ELSE m.home_team END AS home_team,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team ELSE m.away_team END AS away_team,
+                       CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END AS start_time,
+                       rem.source_url,
                       rem.source_league_id,
                       rem.source_league_name,
                       rem.source_home_team,
@@ -1899,10 +1998,30 @@ async def _get_event_review_case_variants_tx(
                FROM resolved_event_members rem
                LEFT JOIN bookmakers b ON b.id = rem.bookmaker_id
                LEFT JOIN matches m ON m.id = rem.match_id
-               LEFT JOIN leagues l ON l.id = m.league_id
+               LEFT JOIN snapshot_matches sm
+                 ON sm.snapshot_id = ? AND sm.match_id = m.id
+               LEFT JOIN leagues l
+                 ON l.id = CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END
                WHERE rem.resolved_event_id = ?
-               ORDER BY rem.id ASC""",
-            (resolved_event_id,),
+                 {member_snapshot_clause}
+                 {member_metadata_clause}
+               ORDER BY CASE
+                   WHEN EXISTS (
+                       SELECT 1
+                       FROM resolved_events re
+                       WHERE re.id = rem.resolved_event_id
+                         AND re.method IN ('manual', 'manual_review')
+                   ) THEN 0
+                   ELSE 1
+               END,
+               {member_order}
+               rem.id ASC""",
+            [
+                current_snapshot_id,
+                resolved_event_id,
+                *member_params,
+                *member_order_params,
+            ],
         )
         for row in rows:
             key = (row["match_id"], row["bookmaker_id"])
@@ -1919,46 +2038,53 @@ async def _get_event_review_case_variants_tx(
             if match_id
         )
     )
-    if candidate_match_ids:
-        current_snapshot_id = await _get_current_snapshot_id(db)
+    if candidate_match_ids and not (has_snapshot_mode and current_snapshot_id is None):
         placeholders = _sql_placeholders(candidate_match_ids)
         if current_snapshot_id is not None:
             source_snapshot_clause = "AND s.snapshot_id = ?"
             source_params: list[object] = [current_snapshot_id]
+            match_metadata_clause = "AND sm.match_id IS NOT NULL"
         elif await _has_scrape_snapshots(db):
             source_snapshot_clause = "AND 1 = 0"
             source_params = []
+            match_metadata_clause = ""
         else:
             source_snapshot_clause = "AND s.snapshot_id IS NULL"
             source_params = []
+            match_metadata_clause = ""
         rows = await db.execute_fetchall(
             f"""SELECT m.id AS match_id,
                         s.bookmaker_id,
                         b.name AS bookmaker_name,
-                        m.league_id,
-                       l.name AS league_name,
-                       m.home_team,
-                       m.away_team,
-                       m.start_time,
-                       s.source_url,
-                       NULL AS source_league_id,
-                       l.name AS source_league_name,
-                       m.home_team AS source_home_team,
-                       m.away_team AS source_away_team,
-                       m.start_time AS source_start_time,
-                       'as_listed' AS orientation,
-                       NULL AS member_confidence,
-                       '[]' AS member_evidence
-                FROM matches m
-                LEFT JOIN leagues l ON l.id = m.league_id
-                LEFT JOIN match_bookmaker_sources s
-                  ON s.match_id = m.id
-                 {source_snapshot_clause}
-                LEFT JOIN bookmakers b ON b.id = s.bookmaker_id
-                WHERE m.id IN ({placeholders})
-                ORDER BY m.start_time ASC, m.id ASC, s.bookmaker_id ASC,
-                         s.id ASC""",
-            [*source_params, *candidate_match_ids],
+                        CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END AS league_id,
+                        l.name AS league_name,
+                        CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team ELSE m.home_team END AS home_team,
+                        CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team ELSE m.away_team END AS away_team,
+                        CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END AS start_time,
+                        s.source_url,
+                        NULL AS source_league_id,
+                        l.name AS source_league_name,
+                        CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team ELSE m.home_team END AS source_home_team,
+                        CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team ELSE m.away_team END AS source_away_team,
+                        CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END AS source_start_time,
+                        'as_listed' AS orientation,
+                        NULL AS member_confidence,
+                        '[]' AS member_evidence
+                 FROM matches m
+                 LEFT JOIN snapshot_matches sm
+                   ON sm.snapshot_id = ? AND sm.match_id = m.id
+                 LEFT JOIN leagues l
+                   ON l.id = CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END
+                 LEFT JOIN match_bookmaker_sources s
+                   ON s.match_id = m.id
+                  {source_snapshot_clause}
+                 LEFT JOIN bookmakers b ON b.id = s.bookmaker_id
+                 WHERE m.id IN ({placeholders})
+                   {match_metadata_clause}
+                 ORDER BY CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END ASC,
+                          m.id ASC, s.bookmaker_id ASC,
+                          s.id ASC""",
+            [current_snapshot_id, *source_params, *candidate_match_ids],
         )
         for row in rows:
             key = (row["match_id"], row["bookmaker_id"])
@@ -1994,15 +2120,19 @@ async def _get_event_review_case_variants_tx(
             bookmaker_names = {row["id"]: row["name"] for row in bookmaker_rows}
             match_rows = await db.execute_fetchall(
                 f"""SELECT m.id AS match_id,
-                           m.league_id,
+                           CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END AS league_id,
                            l.name AS league_name,
-                           m.home_team,
-                           m.away_team,
-                           m.start_time
+                           CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team ELSE m.home_team END AS home_team,
+                           CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team ELSE m.away_team END AS away_team,
+                           CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END AS start_time
                     FROM matches m
-                    LEFT JOIN leagues l ON l.id = m.league_id
-                    WHERE m.id IN ({placeholders})""",
-                candidate_match_ids,
+                    LEFT JOIN snapshot_matches sm
+                      ON sm.snapshot_id = ? AND sm.match_id = m.id
+                    LEFT JOIN leagues l
+                      ON l.id = CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END
+                    WHERE m.id IN ({placeholders})
+                      {match_metadata_clause}""",
+                [current_snapshot_id, *candidate_match_ids],
             )
             match_map = {row["match_id"]: _row_to_dict(row) for row in match_rows}
 
@@ -2505,19 +2635,19 @@ async def _get_normalized_odds_for_matches_snapshot(
     rows = await db.execute_fetchall(
         f"""SELECT o.match_id,
                    o.bookmaker_id,
-                   COALESCE(sm.league_id, m.league_id) AS league_id,
-                   COALESCE(sm.sport, m.sport) AS sport,
-                   COALESCE(sm.home_team_id, m.home_team_id, 0) AS home_team_id,
-                   COALESCE(sm.away_team_id, m.away_team_id, 0) AS away_team_id,
-                   COALESCE(sm.home_team, m.home_team) AS home_team,
-                   COALESCE(sm.away_team, m.away_team) AS away_team,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END AS league_id,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.sport ELSE m.sport END AS sport,
+                   CASE WHEN sm.match_id IS NOT NULL THEN COALESCE(sm.home_team_id, 0) ELSE COALESCE(m.home_team_id, 0) END AS home_team_id,
+                   CASE WHEN sm.match_id IS NOT NULL THEN COALESCE(sm.away_team_id, 0) ELSE COALESCE(m.away_team_id, 0) END AS away_team_id,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team ELSE m.home_team END AS home_team,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team ELSE m.away_team END AS away_team,
                    s.source_url AS source_url,
                    o.market_type,
                    o.player_name,
                    o.threshold,
                    o.over_odds,
                    o.under_odds,
-                   COALESCE(sm.start_time, m.start_time) AS start_time,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END AS start_time,
                    o.scraped_at
             FROM odds o
             JOIN matches m ON m.id = o.match_id
@@ -2528,7 +2658,8 @@ async def _get_normalized_odds_for_matches_snapshot(
              AND COALESCE(s.snapshot_id, '') = COALESCE(o.snapshot_id, '')
             WHERE o.match_id IN ({placeholders})
               AND {snapshot_filter}
-            ORDER BY COALESCE(sm.start_time, m.start_time) ASC, o.match_id ASC, o.bookmaker_id ASC,
+            ORDER BY CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END ASC,
+                     o.match_id ASC, o.bookmaker_id ASC,
                      o.market_type ASC, o.player_name ASC, o.threshold ASC""",
         [*metadata_params, *selected_match_ids, *snapshot_params],
     )
@@ -2577,19 +2708,19 @@ async def _get_normalized_outcome_offers_for_matches_snapshot(
     rows = await db.execute_fetchall(
         f"""SELECT o.match_id,
                    o.bookmaker_id,
-                   COALESCE(sm.league_id, m.league_id) AS league_id,
-                   COALESCE(sm.sport, m.sport) AS sport,
-                   COALESCE(sm.home_team_id, m.home_team_id, 0) AS home_team_id,
-                   COALESCE(sm.away_team_id, m.away_team_id, 0) AS away_team_id,
-                   COALESCE(sm.home_team, m.home_team) AS home_team,
-                   COALESCE(sm.away_team, m.away_team) AS away_team,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END AS league_id,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.sport ELSE m.sport END AS sport,
+                   CASE WHEN sm.match_id IS NOT NULL THEN COALESCE(sm.home_team_id, 0) ELSE COALESCE(m.home_team_id, 0) END AS home_team_id,
+                   CASE WHEN sm.match_id IS NOT NULL THEN COALESCE(sm.away_team_id, 0) ELSE COALESCE(m.away_team_id, 0) END AS away_team_id,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team ELSE m.home_team END AS home_team,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team ELSE m.away_team END AS away_team,
                    s.source_url AS source_url,
                    o.market_type,
                    o.outcome_code,
                    o.odds,
                    o.line,
                    o.raw_label,
-                   COALESCE(sm.start_time, m.start_time) AS start_time,
+                   CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END AS start_time,
                    o.scraped_at
             FROM outcome_offers o
             JOIN matches m ON m.id = o.match_id
@@ -2600,7 +2731,8 @@ async def _get_normalized_outcome_offers_for_matches_snapshot(
              AND COALESCE(s.snapshot_id, '') = COALESCE(o.snapshot_id, '')
             WHERE o.match_id IN ({placeholders})
               AND {snapshot_filter}
-            ORDER BY COALESCE(sm.start_time, m.start_time) ASC, o.match_id ASC, o.bookmaker_id ASC,
+            ORDER BY CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END ASC,
+                     o.match_id ASC, o.bookmaker_id ASC,
                      o.market_type ASC, o.line ASC, o.outcome_code ASC""",
         [*metadata_params, *selected_match_ids, *snapshot_params],
     )
@@ -2901,7 +3033,7 @@ async def get_outcome_offers(
     params: list[object] = [current_snapshot_id, *snapshot_params]
 
     if sport:
-        conditions.append("COALESCE(sm.sport, m.sport) = ?")
+        conditions.append("CASE WHEN sm.match_id IS NOT NULL THEN sm.sport ELSE m.sport END = ?")
         params.append(sport)
     if match_id:
         conditions.append("o.match_id = ?")
@@ -2916,7 +3048,7 @@ async def get_outcome_offers(
 
     q += " WHERE " + " AND ".join(conditions)
     q += (
-        " ORDER BY COALESCE(sm.start_time, m.start_time) ASC, "
+        " ORDER BY CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END ASC, "
         "o.market_type ASC, o.line ASC, o.outcome_code ASC LIMIT ? OFFSET ?"
     )
     params.extend([limit, offset])
@@ -3002,7 +3134,7 @@ async def publish_opportunities(
     detected_at: str,
 ) -> str:
     publish_id = _new_opportunity_publish_id(detected_at)
-    db = await get_db()
+    db = await _open_isolated_db_connection()
     try:
         await db.execute("BEGIN IMMEDIATE")
         await db.execute(
@@ -3087,6 +3219,8 @@ async def publish_opportunities(
     except Exception:
         await db.rollback()
         raise
+    finally:
+        await db.close()
     return publish_id
 
 
@@ -3121,9 +3255,9 @@ async def get_opportunities(
     current_publish_id = await _get_current_opportunity_publish_id(db)
     current_snapshot_id = await _get_current_snapshot_id(db)
     q = """SELECT op.*,
-                  COALESCE(sm.home_team, m.home_team) AS home_team,
-                  COALESCE(sm.away_team, m.away_team) AS away_team,
-                  COALESCE(sm.start_time, m.start_time) AS start_time,
+                  CASE WHEN sm.match_id IS NOT NULL THEN sm.home_team ELSE m.home_team END AS home_team,
+                  CASE WHEN sm.match_id IS NOT NULL THEN sm.away_team ELSE m.away_team END AS away_team,
+                  CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END AS start_time,
                   l.name AS league_name
            FROM opportunities op
            LEFT JOIN opportunity_publishes pub ON pub.id = op.publish_id
@@ -3131,7 +3265,8 @@ async def get_opportunities(
            LEFT JOIN snapshot_matches sm
              ON sm.snapshot_id = COALESCE(pub.snapshot_id, ?)
             AND sm.match_id = op.match_id
-           LEFT JOIN leagues l ON l.id = COALESCE(sm.league_id, m.league_id)"""
+           LEFT JOIN leagues l
+             ON l.id = CASE WHEN sm.match_id IS NOT NULL THEN sm.league_id ELSE m.league_id END"""
     if current_publish_id is not None:
         conditions = ["op.publish_id = ?", "op.is_active = TRUE"]
         params: list[object] = [current_snapshot_id, current_publish_id]
@@ -3157,7 +3292,7 @@ async def get_opportunities(
         params.extend(bookmaker_ids)
     q += " WHERE " + " AND ".join(conditions)
     q += """ ORDER BY COALESCE(op.profit_margin, -999) DESC,
-                    COALESCE(sm.start_time, m.start_time) ASC,
+                    CASE WHEN sm.match_id IS NOT NULL THEN sm.start_time ELSE m.start_time END ASC,
                     op.id ASC
              LIMIT ? OFFSET ?"""
     params.extend([limit, offset])
@@ -3308,11 +3443,7 @@ async def get_unresolved_odds(
     offset: int = 0,
 ) -> list[UnresolvedOddsOut]:
     db = await get_db()
-    snapshot_id = await _get_current_snapshot_id(db)
-    snapshot_at = await _get_current_snapshot_at(db)
-    if snapshot_id is None:
-        snapshot_at = await _get_latest_unresolved_snapshot_at(db)
-        snapshot_id = _snapshot_id_from_scraped_at(snapshot_at) if snapshot_at else None
+    snapshot_id, snapshot_at = await _get_visible_diagnostic_snapshot(db, "unresolved_odds")
     if snapshot_at is None:
         return []
 
@@ -3425,8 +3556,7 @@ async def get_team_review_cases(
     offset: int = 0,
 ) -> list[TeamReviewOut]:
     db = await get_db()
-    snapshot_id = await _get_current_snapshot_id(db)
-    snapshot_at = await _get_team_review_snapshot_at(db)
+    snapshot_id, snapshot_at = await _get_visible_diagnostic_snapshot(db, "team_review_cases")
     if snapshot_at is None:
         return []
 
@@ -3434,8 +3564,6 @@ async def get_team_review_cases(
            FROM team_review_cases c
            LEFT JOIN bookmakers b ON c.bookmaker_id = b.id
            LEFT JOIN leagues l ON c.scope_league_id = l.id"""
-    if snapshot_id is None:
-        snapshot_id = _snapshot_id_from_scraped_at(snapshot_at)
     conditions = ["c.snapshot_id = ?" if snapshot_id else "c.scraped_at = ?"]
     params: list[object] = [snapshot_id or snapshot_at]
 
@@ -3603,8 +3731,7 @@ def _retention_cutoff(snapshot_at: str, days: int) -> str:
 
 
 async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
-    db = await aiosqlite.connect(settings.db_path)
-    db.row_factory = aiosqlite.Row
+    db = await _open_isolated_db_connection()
     try:
         await db.execute("BEGIN IMMEDIATE")
         published_snapshot_id, published_snapshot_at = await _get_current_snapshot(db)
@@ -3612,42 +3739,60 @@ async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
         preserved_snapshot_id = published_snapshot_id or _snapshot_id_from_scraped_at(
             current_snapshot_at
         )
+        preserved_snapshot_ids = [preserved_snapshot_id]
+        newer_failure_params: list[object] = []
+        newer_failure_clause = ""
+        if published_snapshot_at is not None:
+            newer_failure_clause = "AND datetime(scraped_at) > datetime(?)"
+            newer_failure_params.append(published_snapshot_at)
+        failed_snapshot_rows = await db.execute_fetchall(
+            f"""SELECT id
+                FROM scrape_snapshots
+                WHERE status = 'analysis_failed'
+                  {newer_failure_clause}
+                ORDER BY datetime(scraped_at) DESC, id DESC
+                LIMIT 1""",
+            newer_failure_params,
+        )
+        if failed_snapshot_rows and failed_snapshot_rows[0]["id"] not in preserved_snapshot_ids:
+            preserved_snapshot_ids.append(failed_snapshot_rows[0]["id"])
+        preserved_snapshot_placeholders = _sql_placeholders(preserved_snapshot_ids)
         retention_anchor_at = published_snapshot_at or current_snapshot_at
         deleted_stale_odds_cur = await db.execute(
-            """DELETE FROM odds
+            f"""DELETE FROM odds
                WHERE COALESCE(snapshot_id, scraped_at) IS NULL
-                   OR COALESCE(snapshot_id, scraped_at) != ?""",
-            (preserved_snapshot_id,),
+                    OR COALESCE(snapshot_id, scraped_at) NOT IN ({preserved_snapshot_placeholders})""",
+            preserved_snapshot_ids,
         )
         await db.execute(
-            """DELETE FROM outcome_offers
+            f"""DELETE FROM outcome_offers
                WHERE COALESCE(snapshot_id, scraped_at) IS NULL
-                  OR COALESCE(snapshot_id, scraped_at) != ?""",
-            (preserved_snapshot_id,),
+                   OR COALESCE(snapshot_id, scraped_at) NOT IN ({preserved_snapshot_placeholders})""",
+            preserved_snapshot_ids,
         )
         deleted_unresolved_cur = await db.execute(
-            """DELETE FROM unresolved_odds
+            f"""DELETE FROM unresolved_odds
                WHERE COALESCE(snapshot_id, scraped_at) IS NULL
-                  OR COALESCE(snapshot_id, scraped_at) != ?""",
-            (preserved_snapshot_id,),
+                   OR COALESCE(snapshot_id, scraped_at) NOT IN ({preserved_snapshot_placeholders})""",
+            preserved_snapshot_ids,
         )
         await db.execute(
-            """DELETE FROM snapshot_matches
+            f"""DELETE FROM snapshot_matches
                WHERE snapshot_id IS NULL
-                  OR snapshot_id != ?""",
-            (preserved_snapshot_id,),
+                   OR snapshot_id NOT IN ({preserved_snapshot_placeholders})""",
+            preserved_snapshot_ids,
         )
         deleted_match_sources_cur = await db.execute(
-            """DELETE FROM match_bookmaker_sources
+            f"""DELETE FROM match_bookmaker_sources
                WHERE snapshot_id IS NOT NULL
-                 AND snapshot_id != ?""",
-            (preserved_snapshot_id,),
+                  AND snapshot_id NOT IN ({preserved_snapshot_placeholders})""",
+            preserved_snapshot_ids,
         )
         deleted_resolved_event_members_cur = await db.execute(
-            """DELETE FROM resolved_event_members
+            f"""DELETE FROM resolved_event_members
                WHERE snapshot_id IS NOT NULL
-                 AND snapshot_id != ?""",
-            (preserved_snapshot_id,),
+                  AND snapshot_id NOT IN ({preserved_snapshot_placeholders})""",
+            preserved_snapshot_ids,
         )
         if current_publish_id is not None:
             deleted_opportunities_cur = await db.execute(
@@ -3672,33 +3817,33 @@ async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
                 retention_anchor_at, settings.odds_history_retention_days
             )
             deleted_odds_history_cur = await db.execute(
-                """
+                f"""
                 DELETE FROM odds_history
                 WHERE scraped_at IS NOT NULL
                   AND datetime(scraped_at) < datetime(?)
                   AND (
-                      COALESCE(snapshot_id, scraped_at) IS NULL
-                      OR COALESCE(snapshot_id, scraped_at) != ?
-                  )
+                       COALESCE(snapshot_id, scraped_at) IS NULL
+                       OR COALESCE(snapshot_id, scraped_at) NOT IN ({preserved_snapshot_placeholders})
+                   )
                 """,
-                (odds_history_cutoff, preserved_snapshot_id),
+                [odds_history_cutoff, *preserved_snapshot_ids],
             )
         else:
             deleted_odds_history_cur = await db.execute(
-                """DELETE FROM odds_history
+                f"""DELETE FROM odds_history
                    WHERE COALESCE(snapshot_id, scraped_at) IS NULL
-                      OR COALESCE(snapshot_id, scraped_at) != ?""",
-                (preserved_snapshot_id,),
+                       OR COALESCE(snapshot_id, scraped_at) NOT IN ({preserved_snapshot_placeholders})""",
+                preserved_snapshot_ids,
             )
         deleted_scrape_snapshots_cur = await db.execute(
-            """DELETE FROM scrape_snapshots
-               WHERE id != ?
+            f"""DELETE FROM scrape_snapshots
+               WHERE id NOT IN ({preserved_snapshot_placeholders})
                  AND NOT EXISTS (
                      SELECT 1
                      FROM odds_history h
                      WHERE COALESCE(h.snapshot_id, h.scraped_at) = scrape_snapshots.id
                  )""",
-            (preserved_snapshot_id,),
+            preserved_snapshot_ids,
         )
 
         if settings.team_review_retention_days > 0:
@@ -3706,23 +3851,23 @@ async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
                 retention_anchor_at, settings.team_review_retention_days
             )
             deleted_team_reviews_cur = await db.execute(
-                """
+                f"""
                 DELETE FROM team_review_cases
                 WHERE scraped_at IS NOT NULL
                   AND datetime(scraped_at) < datetime(?)
                   AND (
-                      COALESCE(snapshot_id, scraped_at) IS NULL
-                      OR COALESCE(snapshot_id, scraped_at) != ?
-                  )
+                       COALESCE(snapshot_id, scraped_at) IS NULL
+                       OR COALESCE(snapshot_id, scraped_at) NOT IN ({preserved_snapshot_placeholders})
+                   )
                 """,
-                (team_review_cutoff, preserved_snapshot_id),
+                [team_review_cutoff, *preserved_snapshot_ids],
             )
         else:
             deleted_team_reviews_cur = await db.execute(
-                """DELETE FROM team_review_cases
+                f"""DELETE FROM team_review_cases
                    WHERE COALESCE(snapshot_id, scraped_at) IS NULL
-                      OR COALESCE(snapshot_id, scraped_at) != ?""",
-                (preserved_snapshot_id,),
+                       OR COALESCE(snapshot_id, scraped_at) NOT IN ({preserved_snapshot_placeholders})""",
+                preserved_snapshot_ids,
             )
 
         if settings.persist_inapp_notifications and settings.notification_retention_days > 0:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -648,6 +648,37 @@ async def test_match_history(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_match_history_hides_first_unpublished_snapshot(client: AsyncClient):
+    snapshot_at = "2026-04-11T20:06:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="hidden-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Hidden Home",
+                away_team="Hidden Away",
+                market_type="player_points",
+                player_name="Hidden Player",
+                threshold=13.5,
+                over_odds=2.1,
+                under_odds=1.7,
+                start_time="2026-04-11T22:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+
+    resp = await client.get("/api/v1/matches/hidden-match/history")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_discrepancy_api_removed(client: AsyncClient):
     list_resp = await client.get("/api/v1/discrepancies")
     assert list_resp.status_code == 404

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -9,6 +9,7 @@ import pytest
 from app.config import settings
 from app.models.schemas import (
     NormalizedOdds,
+    NormalizedOutcomeOffer,
     OpportunityLeg,
     RawOddsData,
     RawOutcomeOffer,
@@ -735,10 +736,10 @@ async def test_scheduler_shadow_analysis_handles_tennis_outcome_offers(
 
 
 @pytest.mark.asyncio
-async def test_scheduler_canonical_analysis_failure_deactivates_stale_opportunities(
+async def test_scheduler_canonical_analysis_failure_preserves_stale_opportunities(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    async def fail_canonical_analysis(match_ids: set[str]):
+    async def fail_canonical_analysis(match_ids: set[str], **kwargs):
         raise RuntimeError("canonical boom")
 
     monkeypatch.setattr(
@@ -748,41 +749,59 @@ async def test_scheduler_canonical_analysis_failure_deactivates_stale_opportunit
     await odds_store.upsert_league("premier-league", "Premier League", "football")
     await odds_store.upsert_bookmaker("maxbet", "MaxBet")
     await odds_store.upsert_bookmaker("balkanbet", "BalkanBet")
-    await odds_store.upsert_match(
-        id="stale-football-match",
-        league_id="premier-league",
-        sport="football",
-        home_team="Arsenal",
-        away_team="Chelsea",
-        start_time="2030-01-01T20:00:00+00:00",
+    stale_snapshot_at = "2029-01-01T00:00:00"
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=stale_snapshot_at,
+        odds=[],
+        outcome_offers=[
+            NormalizedOutcomeOffer(
+                match_id="stale-football-match",
+                bookmaker_id="maxbet",
+                league_id="premier-league",
+                sport="football",
+                home_team="Arsenal",
+                away_team="Chelsea",
+                market_type="football_total_goals",
+                outcome_code="under",
+                odds=1.95,
+                line=2.5,
+                start_time="2030-01-01T20:00:00+00:00",
+            )
+        ],
+        unresolved_odds=[],
+        team_review_cases=[],
     )
-    await odds_store.insert_opportunity(
-        Opportunity(
-            sport="football",
-            match_id="stale-football-match",
-            opportunity_type="same_line_arbitrage",
-            market_type="football_total_goals",
-            line=2.5,
-            profit_margin=0.02,
-            middle_profit_margin=None,
-            legs=[
-                OpportunityLeg(
-                    bookmaker_id="maxbet",
-                    market_type="football_total_goals",
-                    outcome_code="under",
-                    line=2.5,
-                    odds=1.95,
-                ),
-                OpportunityLeg(
-                    bookmaker_id="balkanbet",
-                    market_type="football_total_goals",
-                    outcome_code="over",
-                    line=2.5,
-                    odds=2.10,
-                ),
-            ],
-        ),
-        detected_at="2029-01-01T00:00:00",
+    await odds_store.publish_opportunities(
+        snapshot_id=stale_snapshot_at,
+        snapshot_at=stale_snapshot_at,
+        opportunities=[
+            Opportunity(
+                sport="football",
+                match_id="stale-football-match",
+                opportunity_type="same_line_arbitrage",
+                market_type="football_total_goals",
+                line=2.5,
+                profit_margin=0.02,
+                middle_profit_margin=None,
+                legs=[
+                    OpportunityLeg(
+                        bookmaker_id="maxbet",
+                        market_type="football_total_goals",
+                        outcome_code="under",
+                        line=2.5,
+                        odds=1.95,
+                    ),
+                    OpportunityLeg(
+                        bookmaker_id="balkanbet",
+                        market_type="football_total_goals",
+                        outcome_code="over",
+                        line=2.5,
+                        odds=2.10,
+                    ),
+                ],
+            )
+        ],
+        detected_at=stale_snapshot_at,
     )
     _register_test_scrapers(
         StubScraper(
@@ -800,7 +819,13 @@ async def test_scheduler_canonical_analysis_failure_deactivates_stale_opportunit
     assert result["opportunities_found"] == 0
     assert result["canonical_shadow_warnings"] == ["canonical_analysis_failed"]
     assert await odds_store.get_opportunities(sport="basketball") == []
-    assert await odds_store.get_opportunities(sport="football") == []
+    assert await odds_store.get_opportunities(sport="football")
+    assert [match.id for match in await odds_store.get_matches(sport="football")] == [
+        "stale-football-match"
+    ]
+    assert [
+        offer.match_id for offer in await odds_store.get_outcome_offers(sport="football")
+    ] == ["stale-football-match"]
 
 
 @pytest.mark.asyncio
@@ -1305,17 +1330,14 @@ async def test_scheduler_run_cycle_keeps_previous_snapshot_if_store_fails_mid_ba
     )
     await odds_store.set_current_snapshot("2026-04-10T13:39:04.516801")
 
-    original_upsert_odds = odds_store.upsert_odds
-    call_count = 0
+    async def failing_persist_scrape_snapshot_batch(**kwargs):
+        raise RuntimeError("simulated store failure")
 
-    async def failing_upsert_odds(odds, *, scraped_at):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 2:
-            raise RuntimeError("simulated store failure")
-        return await original_upsert_odds(odds, scraped_at=scraped_at)
-
-    monkeypatch.setattr(odds_store, "upsert_odds", failing_upsert_odds)
+    monkeypatch.setattr(
+        odds_store,
+        "persist_scrape_snapshot_batch",
+        failing_persist_scrape_snapshot_batch,
+    )
 
     _register_test_scrapers(
         StubScraper(
@@ -2114,17 +2136,14 @@ async def test_scheduler_run_cycle_rolls_back_auto_saved_alias_if_store_fails(
         ),
     )
 
-    original_upsert_odds = odds_store.upsert_odds
-    call_count = 0
+    async def failing_persist_scrape_snapshot_batch(**kwargs):
+        raise RuntimeError("simulated store failure")
 
-    async def failing_upsert_odds(odds, *, scraped_at):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 2:
-            raise RuntimeError("simulated store failure")
-        return await original_upsert_odds(odds, scraped_at=scraped_at)
-
-    monkeypatch.setattr(odds_store, "upsert_odds", failing_upsert_odds)
+    monkeypatch.setattr(
+        odds_store,
+        "persist_scrape_snapshot_batch",
+        failing_persist_scrape_snapshot_batch,
+    )
 
     with pytest.raises(RuntimeError, match="simulated store failure"):
         await Scheduler(interval_minutes=1).run_cycle()
@@ -2206,10 +2225,10 @@ async def test_scheduler_run_cycle_rolls_back_auto_merge_if_store_fails(
         target_away=target_away,
     )
 
-    async def failing_set_current_snapshot(snapshot_at: str) -> None:
+    async def failing_publish_opportunities(**kwargs) -> str:
         raise RuntimeError("simulated snapshot failure")
 
-    monkeypatch.setattr(odds_store, "set_current_snapshot", failing_set_current_snapshot)
+    monkeypatch.setattr(odds_store, "publish_opportunities", failing_publish_opportunities)
 
     with pytest.raises(RuntimeError, match="simulated snapshot failure"):
         await Scheduler(interval_minutes=1).run_cycle()
@@ -2247,7 +2266,7 @@ async def test_auto_merge_audit_cleanup_failure_does_not_block_canonical_rollbac
         target_away=target_away,
     )
 
-    async def failing_set_current_snapshot(snapshot_at: str) -> None:
+    async def failing_publish_opportunities(**kwargs) -> str:
         raise RuntimeError("simulated snapshot failure")
 
     async def failing_delete_team_review_cases(
@@ -2258,7 +2277,7 @@ async def test_auto_merge_audit_cleanup_failure_does_not_block_canonical_rollbac
         delete_called = True
         raise RuntimeError("simulated audit cleanup failure")
 
-    monkeypatch.setattr(odds_store, "set_current_snapshot", failing_set_current_snapshot)
+    monkeypatch.setattr(odds_store, "publish_opportunities", failing_publish_opportunities)
     monkeypatch.setattr(
         odds_store,
         "delete_team_review_cases",
@@ -2302,7 +2321,7 @@ async def test_auto_merge_audit_rows_remain_when_canonical_rollback_fails(
         target_away=target_away,
     )
 
-    async def failing_set_current_snapshot(snapshot_at: str) -> None:
+    async def failing_publish_opportunities(**kwargs) -> str:
         raise RuntimeError("simulated snapshot failure")
 
     async def failed_auto_merge_rollback(self, applied_merges):
@@ -2316,7 +2335,7 @@ async def test_auto_merge_audit_rows_remain_when_canonical_rollback_fails(
         delete_called = True
         return len(case_ids)
 
-    monkeypatch.setattr(odds_store, "set_current_snapshot", failing_set_current_snapshot)
+    monkeypatch.setattr(odds_store, "publish_opportunities", failing_publish_opportunities)
     monkeypatch.setattr(
         Scheduler,
         "_rollback_auto_applied_merges",
@@ -2421,17 +2440,17 @@ async def test_scheduler_run_cycle_ignores_unsnapshotted_review_history_for_auto
     )
     await odds_store.set_current_snapshot("2020-01-01T00:00:00+00:00")
 
-    original_set_current_snapshot = odds_store.set_current_snapshot
+    original_publish_opportunities = odds_store.publish_opportunities
     call_count = 0
 
-    async def flaky_set_current_snapshot(snapshot_at: str) -> None:
+    async def flaky_publish_opportunities(**kwargs) -> str:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             raise RuntimeError("simulated snapshot failure")
-        await original_set_current_snapshot(snapshot_at)
+        return await original_publish_opportunities(**kwargs)
 
-    monkeypatch.setattr(odds_store, "set_current_snapshot", flaky_set_current_snapshot)
+    monkeypatch.setattr(odds_store, "publish_opportunities", flaky_publish_opportunities)
 
     with pytest.raises(RuntimeError, match="simulated snapshot failure"):
         await Scheduler(interval_minutes=1).run_cycle()

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -59,6 +59,7 @@ async def test_upsert_and_get_match():
         ),
         scraped_at="2026-04-11T20:06:00.735723",
     )
+    await odds_store.set_current_snapshot("2026-04-11T20:06:00.735723")
     matches = await odds_store.get_matches()
     assert len(matches) == 1
     assert matches[0].home_team == "Partizan"
@@ -100,6 +101,7 @@ async def test_upsert_odds_and_history():
         under_odds=1.95,
     )
     await odds_store.upsert_odds(odds, scraped_at="2026-04-11T20:06:00.735723")
+    await odds_store.set_current_snapshot("2026-04-11T20:06:00.735723")
 
     current = await odds_store.get_odds_for_match("m1")
     assert len(current) == 1
@@ -339,10 +341,11 @@ async def test_current_canonical_offers_capture_snapshot_once(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_upsert_odds_preserves_existing_source_url_when_new_snapshot_has_none():
+async def test_upsert_odds_preserves_existing_source_url_within_snapshot():
     await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
     await odds_store.upsert_match("m1", "euroleague", "Partizan", "Crvena Zvezda")
     await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    snapshot_at = "2026-04-11T20:06:00.735723"
 
     await odds_store.upsert_odds(
         NormalizedOdds(
@@ -358,7 +361,7 @@ async def test_upsert_odds_preserves_existing_source_url_when_new_snapshot_has_n
             over_odds=1.85,
             under_odds=1.95,
         ),
-        scraped_at="2026-04-11T20:06:00.735723",
+        scraped_at=snapshot_at,
     )
     await odds_store.upsert_odds(
         NormalizedOdds(
@@ -374,9 +377,9 @@ async def test_upsert_odds_preserves_existing_source_url_when_new_snapshot_has_n
             over_odds=1.9,
             under_odds=1.9,
         ),
-        scraped_at="2026-04-11T20:11:00.735723",
+        scraped_at=snapshot_at,
     )
-    await odds_store.set_current_snapshot("2026-04-11T20:11:00.735723")
+    await odds_store.set_current_snapshot(snapshot_at)
 
     current = await odds_store.get_odds_for_match("m1")
 
@@ -417,8 +420,12 @@ async def test_get_matches_returns_only_latest_scrape_batch():
         under_odds=1.66,
     )
 
-    await odds_store.upsert_odds(stale_odds, scraped_at="2026-04-10T13:39:04.516801")
-    await odds_store.upsert_odds(fresh_odds, scraped_at="2026-04-11T20:06:00.735723")
+    stale_snapshot_at = "2026-04-10T13:39:04.516801"
+    fresh_snapshot_at = "2026-04-11T20:06:00.735723"
+    await odds_store.upsert_odds(stale_odds, scraped_at=stale_snapshot_at)
+    await odds_store.set_current_snapshot(stale_snapshot_at)
+    await odds_store.upsert_odds(fresh_odds, scraped_at=fresh_snapshot_at)
+    await odds_store.set_current_snapshot(fresh_snapshot_at)
 
     matches = await odds_store.get_matches()
 
@@ -519,8 +526,12 @@ async def test_get_odds_for_match_returns_only_latest_scrape_batch():
         under_odds=1.66,
     )
 
-    await odds_store.upsert_odds(stale_odds, scraped_at="2026-04-10T13:39:04.516801")
-    await odds_store.upsert_odds(fresh_odds, scraped_at="2026-04-11T20:06:00.735723")
+    stale_snapshot_at = "2026-04-10T13:39:04.516801"
+    fresh_snapshot_at = "2026-04-11T20:06:00.735723"
+    await odds_store.upsert_odds(stale_odds, scraped_at=stale_snapshot_at)
+    await odds_store.set_current_snapshot(stale_snapshot_at)
+    await odds_store.upsert_odds(fresh_odds, scraped_at=fresh_snapshot_at)
+    await odds_store.set_current_snapshot(fresh_snapshot_at)
 
     current = await odds_store.get_odds_for_match("m1")
     history = await odds_store.get_odds_history_for_match("m1")
@@ -564,6 +575,7 @@ async def test_upsert_odds_keeps_line_and_milestone_rows_separate():
     batch_scraped_at = "2026-04-11T20:06:00.735723"
     await odds_store.upsert_odds(line, scraped_at=batch_scraped_at)
     await odds_store.upsert_odds(milestone, scraped_at=batch_scraped_at)
+    await odds_store.set_current_snapshot(batch_scraped_at)
 
     current = await odds_store.get_odds_for_match("m1")
     assert len(current) == 2
@@ -723,6 +735,146 @@ async def test_legacy_discrepancies_table_is_dropped(
     )
 
     assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_match_bookmaker_sources_migration_is_snapshot_scoped(
+    tmp_path,
+    monkeypatch,
+):
+    await close_db()
+    legacy_db_path = tmp_path / "legacy_sources.db"
+    with sqlite3.connect(legacy_db_path) as conn:
+        conn.execute(
+            """CREATE TABLE match_bookmaker_sources (
+                   id INTEGER PRIMARY KEY AUTOINCREMENT,
+                   match_id TEXT NOT NULL REFERENCES matches(id),
+                   bookmaker_id TEXT NOT NULL REFERENCES bookmakers(id),
+                   source_url TEXT,
+                   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                   UNIQUE(match_id, bookmaker_id)
+               )"""
+        )
+        conn.execute(
+            """INSERT INTO match_bookmaker_sources (
+                   match_id,
+                   bookmaker_id,
+                   source_url
+               ) VALUES ('match-1', 'meridian', 'https://legacy.example')"""
+        )
+    monkeypatch.setattr(settings, "database_url", f"sqlite:///{legacy_db_path}")
+
+    await init_db(str(legacy_db_path))
+    db = await get_db()
+    columns = await db.execute_fetchall("PRAGMA table_info(match_bookmaker_sources)")
+    indexes = await db.execute_fetchall("PRAGMA index_list(match_bookmaker_sources)")
+    rows = await db.execute_fetchall(
+        """SELECT snapshot_id, match_id, bookmaker_id, source_url
+           FROM match_bookmaker_sources"""
+    )
+
+    assert "snapshot_id" in {row[1] for row in columns}
+    assert not any(
+        str(row[1]).startswith("sqlite_autoindex_match_bookmaker_sources")
+        for row in indexes
+    )
+    assert "idx_match_bookmaker_sources_unique_snapshot" in {row[1] for row in indexes}
+    assert [tuple(row) for row in rows] == [
+        (None, "match-1", "meridian", "https://legacy.example")
+    ]
+
+    await db.execute(
+        "INSERT INTO bookmakers (id, name) VALUES ('meridian', 'Meridian')"
+    )
+    await db.execute(
+        """INSERT INTO matches (id, home_team, away_team)
+           VALUES ('match-1', 'Home', 'Away')"""
+    )
+    await db.commit()
+    await db.execute(
+        """INSERT INTO match_bookmaker_sources (
+               snapshot_id,
+               match_id,
+               bookmaker_id,
+               source_url
+           ) VALUES ('snapshot-1', 'match-1', 'meridian', 'https://snapshot.example')"""
+    )
+    await db.commit()
+    with pytest.raises(aiosqlite.IntegrityError):
+        await db.execute(
+            """INSERT INTO match_bookmaker_sources (
+                   snapshot_id,
+                   match_id,
+                   bookmaker_id,
+                   source_url
+               ) VALUES ('snapshot-1', 'match-1', 'meridian', 'https://dupe.example')"""
+        )
+        await db.commit()
+    await db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_odds_history_migration_backfills_snapshot_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    await close_db()
+    legacy_db_path = tmp_path / "legacy_history.db"
+    history_at = "2026-04-11T20:06:00.735723"
+    with sqlite3.connect(legacy_db_path) as conn:
+        conn.execute(
+            """CREATE TABLE odds_history (
+                   id INTEGER PRIMARY KEY AUTOINCREMENT,
+                   match_id TEXT,
+                   bookmaker_id TEXT,
+                   market_type TEXT,
+                   player_name TEXT,
+                   threshold REAL,
+                   over_odds REAL,
+                   under_odds REAL,
+                   scraped_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+               )"""
+        )
+        conn.execute(
+            """INSERT INTO odds_history (
+                   match_id,
+                   bookmaker_id,
+                   market_type,
+                   player_name,
+                   threshold,
+                   over_odds,
+                   under_odds,
+                   scraped_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "match-1",
+                "meridian",
+                "player_points",
+                "Saben Lee",
+                13.5,
+                1.8,
+                2.0,
+                history_at,
+            ),
+        )
+    monkeypatch.setattr(settings, "database_url", f"sqlite:///{legacy_db_path}")
+
+    await init_db(str(legacy_db_path))
+    db = await get_db()
+    history_rows = await db.execute_fetchall(
+        "SELECT snapshot_id, scraped_at FROM odds_history"
+    )
+    snapshot_rows = await db.execute_fetchall(
+        "SELECT id, scraped_at, status FROM scrape_snapshots"
+    )
+
+    assert [(row["snapshot_id"], row["scraped_at"]) for row in history_rows] == [
+        (history_at, history_at)
+    ]
+    assert [(row["id"], row["scraped_at"], row["status"]) for row in snapshot_rows] == [
+        (history_at, history_at, "published")
+    ]
 
 
 @pytest.mark.asyncio
@@ -1132,6 +1284,7 @@ async def test_cleanup_retained_data_prunes_stale_snapshot_rows(monkeypatch: pyt
         "deleted_stale_odds": 1,
         "deleted_stale_unresolved_odds": 1,
         "deleted_stale_resolved_event_members": 1,
+        "deleted_stale_match_bookmaker_sources": 1,
         "deleted_stale_opportunities": 1,
         "deleted_stale_opportunity_publishes": 1,
         "deleted_stale_scrape_snapshots": 3,
@@ -1291,9 +1444,13 @@ async def test_system_status_counts_only_latest_scrape_batch():
         under_odds=1.73,
     )
 
-    await odds_store.upsert_odds(stale_odds, scraped_at="2026-04-10T13:39:04.516801")
-    await odds_store.upsert_odds(fresh_odds_a, scraped_at="2026-04-11T20:06:00.735723")
-    await odds_store.upsert_odds(fresh_odds_b, scraped_at="2026-04-11T20:06:00.735723")
+    stale_snapshot_at = "2026-04-10T13:39:04.516801"
+    fresh_snapshot_at = "2026-04-11T20:06:00.735723"
+    await odds_store.upsert_odds(stale_odds, scraped_at=stale_snapshot_at)
+    await odds_store.set_current_snapshot(stale_snapshot_at)
+    await odds_store.upsert_odds(fresh_odds_a, scraped_at=fresh_snapshot_at)
+    await odds_store.upsert_odds(fresh_odds_b, scraped_at=fresh_snapshot_at)
+    await odds_store.set_current_snapshot(fresh_snapshot_at)
 
     status = await odds_store.get_system_status()
 
@@ -1531,6 +1688,591 @@ async def test_unpublished_snapshot_match_metadata_does_not_leak_to_public_reads
     assert [
         (item.home_team, item.away_team, item.start_time) for item in opportunities
     ] == [("Old Home", "Old Away", "2026-04-11T20:00:00+00:00")]
+
+
+@pytest.mark.asyncio
+async def test_unpublished_snapshot_source_urls_do_not_leak_to_public_reads():
+    old_snapshot_at = "2026-04-11T20:06:00.735723"
+    new_snapshot_at = "2026-04-11T20:11:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=old_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Old Home",
+                away_team="Old Away",
+                source_url="https://old.example/match",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=old_snapshot_at,
+        snapshot_at=old_snapshot_at,
+        opportunities=[
+            Opportunity(
+                sport="basketball",
+                match_id="shared-match",
+                opportunity_type="same_line_arbitrage",
+                market_type="player_points",
+                subject_type="player",
+                subject_key="saben lee",
+                subject_name="Saben Lee",
+                line=13.5,
+                profit_margin=0.02,
+                middle_profit_margin=None,
+                legs=[
+                    OpportunityLeg(
+                        bookmaker_id="meridian",
+                        market_type="player_points",
+                        outcome_code="over",
+                        odds=2.05,
+                        line=13.5,
+                    )
+                ],
+            )
+        ],
+        detected_at=old_snapshot_at,
+    )
+
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=new_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="New Home",
+                away_team="New Away",
+                source_url="https://new-hidden.example/match",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time="2026-04-11T21:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+
+    current_odds = await odds_store.get_odds_for_match("shared-match")
+    current_canonical_rows = await odds_store.get_current_normalized_odds_for_matches(
+        ["shared-match"]
+    )
+    current_opportunities = await odds_store.get_opportunities()
+    hidden_snapshot_rows = await odds_store.get_current_normalized_odds_for_matches(
+        ["shared-match"],
+        snapshot_id=new_snapshot_at,
+    )
+
+    assert [row.source_url for row in current_odds] == ["https://old.example/match"]
+    assert [row.source_url for row in current_canonical_rows] == [
+        "https://old.example/match"
+    ]
+    assert current_opportunities[0].legs[0].source_url == "https://old.example/match"
+    assert [row.source_url for row in hidden_snapshot_rows] == [
+        "https://new-hidden.example/match"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_legacy_null_source_url_does_not_leak_to_snapshot_public_reads():
+    snapshot_at = "2026-04-11T20:06:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Home",
+                away_team="Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[
+            NormalizedOutcomeOffer(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Home",
+                away_team="Away",
+                market_type="game_winner",
+                outcome_code="home",
+                odds=1.8,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=snapshot_at,
+        snapshot_at=snapshot_at,
+        opportunities=[
+            Opportunity(
+                sport="basketball",
+                match_id="shared-match",
+                opportunity_type="same_line_arbitrage",
+                market_type="player_points",
+                subject_type="player",
+                subject_key="saben lee",
+                subject_name="Saben Lee",
+                line=13.5,
+                profit_margin=0.02,
+                middle_profit_margin=None,
+                legs=[
+                    OpportunityLeg(
+                        bookmaker_id="meridian",
+                        market_type="player_points",
+                        outcome_code="over",
+                        odds=2.05,
+                        line=13.5,
+                    )
+                ],
+            )
+        ],
+        detected_at=snapshot_at,
+    )
+    db = await get_db()
+    await db.execute(
+        """INSERT INTO match_bookmaker_sources (
+               snapshot_id,
+               match_id,
+               bookmaker_id,
+               source_url
+           ) VALUES (NULL, ?, ?, ?)""",
+        ("shared-match", "meridian", "https://new-hidden.example/match"),
+    )
+    await db.commit()
+
+    current_odds = await odds_store.get_odds_for_match("shared-match")
+    current_canonical_rows = await odds_store.get_current_normalized_odds_for_matches(
+        ["shared-match"]
+    )
+    current_outcome_rows = (
+        await odds_store.get_current_normalized_outcome_offers_for_matches(
+            ["shared-match"]
+        )
+    )
+    outcome_offers = await odds_store.get_outcome_offers(match_id="shared-match")
+    current_opportunities = await odds_store.get_opportunities()
+
+    assert [row.source_url for row in current_odds] == [None]
+    assert [row.source_url for row in current_canonical_rows] == [None]
+    assert [row.source_url for row in current_outcome_rows] == [None]
+    assert [row.source_url for row in outcome_offers] == [None]
+    assert current_opportunities[0].legs[0].source_url is None
+
+
+@pytest.mark.asyncio
+async def test_unpublished_event_resolution_source_url_uses_batch_snapshot_scope():
+    old_snapshot_at = "2026-04-11T20:06:00.735723"
+    new_snapshot_at = "2026-04-11T20:11:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=old_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Old Home",
+                away_team="Old Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=old_snapshot_at,
+        snapshot_at=old_snapshot_at,
+        opportunities=[],
+        detected_at=old_snapshot_at,
+    )
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=new_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="New Home",
+                away_team="New Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time="2026-04-11T21:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.persist_event_resolution_batch(
+        snapshot_id=new_snapshot_at,
+        events=[
+            ResolvedEventIn(
+                id="evt-new",
+                sport="basketball",
+                start_time="2026-04-11T21:00:00+00:00",
+                primary_match_id="shared-match",
+                method="exact",
+            )
+        ],
+        members=[
+            ResolvedEventMemberIn(
+                resolved_event_id="evt-new",
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                source_url="https://new-hidden.example/event",
+            )
+        ],
+        review_cases=[],
+    )
+
+    current_odds = await odds_store.get_odds_for_match("shared-match")
+    db = await get_db()
+    source_rows = await db.execute_fetchall(
+        """SELECT snapshot_id, source_url
+           FROM match_bookmaker_sources
+           ORDER BY snapshot_id"""
+    )
+
+    assert [row.source_url for row in current_odds] == [None]
+    assert [(row["snapshot_id"], row["source_url"]) for row in source_rows] == [
+        (new_snapshot_at, "https://new-hidden.example/event")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unpublished_snapshot_odds_history_does_not_leak_to_public_reads():
+    old_snapshot_at = "2026-04-11T20:06:00.735723"
+    new_snapshot_at = "2026-04-11T20:11:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=old_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Old Home",
+                away_team="Old Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=old_snapshot_at,
+        snapshot_at=old_snapshot_at,
+        opportunities=[],
+        detected_at=old_snapshot_at,
+    )
+
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=new_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="New Home",
+                away_team="New Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time="2026-04-11T21:00:00+00:00",
+            ),
+            NormalizedOdds(
+                match_id="hidden-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Hidden Home",
+                away_team="Hidden Away",
+                source_url="https://hidden.example/odds",
+                market_type="player_points",
+                player_name="Hidden Player",
+                threshold=13.5,
+                over_odds=2.1,
+                under_odds=1.7,
+                start_time="2026-04-11T22:00:00+00:00",
+            ),
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+
+    shared_history = await odds_store.get_odds_history_for_match("shared-match")
+    hidden_history = await odds_store.get_odds_history_for_match("hidden-match")
+    hidden_public_match = await odds_store.get_match(
+        "hidden-match",
+        require_current_snapshot=True,
+    )
+
+    assert [(row.scraped_at, row.over_odds) for row in shared_history] == [
+        (old_snapshot_at, 1.8)
+    ]
+    assert hidden_history == []
+    assert hidden_public_match is None
+
+
+@pytest.mark.asyncio
+async def test_first_unpublished_snapshot_history_and_match_stay_hidden():
+    snapshot_at = "2026-04-11T20:06:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="hidden-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Hidden Home",
+                away_team="Hidden Away",
+                market_type="player_points",
+                player_name="Hidden Player",
+                threshold=13.5,
+                over_odds=2.1,
+                under_odds=1.7,
+                start_time="2026-04-11T22:00:00+00:00",
+            )
+        ],
+        outcome_offers=[
+            NormalizedOutcomeOffer(
+                match_id="hidden-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Hidden Home",
+                away_team="Hidden Away",
+                source_url="https://hidden.example/offer",
+                market_type="game_winner",
+                outcome_code="home",
+                odds=2.1,
+                start_time="2026-04-11T22:00:00+00:00",
+            )
+        ],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+
+    hidden_history = await odds_store.get_odds_history_for_match("hidden-match")
+    hidden_public_match = await odds_store.get_match(
+        "hidden-match",
+        require_current_snapshot=True,
+    )
+    hidden_odds = await odds_store.get_odds_for_match("hidden-match")
+    hidden_normalized_odds = await odds_store.get_current_normalized_odds_for_matches(
+        ["hidden-match"]
+    )
+    hidden_normalized_offers = (
+        await odds_store.get_current_normalized_outcome_offers_for_matches(
+            ["hidden-match"]
+        )
+    )
+    hidden_outcome_offers = await odds_store.get_outcome_offers(match_id="hidden-match")
+    matches = await odds_store.get_matches()
+    status = await odds_store.get_system_status()
+
+    assert hidden_history == []
+    assert hidden_public_match is None
+    assert hidden_odds == []
+    assert hidden_normalized_odds == []
+    assert hidden_normalized_offers == []
+    assert hidden_outcome_offers == []
+    assert matches == []
+    assert status.total_matches == 0
+    assert status.total_odds == 0
+    assert status.last_scrape_at is None
+
+
+@pytest.mark.asyncio
+async def test_current_reads_use_latest_published_snapshot_when_state_row_is_missing():
+    old_snapshot_at = "2026-04-11T20:06:00.735723"
+    new_snapshot_at = "2026-04-11T20:11:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=old_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Old Home",
+                away_team="Old Away",
+                source_url="https://old.example/odds",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=old_snapshot_at,
+        snapshot_at=old_snapshot_at,
+        opportunities=[],
+        detected_at=old_snapshot_at,
+    )
+    db = await get_db()
+    await db.execute("DELETE FROM scrape_state")
+    await db.commit()
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=new_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="New Home",
+                away_team="New Away",
+                source_url="https://hidden.example/odds",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time="2026-04-11T21:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+
+    matches = await odds_store.get_matches()
+    current_odds = await odds_store.get_odds_for_match("shared-match")
+    status = await odds_store.get_system_status()
+
+    assert [(match.home_team, match.start_time) for match in matches] == [
+        ("Old Home", "2026-04-11T20:00:00+00:00")
+    ]
+    assert [(row.source_url, row.over_odds) for row in current_odds] == [
+        ("https://old.example/odds", 1.8)
+    ]
+    assert status.total_matches == 1
+    assert status.total_odds == 1
+    assert status.last_scrape_at == old_snapshot_at
+
+
+@pytest.mark.asyncio
+async def test_cleanup_retained_data_keeps_snapshot_metadata_for_retained_history(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings, "persist_inapp_notifications", False)
+    monkeypatch.setattr(settings, "odds_history_retention_days", 7)
+    monkeypatch.setattr(settings, "team_review_retention_days", 0)
+
+    old_snapshot_at = "2026-04-18T12:00:00"
+    current_snapshot_at = "2026-04-20T12:00:00"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    for snapshot_at, over_odds in (
+        (old_snapshot_at, 1.8),
+        (current_snapshot_at, 1.9),
+    ):
+        await odds_store.persist_scrape_snapshot_batch(
+            snapshot_at=snapshot_at,
+            odds=[
+                NormalizedOdds(
+                    match_id="shared-match",
+                    bookmaker_id="meridian",
+                    league_id="euroleague",
+                    sport="basketball",
+                    home_team="Home",
+                    away_team="Away",
+                    market_type="player_points",
+                    player_name="Saben Lee",
+                    threshold=13.5,
+                    over_odds=over_odds,
+                    under_odds=2.0,
+                    start_time="2026-04-20T20:00:00+00:00",
+                )
+            ],
+            outcome_offers=[],
+            unresolved_odds=[],
+            team_review_cases=[],
+        )
+        await odds_store.publish_opportunities(
+            snapshot_id=snapshot_at,
+            snapshot_at=snapshot_at,
+            opportunities=[],
+            detected_at=snapshot_at,
+        )
+
+    counts = await odds_store.cleanup_retained_data(current_snapshot_at)
+    history = await odds_store.get_odds_history_for_match("shared-match")
+    db = await get_db()
+    snapshot_rows = await db.execute_fetchall(
+        "SELECT id, status FROM scrape_snapshots ORDER BY id"
+    )
+
+    assert [(row.scraped_at, row.over_odds) for row in history] == [
+        (current_snapshot_at, 1.9),
+        (old_snapshot_at, 1.8),
+    ]
+    assert [(row["id"], row["status"]) for row in snapshot_rows] == [
+        (old_snapshot_at, "published"),
+        (current_snapshot_at, "published"),
+    ]
+    assert counts["deleted_stale_scrape_snapshots"] == 0
 
 
 @pytest.mark.asyncio
@@ -1912,6 +2654,9 @@ async def test_legacy_fallback_groups_recent_rows_before_snapshot_exists():
         ),
         scraped_at="2026-04-11T20:05:00.000001",
     )
+    db = await get_db()
+    await db.execute("DELETE FROM scrape_snapshots")
+    await db.commit()
 
     matches = await odds_store.get_matches(limit=10)
     status = await odds_store.get_system_status()

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -2665,3 +2665,499 @@ async def test_legacy_fallback_groups_recent_rows_before_snapshot_exists():
     assert status.total_matches == 2
     assert status.total_odds == 2
     assert status.last_scrape_at == "2026-04-11T20:05:00.000001"
+
+
+@pytest.mark.asyncio
+async def test_current_snapshot_reads_do_not_fallback_to_hidden_match_metadata():
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    published_at = "2030-01-01T19:55:00+00:00"
+    hidden_at = "2030-01-01T20:05:00+00:00"
+
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=published_at,
+        odds=[
+            NormalizedOdds(
+                match_id="snapshot-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Partizan",
+                away_team="Crvena Zvezda",
+                market_type="player_points",
+                player_name="Player One",
+                threshold=16.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time=None,
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=published_at,
+        snapshot_at=published_at,
+        opportunities=[
+            Opportunity(
+                sport="basketball",
+                match_id="snapshot-match",
+                opportunity_type="same_line_arbitrage",
+                market_type="player_points",
+                line=None,
+                profit_margin=0.01,
+                middle_profit_margin=None,
+                legs=[
+                    OpportunityLeg(
+                        bookmaker_id="meridian",
+                        market_type="player_points",
+                        outcome_code="over",
+                        odds=1.9,
+                    )
+                ],
+            )
+        ],
+        detected_at=published_at,
+    )
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=hidden_at,
+        odds=[
+            NormalizedOdds(
+                match_id="snapshot-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Partizan",
+                away_team="Crvena Zvezda",
+                market_type="player_points",
+                player_name="Player One",
+                threshold=16.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2030-01-01T21:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+
+    listed_match = (await odds_store.get_matches())[0]
+    detailed_match = await odds_store.get_match(
+        "snapshot-match", require_current_snapshot=True
+    )
+    opportunity = (await odds_store.get_opportunities(sport="basketball"))[0]
+
+    assert listed_match.start_time is None
+    assert detailed_match is not None
+    assert detailed_match.start_time is None
+    assert opportunity.start_time is None
+
+
+@pytest.mark.asyncio
+async def test_uncommitted_publish_state_on_isolated_connection_is_not_public():
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    published_at = "2030-01-01T19:55:00+00:00"
+    hidden_at = "2030-01-01T20:05:00+00:00"
+
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=published_at,
+        odds=[
+            NormalizedOdds(
+                match_id="published-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Published Home",
+                away_team="Published Away",
+                market_type="player_points",
+                player_name="Player One",
+                threshold=10.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time="2030-01-01T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=published_at,
+        snapshot_at=published_at,
+        opportunities=[],
+        detected_at=published_at,
+    )
+
+    writer = await aiosqlite.connect(settings.db_path)
+    try:
+        await writer.execute("BEGIN IMMEDIATE")
+        await writer.execute(
+            """INSERT INTO scrape_snapshots (id, scraped_at, completed_at, status)
+               VALUES (?, ?, ?, 'published')""",
+            (hidden_at, hidden_at, hidden_at),
+        )
+        await writer.execute(
+            """INSERT INTO snapshot_matches (
+                   snapshot_id, match_id, league_id, sport, home_team, away_team,
+                   start_time, status
+               ) VALUES (?, 'hidden-match', 'euroleague', 'basketball',
+                         'Hidden Home', 'Hidden Away', ?, 'upcoming')""",
+            (hidden_at, "2030-01-01T21:00:00+00:00"),
+        )
+        await writer.execute(
+            """INSERT INTO odds (
+                   snapshot_id, match_id, bookmaker_id, market_type, player_name,
+                   threshold, over_odds, under_odds, scraped_at
+               ) VALUES (?, 'hidden-match', 'meridian', 'player_points',
+                         'Player Two', 11.5, 1.8, 2.0, ?)""",
+            (hidden_at, hidden_at),
+        )
+        await writer.execute(
+            """INSERT INTO scrape_state (
+                   id, current_snapshot_id, current_snapshot_at, updated_at
+               ) VALUES (1, ?, ?, CURRENT_TIMESTAMP)
+               ON CONFLICT(id) DO UPDATE SET
+                   current_snapshot_id = excluded.current_snapshot_id,
+                   current_snapshot_at = excluded.current_snapshot_at,
+                   updated_at = CURRENT_TIMESTAMP""",
+            (hidden_at, hidden_at),
+        )
+
+        visible_during_uncommitted_write = await odds_store.get_matches(limit=10)
+        await writer.rollback()
+    finally:
+        await writer.close()
+
+    visible_after_rollback = await odds_store.get_matches(limit=10)
+    assert [match.id for match in visible_during_uncommitted_write] == [
+        "published-match"
+    ]
+    assert [match.id for match in visible_after_rollback] == ["published-match"]
+
+
+@pytest.mark.asyncio
+async def test_event_review_variants_use_published_snapshot_metadata():
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    published_at = "2030-01-01T19:55:00+00:00"
+    hidden_at = "2030-01-01T20:05:00+00:00"
+
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=published_at,
+        odds=[
+            NormalizedOdds(
+                match_id="review-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Published Home",
+                away_team="Published Away",
+                source_url="https://published.example",
+                market_type="player_points",
+                player_name="Player One",
+                threshold=10.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time="2030-01-01T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=published_at,
+        snapshot_at=published_at,
+        opportunities=[],
+        detected_at=published_at,
+    )
+    await odds_store.upsert_resolved_event(
+        ResolvedEventIn(
+            id="resolved-review-event",
+            sport="basketball",
+            start_time="2030-01-01T20:00:00+00:00",
+            primary_match_id="review-match",
+            method="exact",
+        )
+    )
+    await odds_store.link_resolved_event_member(
+        ResolvedEventMemberIn(
+            snapshot_id=published_at,
+            resolved_event_id="resolved-review-event",
+            match_id="review-match",
+            bookmaker_id="meridian",
+            source_url="https://published-member.example",
+        )
+    )
+    case_id = await odds_store.upsert_event_review_case(
+        EventReviewCaseIn(
+            fingerprint="review-match-case",
+            sport="basketball",
+            start_time="2030-01-01T20:00:00+00:00",
+            primary_match_id="review-match",
+            candidate_resolved_event_id="resolved-review-event",
+            candidate_match_ids=["review-match"],
+            reason_code="manual_review",
+            source_bookmaker_ids=["meridian"],
+        )
+    )
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=hidden_at,
+        odds=[
+            NormalizedOdds(
+                match_id="review-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Hidden Home",
+                away_team="Hidden Away",
+                source_url="https://hidden.example",
+                market_type="player_points",
+                player_name="Player One",
+                threshold=10.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2030-01-01T21:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.link_resolved_event_member(
+        ResolvedEventMemberIn(
+            snapshot_id=hidden_at,
+            resolved_event_id="resolved-review-event",
+            match_id="review-match",
+            bookmaker_id="meridian",
+            source_url="https://hidden-member.example",
+        )
+    )
+    await odds_store.link_resolved_event_member(
+        ResolvedEventMemberIn(
+            snapshot_id=None,
+            resolved_event_id="resolved-review-event",
+            match_id="review-match",
+            bookmaker_id="meridian",
+            source_url="https://unscoped-hidden-member.example",
+        )
+    )
+
+    case = await odds_store.get_event_review_case(case_id, include_variants=True)
+
+    assert case is not None
+    assert len(case.variants) == 1
+    assert case.variants[0].home_team == "Published Home"
+    assert case.variants[0].start_time == "2030-01-01T20:00:00+00:00"
+    assert case.variants[0].source_url == "https://published-member.example"
+
+
+@pytest.mark.asyncio
+async def test_legacy_source_urls_are_backfilled_to_snapshot_sources(
+    tmp_path,
+    monkeypatch,
+):
+    await close_db()
+    legacy_db_path = tmp_path / "legacy_source_backfill.db"
+    scraped_at = "2026-04-11T20:06:00.735723"
+    with sqlite3.connect(legacy_db_path) as conn:
+        conn.execute("CREATE TABLE bookmakers (id TEXT PRIMARY KEY, name TEXT NOT NULL)")
+        conn.execute(
+            """CREATE TABLE leagues (
+                   id TEXT PRIMARY KEY,
+                   name TEXT NOT NULL,
+                   sport TEXT NOT NULL DEFAULT 'basketball'
+               )"""
+        )
+        conn.execute(
+            """CREATE TABLE matches (
+                   id TEXT PRIMARY KEY,
+                   league_id TEXT,
+                   sport TEXT NOT NULL DEFAULT 'basketball',
+                   home_team TEXT NOT NULL,
+                   away_team TEXT NOT NULL,
+                   start_time TEXT,
+                   status TEXT NOT NULL DEFAULT 'upcoming',
+                   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+               )"""
+        )
+        conn.execute(
+            """CREATE TABLE odds (
+                   id INTEGER PRIMARY KEY AUTOINCREMENT,
+                   match_id TEXT,
+                   bookmaker_id TEXT,
+                   market_type TEXT NOT NULL,
+                   player_name TEXT,
+                   threshold REAL NOT NULL,
+                   over_odds REAL,
+                   under_odds REAL,
+                   scraped_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                   UNIQUE(match_id, bookmaker_id, market_type, player_name, threshold)
+               )"""
+        )
+        conn.execute(
+            """CREATE TABLE match_bookmaker_sources (
+                   id INTEGER PRIMARY KEY AUTOINCREMENT,
+                   match_id TEXT NOT NULL,
+                   bookmaker_id TEXT NOT NULL,
+                   source_url TEXT,
+                   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                   UNIQUE(match_id, bookmaker_id)
+               )"""
+        )
+        conn.execute(
+            """CREATE TABLE scrape_state (
+                   id INTEGER PRIMARY KEY CHECK (id = 1),
+                   current_snapshot_at TIMESTAMP,
+                   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+               )"""
+        )
+        conn.execute("INSERT INTO bookmakers (id, name) VALUES ('meridian', 'Meridian')")
+        conn.execute(
+            """INSERT INTO leagues (id, name, sport)
+               VALUES ('euroleague', 'Euroleague', 'basketball')"""
+        )
+        conn.execute(
+            """INSERT INTO matches (
+                   id, league_id, sport, home_team, away_team, start_time, status
+               ) VALUES (
+                   'legacy-match', 'euroleague', 'basketball', 'Partizan',
+                   'Crvena Zvezda', '2026-04-11T20:00:00+00:00', 'upcoming'
+               )"""
+        )
+        conn.execute(
+            """INSERT INTO odds (
+                   match_id, bookmaker_id, market_type, player_name, threshold,
+                   over_odds, under_odds, scraped_at
+               ) VALUES (
+                   'legacy-match', 'meridian', 'player_points', 'Player One',
+                   16.5, 1.9, 1.9, ?
+               )""",
+            (scraped_at,),
+        )
+        conn.execute(
+            """INSERT INTO match_bookmaker_sources (
+                   match_id, bookmaker_id, source_url
+               ) VALUES (
+                   'legacy-match', 'meridian', 'https://legacy-source.example'
+               )"""
+        )
+        conn.execute(
+            "INSERT INTO scrape_state (id, current_snapshot_at) VALUES (1, ?)",
+            (scraped_at,),
+        )
+    monkeypatch.setattr(settings, "database_url", f"sqlite:///{legacy_db_path}")
+
+    await init_db(str(legacy_db_path))
+
+    odds = await odds_store.get_odds_for_match("legacy-match")
+    db = await get_db()
+    source_rows = await db.execute_fetchall(
+        """SELECT snapshot_id, source_url
+           FROM match_bookmaker_sources
+           WHERE match_id = 'legacy-match'
+           ORDER BY snapshot_id IS NOT NULL, snapshot_id"""
+    )
+    assert [item.source_url for item in odds] == ["https://legacy-source.example"]
+    assert (scraped_at, "https://legacy-source.example") in [
+        tuple(row) for row in source_rows
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_latest_analysis_failed_diagnostics():
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    published_at = "2030-01-01T19:55:00+00:00"
+    failed_at = "2030-01-01T20:05:00+00:00"
+
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=published_at,
+        odds=[
+            NormalizedOdds(
+                match_id="published-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Published Home",
+                away_team="Published Away",
+                market_type="player_points",
+                player_name="Player One",
+                threshold=10.5,
+                over_odds=1.9,
+                under_odds=1.9,
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=published_at,
+        snapshot_at=published_at,
+        opportunities=[],
+        detected_at=published_at,
+    )
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=failed_at,
+        odds=[
+            NormalizedOdds(
+                match_id="failed-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Failed Home",
+                away_team="Failed Away",
+                market_type="player_points",
+                player_name="Player Two",
+                threshold=11.5,
+                over_odds=1.8,
+                under_odds=2.0,
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[
+            UnresolvedOddsDiagnostic(
+                bookmaker_id="meridian",
+                raw_league_id="euroleague",
+                league_id="euroleague",
+                sport="basketball",
+                market_type="player_points",
+                raw_team_name="Failed Home",
+                normalized_team_name="Failed Home",
+                threshold=11.5,
+                reason_code="ambiguous_multiple_matchups_for_team_at_slot",
+            )
+        ],
+        team_review_cases=[
+            TeamReviewDiagnostic(
+                bookmaker_id="meridian",
+                raw_league_id="euroleague",
+                normalized_raw_league_id="euroleague",
+                sport="basketball",
+                raw_team_name="Failed Home",
+                normalized_raw_team_name="failed home",
+                reason_code="alias_suggestion",
+            )
+        ],
+    )
+    await odds_store.mark_scrape_snapshot_analysis_failed(
+        snapshot_id=failed_at,
+        snapshot_at=failed_at,
+        error="canonical boom",
+    )
+
+    deleted = await odds_store.cleanup_retained_data(failed_at)
+    unresolved = await odds_store.get_unresolved_odds()
+    team_reviews = await odds_store.get_team_review_cases()
+    public_matches = await odds_store.get_matches(limit=10)
+
+    assert deleted["deleted_stale_unresolved_odds"] == 0
+    assert deleted["deleted_team_review_cases"] == 0
+    assert [item.raw_team_name for item in unresolved] == ["Failed Home"]
+    assert [item.raw_team_name for item in team_reviews] == ["Failed Home"]
+    assert [match.id for match in public_matches] == ["published-match"]

--- a/backend/tests/test_store.py
+++ b/backend/tests/test_store.py
@@ -12,11 +12,13 @@ from app.models.schemas import (
     EventReviewCaseIn,
     NormalizedOdds,
     NormalizedOutcomeOffer,
+    OpportunityLeg,
     ResolvedEventIn,
     ResolvedEventMemberIn,
     TeamReviewDiagnostic,
     UnresolvedOddsDiagnostic,
 )
+from app.services.opportunity_analyzer import Opportunity
 from app.store import odds_store
 
 
@@ -991,6 +993,90 @@ async def test_cleanup_retained_data_prunes_stale_snapshot_rows(monkeypatch: pyt
         ("2026-04-19 12:00:00", recent_notification_id),
     )
     await db.commit()
+    await odds_store.persist_event_resolution_batch(
+        snapshot_id=stale_snapshot_at,
+        events=[
+            ResolvedEventIn(
+                id="evt-stale",
+                sport="basketball",
+                start_time=stale_snapshot_at,
+                primary_match_id="stale",
+                method="exact",
+            )
+        ],
+        members=[
+            ResolvedEventMemberIn(
+                resolved_event_id="evt-stale",
+                match_id="stale",
+                bookmaker_id="meridian",
+            )
+        ],
+        review_cases=[],
+    )
+    await odds_store.persist_event_resolution_batch(
+        snapshot_id=current_snapshot_at,
+        events=[
+            ResolvedEventIn(
+                id="evt-current",
+                sport="basketball",
+                start_time=current_snapshot_at,
+                primary_match_id="fresh",
+                method="exact",
+            )
+        ],
+        members=[
+            ResolvedEventMemberIn(
+                resolved_event_id="evt-current",
+                match_id="fresh",
+                bookmaker_id="meridian",
+            )
+        ],
+        review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=current_snapshot_at,
+        snapshot_at=current_snapshot_at,
+        opportunities=[],
+        detected_at=current_snapshot_at,
+    )
+    await db.execute(
+        """INSERT INTO opportunity_publishes (
+               id,
+               snapshot_id,
+               detected_at,
+               status,
+               opportunity_count
+           )
+           VALUES (?, ?, ?, 'published', 1)""",
+        ("publish-stale", stale_snapshot_at, stale_snapshot_at),
+    )
+    await db.execute(
+        """INSERT INTO opportunities (
+               publish_id,
+               sport,
+               match_id,
+               opportunity_type,
+               market_type,
+               profit_margin,
+               market_keys,
+               legs,
+               detected_at,
+               is_active
+           )
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, FALSE)""",
+        (
+            "publish-stale",
+            "basketball",
+            "stale",
+            "same_line_arbitrage",
+            "player_points",
+            0.01,
+            "[]",
+            "[]",
+            stale_snapshot_at,
+        ),
+    )
+    await db.commit()
 
     counts = await odds_store.cleanup_retained_data(current_snapshot_at)
 
@@ -1009,6 +1095,18 @@ async def test_cleanup_retained_data_prunes_stale_snapshot_rows(monkeypatch: pyt
     notification_rows = await db.execute_fetchall(
         "SELECT id FROM notifications ORDER BY id"
     )
+    member_rows = await db.execute_fetchall(
+        "SELECT snapshot_id, resolved_event_id FROM resolved_event_members ORDER BY id"
+    )
+    scrape_snapshot_rows = await db.execute_fetchall(
+        "SELECT id FROM scrape_snapshots ORDER BY id"
+    )
+    publish_rows = await db.execute_fetchall(
+        "SELECT id FROM opportunity_publishes ORDER BY id"
+    )
+    opportunity_rows = await db.execute_fetchall(
+        "SELECT publish_id FROM opportunities ORDER BY id"
+    )
 
     assert [(row["match_id"], row["scraped_at"]) for row in odds_rows] == [
         ("fresh", current_snapshot_at)
@@ -1023,9 +1121,20 @@ async def test_cleanup_retained_data_prunes_stale_snapshot_rows(monkeypatch: pyt
         (recent_case_id, "Recent Alias")
     ]
     assert notification_rows == []
+    assert [
+        (row["snapshot_id"], row["resolved_event_id"]) for row in member_rows
+    ] == [(current_snapshot_at, "evt-current")]
+    assert [row["id"] for row in scrape_snapshot_rows] == [current_snapshot_at]
+    assert len(publish_rows) == 1
+    assert publish_rows[0]["id"].startswith(f"{current_snapshot_at}:")
+    assert opportunity_rows == []
     assert counts == {
         "deleted_stale_odds": 1,
         "deleted_stale_unresolved_odds": 1,
+        "deleted_stale_resolved_event_members": 1,
+        "deleted_stale_opportunities": 1,
+        "deleted_stale_opportunity_publishes": 1,
+        "deleted_stale_scrape_snapshots": 3,
         "deleted_odds_history": 1,
         "deleted_team_review_cases": 1,
         "deleted_notifications": 2,
@@ -1222,6 +1331,532 @@ async def test_current_snapshot_can_hide_previous_rows_without_new_odds():
     assert status.total_matches == 0
     assert status.total_odds == 0
     assert status.last_scrape_at == "2026-04-11T20:06:00.735723"
+
+
+@pytest.mark.asyncio
+async def test_system_status_counts_outcome_offer_only_snapshot():
+    snapshot_at = "2026-04-11T20:06:00.735723"
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+    persisted = await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=snapshot_at,
+        odds=[],
+        outcome_offers=[
+            NormalizedOutcomeOffer(
+                match_id="football-match",
+                bookmaker_id="maxbet",
+                league_id="premier-league",
+                sport="football",
+                home_team="Arsenal",
+                away_team="Chelsea",
+                market_type="football_total_goals",
+                outcome_code="over",
+                odds=1.85,
+                line=2.5,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=str(persisted["snapshot_id"]),
+        snapshot_at=snapshot_at,
+        opportunities=[],
+        detected_at=snapshot_at,
+    )
+
+    status = await odds_store.get_system_status()
+
+    assert status.total_matches == 1
+    assert status.total_odds == 1
+    assert status.last_scrape_at == snapshot_at
+
+
+@pytest.mark.asyncio
+async def test_persisted_snapshot_is_hidden_until_opportunity_publish():
+    old_snapshot_at = "2026-04-11T20:06:00.735723"
+    new_snapshot_at = "2026-04-11T20:11:00.735723"
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.upsert_match("old", "euroleague", "Bayern Munich", "Maccabi Tel Aviv")
+    await odds_store.upsert_odds(
+        NormalizedOdds(
+            match_id="old",
+            bookmaker_id="meridian",
+            league_id="euroleague",
+            home_team="Bayern Munich",
+            away_team="Maccabi Tel Aviv",
+            market_type="player_points",
+            player_name="Saben Lee",
+            threshold=13.5,
+            over_odds=1.8,
+            under_odds=2.0,
+        ),
+        scraped_at=old_snapshot_at,
+    )
+    await odds_store.set_current_snapshot(old_snapshot_at)
+
+    persisted = await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=new_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="new",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                home_team="Partizan",
+                away_team="Crvena Zvezda",
+                market_type="player_points",
+                player_name="Carlik Jones",
+                threshold=14.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+
+    status_before_publish = await odds_store.get_system_status()
+    matches_before_publish = await odds_store.get_matches()
+    assert status_before_publish.last_scrape_at == old_snapshot_at
+    assert status_before_publish.total_matches == 1
+    assert matches_before_publish[0].id == "old"
+
+    await odds_store.publish_opportunities(
+        snapshot_id=str(persisted["snapshot_id"]),
+        snapshot_at=new_snapshot_at,
+        opportunities=[],
+        detected_at=new_snapshot_at,
+    )
+
+    status_after_publish = await odds_store.get_system_status()
+    matches_after_publish = await odds_store.get_matches()
+    assert status_after_publish.last_scrape_at == new_snapshot_at
+    assert status_after_publish.total_matches == 1
+    assert status_after_publish.total_opportunities == 0
+    assert matches_after_publish[0].id == "new"
+
+
+@pytest.mark.asyncio
+async def test_unpublished_snapshot_match_metadata_does_not_leak_to_public_reads():
+    old_snapshot_at = "2026-04-11T20:06:00.735723"
+    new_snapshot_at = "2026-04-11T20:11:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=old_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Old Home",
+                away_team="Old Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=old_snapshot_at,
+        snapshot_at=old_snapshot_at,
+        opportunities=[
+            Opportunity(
+                sport="basketball",
+                match_id="shared-match",
+                opportunity_type="same_line_arbitrage",
+                market_type="player_points",
+                subject_type="player",
+                subject_key="saben lee",
+                subject_name="Saben Lee",
+                line=13.5,
+                profit_margin=0.02,
+                middle_profit_margin=None,
+                legs=[
+                    OpportunityLeg(
+                        bookmaker_id="meridian",
+                        market_type="player_points",
+                        outcome_code="over",
+                        odds=2.05,
+                        line=13.5,
+                    )
+                ],
+            )
+        ],
+        detected_at=old_snapshot_at,
+    )
+
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=new_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="New Home",
+                away_team="New Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time="2026-04-11T21:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+
+    matches = await odds_store.get_matches()
+    odds = await odds_store.get_current_normalized_odds_for_matches(["shared-match"])
+    opportunities = await odds_store.get_opportunities()
+
+    assert [(match.home_team, match.away_team, match.start_time) for match in matches] == [
+        ("Old Home", "Old Away", "2026-04-11T20:00:00+00:00")
+    ]
+    assert [(item.home_team, item.away_team, item.start_time) for item in odds] == [
+        ("Old Home", "Old Away", "2026-04-11T20:00:00+00:00")
+    ]
+    assert [
+        (item.home_team, item.away_team, item.start_time) for item in opportunities
+    ] == [("Old Home", "Old Away", "2026-04-11T20:00:00+00:00")]
+
+
+@pytest.mark.asyncio
+async def test_unpublished_event_resolution_does_not_leak_to_public_match_reads():
+    old_snapshot_at = "2026-04-11T20:06:00.735723"
+    new_snapshot_at = "2026-04-11T20:11:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=old_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Old Home",
+                away_team="Old Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.persist_event_resolution_batch(
+        snapshot_id=old_snapshot_at,
+        events=[
+            ResolvedEventIn(
+                id="evt-old",
+                sport="basketball",
+                start_time="2026-04-11T20:00:00+00:00",
+                primary_match_id="shared-match",
+                method="exact",
+            )
+        ],
+        members=[
+            ResolvedEventMemberIn(
+                resolved_event_id="evt-old",
+                match_id="shared-match",
+                bookmaker_id="meridian",
+            )
+        ],
+        review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=old_snapshot_at,
+        snapshot_at=old_snapshot_at,
+        opportunities=[],
+        detected_at=old_snapshot_at,
+    )
+
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=new_snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="New Home",
+                away_team="New Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.9,
+                under_odds=1.9,
+                start_time="2026-04-11T21:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.persist_event_resolution_batch(
+        snapshot_id=new_snapshot_at,
+        events=[
+            ResolvedEventIn(
+                id="evt-new",
+                sport="basketball",
+                start_time="2026-04-11T21:00:00+00:00",
+                primary_match_id="shared-match",
+                method="exact",
+            )
+        ],
+        members=[
+            ResolvedEventMemberIn(
+                resolved_event_id="evt-new",
+                match_id="shared-match",
+                bookmaker_id="meridian",
+            )
+        ],
+        review_cases=[],
+    )
+
+    matches = await odds_store.get_matches()
+    current_event_members = await odds_store.get_eligible_resolved_event_members_for_odds(
+        await odds_store.get_current_normalized_odds_for_matches(["shared-match"])
+    )
+    new_snapshot_event_members = (
+        await odds_store.get_eligible_resolved_event_members_for_odds(
+            await odds_store.get_current_normalized_odds_for_matches(
+                ["shared-match"],
+                snapshot_id=new_snapshot_at,
+            ),
+            snapshot_id=new_snapshot_at,
+        )
+    )
+
+    assert [(match.home_team, match.resolved_event_id) for match in matches] == [
+        ("Old Home", "evt-old")
+    ]
+    assert [member.resolved_event_id for member in current_event_members] == ["evt-old"]
+    assert [member.resolved_event_id for member in new_snapshot_event_members] == [
+        "evt-new"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_manual_event_resolution_overrides_snapshot_auto_member():
+    snapshot_at = "2026-04-11T20:06:00.735723"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.persist_scrape_snapshot_batch(
+        snapshot_at=snapshot_at,
+        odds=[
+            NormalizedOdds(
+                match_id="shared-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Home",
+                away_team="Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.8,
+                under_odds=2.0,
+                start_time="2026-04-11T20:00:00+00:00",
+            )
+        ],
+        outcome_offers=[],
+        unresolved_odds=[],
+        team_review_cases=[],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=snapshot_at,
+        snapshot_at=snapshot_at,
+        opportunities=[],
+        detected_at=snapshot_at,
+    )
+    await odds_store.upsert_resolved_event(
+        ResolvedEventIn(
+            id="evt-manual",
+            sport="basketball",
+            start_time="2026-04-11T20:00:00+00:00",
+            primary_match_id="shared-match",
+            method="manual",
+        )
+    )
+    await odds_store.link_resolved_event_member(
+        ResolvedEventMemberIn(
+            resolved_event_id="evt-manual",
+            match_id="shared-match",
+            bookmaker_id="meridian",
+        )
+    )
+    await odds_store.persist_event_resolution_batch(
+        snapshot_id=snapshot_at,
+        events=[
+            ResolvedEventIn(
+                id="evt-auto",
+                sport="basketball",
+                start_time="2026-04-11T20:00:00+00:00",
+                primary_match_id="shared-match",
+                method="exact",
+            )
+        ],
+        members=[
+            ResolvedEventMemberIn(
+                resolved_event_id="evt-auto",
+                match_id="shared-match",
+                bookmaker_id="meridian",
+            )
+        ],
+        review_cases=[],
+    )
+
+    odds = await odds_store.get_current_normalized_odds_for_matches(["shared-match"])
+    members = await odds_store.get_eligible_resolved_event_members_for_odds(odds)
+    match = (await odds_store.get_matches())[0]
+    member = await odds_store.get_resolved_event_member(
+        match_id="shared-match",
+        bookmaker_id="meridian",
+    )
+
+    assert match.resolved_event_id == "evt-manual"
+    assert [item.resolved_event_id for item in members] == ["evt-manual"]
+    assert member is not None
+    assert member.resolved_event_id == "evt-manual"
+
+
+@pytest.mark.asyncio
+async def test_merge_matches_preserves_same_offer_key_across_snapshots():
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.upsert_match("target-match", "euroleague", "Target Home", "Target Away")
+    await odds_store.upsert_match("source-match", "euroleague", "Source Home", "Source Away")
+
+    for snapshot_at in ("2026-04-11T20:06:00.735723", "2026-04-11T20:11:00.735723"):
+        await odds_store.upsert_odds(
+            NormalizedOdds(
+                match_id="source-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                home_team="Source Home",
+                away_team="Source Away",
+                market_type="player_points",
+                player_name="Saben Lee",
+                threshold=13.5,
+                over_odds=1.8,
+                under_odds=2.0,
+            ),
+            scraped_at=snapshot_at,
+        )
+        await odds_store.upsert_outcome_offer(
+            NormalizedOutcomeOffer(
+                match_id="source-match",
+                bookmaker_id="meridian",
+                league_id="euroleague",
+                sport="basketball",
+                home_team="Source Home",
+                away_team="Source Away",
+                market_type="game_winner",
+                outcome_code="home",
+                odds=1.9,
+            ),
+            scraped_at=snapshot_at,
+        )
+
+    await odds_store.merge_matches(
+        target_match_id="target-match",
+        source_match_ids=["source-match"],
+    )
+
+    db = await get_db()
+    odds_rows = await db.execute_fetchall(
+        "SELECT snapshot_id, match_id FROM odds ORDER BY snapshot_id"
+    )
+    offer_rows = await db.execute_fetchall(
+        "SELECT snapshot_id, match_id FROM outcome_offers ORDER BY snapshot_id"
+    )
+
+    assert [(row["snapshot_id"], row["match_id"]) for row in odds_rows] == [
+        ("2026-04-11T20:06:00.735723", "target-match"),
+        ("2026-04-11T20:11:00.735723", "target-match"),
+    ]
+    assert [(row["snapshot_id"], row["match_id"]) for row in offer_rows] == [
+        ("2026-04-11T20:06:00.735723", "target-match"),
+        ("2026-04-11T20:11:00.735723", "target-match"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_opportunity_publish_preserves_previous_publish():
+    snapshot_at = "2026-04-11T20:06:00.735723"
+    next_snapshot_at = "2026-04-11T20:11:00.735723"
+    await odds_store.upsert_league("premier-league", "Premier League", "football")
+    await odds_store.upsert_bookmaker("maxbet", "MaxBet")
+    await odds_store.upsert_bookmaker("balkanbet", "BalkanBet")
+    await odds_store.upsert_match(
+        "football-match",
+        "premier-league",
+        "Arsenal",
+        "Chelsea",
+        sport="football",
+        start_time="2026-04-11T20:00:00+00:00",
+    )
+    old_opportunity = Opportunity(
+        sport="football",
+        match_id="football-match",
+        opportunity_type="same_line_arbitrage",
+        market_type="football_total_goals",
+        line=2.5,
+        profit_margin=0.02,
+        middle_profit_margin=None,
+        legs=[
+            OpportunityLeg(
+                bookmaker_id="maxbet",
+                market_type="football_total_goals",
+                outcome_code="under",
+                line=2.5,
+                odds=1.95,
+            ),
+            OpportunityLeg(
+                bookmaker_id="balkanbet",
+                market_type="football_total_goals",
+                outcome_code="over",
+                line=2.5,
+                odds=2.10,
+            ),
+        ],
+    )
+    await odds_store.publish_opportunities(
+        snapshot_id=snapshot_at,
+        snapshot_at=snapshot_at,
+        opportunities=[old_opportunity],
+        detected_at=snapshot_at,
+    )
+
+    with pytest.raises(AttributeError):
+        await odds_store.publish_opportunities(
+            snapshot_id=next_snapshot_at,
+            snapshot_at=next_snapshot_at,
+            opportunities=[object()],
+            detected_at=next_snapshot_at,
+        )
+
+    opportunities = await odds_store.get_opportunities(sport="football")
+    status = await odds_store.get_system_status()
+    assert len(opportunities) == 1
+    assert opportunities[0].match_id == "football-match"
+    assert status.total_opportunities == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add explicit scrape snapshot and opportunity publish metadata so public reads stay pinned to the last complete dataset.
- Persist scrape rows under hidden snapshot IDs, analyze the explicit snapshot, and atomically switch opportunity visibility after publish succeeds.
- Make event resolution, cleanup, status counts, and match/public reads snapshot-aware.

Closes #71

## Validation
- `cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q` — 848 passed
- Broad backend regression subset — 172 passed
- Multi-model staged-diff review completed with no significant remaining issues
