### PR TITLE
Cap middle opportunities per market

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,6 +23,10 @@ ENABLED_SPORTS=basketball
 # Basketball threshold scrapers may still fetch game rows as normalization/event context.
 SCRAPE_MARKET_SCOPE=player_props
 
+# Maximum middle opportunities kept per event + subject/player + market.
+# Same-line profitable arbitrage is not capped.
+MAX_MIDDLE_OPPORTUNITIES_PER_MARKET=10
+
 # Use "mock" for deterministic local development or "real" for live bookmaker HTTP calls.
 SCRAPER_MODE=mock
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     enabled_sports: str = "basketball"
     # player_props = skip outcome-offer lanes and persist/analyze player_* thresholds.
     scrape_market_scope: Literal["all", "player_props"] = "player_props"
+    max_middle_opportunities_per_market: int = Field(default=10, ge=1)
     notification_gap_threshold: float = 1.5
     persist_inapp_notifications: bool = False
     notification_retention_days: int = 3

--- a/backend/app/services/canonical_analyzer.py
+++ b/backend/app/services/canonical_analyzer.py
@@ -29,11 +29,20 @@ class _RuleContext:
     resolved_event_id: str | None
 
 
+@dataclass(frozen=True)
+class _LineMiddleCandidate:
+    low: CanonicalOffer
+    high: CanonicalOffer
+    margin: float
+    middle_margin: float
+
+
 def analyze_canonical_offers(
     offers: Sequence[CanonicalOffer],
     *,
     min_gap: float = 0.0,
     event_primary_match_ids: Mapping[str, str] | None = None,
+    max_middle_opportunities_per_market: int | None = 10,
 ) -> list[Opportunity]:
     """Find two-leg opportunities from canonical bookmaker offers."""
     deduped: dict[tuple, Opportunity] = {}
@@ -45,7 +54,12 @@ def analyze_canonical_offers(
 
     for group in _line_market_groups(offers).values():
         context = _context(group, event_primary_match_ids=event_primary_match_ids)
-        for opportunity in _analyze_line_middle(group, context, min_gap=min_gap):
+        for opportunity in _analyze_line_middle(
+            group,
+            context,
+            min_gap=min_gap,
+            max_opportunities=max_middle_opportunities_per_market,
+        ):
             deduped[_dedupe_key(opportunity)] = opportunity
 
     for group in _event_market_family_groups(offers).values():
@@ -105,8 +119,12 @@ def _analyze_line_middle(
     context: _RuleContext,
     *,
     min_gap: float,
+    max_opportunities: int | None,
 ) -> list[Opportunity]:
-    opportunities: list[Opportunity] = []
+    if max_opportunities is not None and max_opportunities <= 0:
+        return []
+
+    candidates: list[_LineMiddleCandidate] = []
     for first, second in combinations(group, 2):
         if first.bookmaker_id == second.bookmaker_id:
             continue
@@ -134,6 +152,29 @@ def _analyze_line_middle(
         ):
             continue
 
+        if margin is None or middle_margin is None:
+            continue
+        candidates.append(
+            _LineMiddleCandidate(
+                low=low,
+                high=high,
+                margin=margin,
+                middle_margin=middle_margin,
+            )
+        )
+
+    ranked_candidates = sorted(
+        candidates,
+        key=_line_middle_candidate_rank,
+        reverse=True,
+    )
+    if max_opportunities is not None:
+        ranked_candidates = ranked_candidates[:max_opportunities]
+
+    opportunities: list[Opportunity] = []
+    for candidate in ranked_candidates:
+        low = candidate.low
+        high = candidate.high
         subject_type, subject_key, subject_name = _subject_metadata(
             low.market,
             high.market,
@@ -145,8 +186,8 @@ def _analyze_line_middle(
                 opportunity_type="middle",
                 market_type=low.market.market_type,
                 line=low.market.line,
-                profit_margin=margin,
-                middle_profit_margin=middle_margin,
+                profit_margin=candidate.margin,
+                middle_profit_margin=candidate.middle_margin,
                 legs=[_leg(low), _leg(high)],
                 resolved_event_id=context.resolved_event_id,
                 subject_type=subject_type,
@@ -156,6 +197,25 @@ def _analyze_line_middle(
             )
         )
     return opportunities
+
+
+def _line_middle_candidate_rank(candidate: _LineMiddleCandidate) -> tuple[float, ...]:
+    low_line = candidate.low.market.line
+    high_line = candidate.high.market.line
+    if low_line is None or high_line is None:
+        relative_width = 0.0
+        gap = 0.0
+    else:
+        gap = high_line - low_line
+        line_scale = max((abs(low_line) + abs(high_line)) / 2.0, 1.0)
+        relative_width = gap / line_scale
+    return (
+        relative_width,
+        candidate.middle_margin,
+        candidate.margin,
+        gap,
+        min(candidate.low.odds, candidate.high.odds),
+    )
 
 
 def _analyze_complementary_outcomes(

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -278,6 +278,7 @@ async def _load_current_canonical_analysis(match_ids: set[str]) -> _CanonicalAna
     canonical_opportunities = analyze_canonical_offers(
         canonical_offers,
         event_primary_match_ids=event_primary_match_ids,
+        max_middle_opportunities_per_market=settings.max_middle_opportunities_per_market,
     )
     return _CanonicalAnalysisResult(
         offers=tuple(canonical_offers),

--- a/backend/tests/test_canonical_analyzer.py
+++ b/backend/tests/test_canonical_analyzer.py
@@ -165,6 +165,66 @@ def test_canonical_line_middle_honors_min_gap():
     assert len(analyze_canonical_offers(offers, min_gap=0.5)) == 1
 
 
+def test_canonical_line_middle_caps_candidates_per_event_player_market():
+    offers = [
+        *_odds("over-book", "Lundberg", 7.5, over=1.90, under=None),
+    ]
+    for index in range(12):
+        offers.extend(
+            _odds(
+                f"under-book-{index}",
+                "Lundberg",
+                8.5 + index,
+                over=None,
+                under=1.90,
+            )
+        )
+
+    opportunities = analyze_canonical_offers(
+        offers,
+        max_middle_opportunities_per_market=10,
+    )
+
+    assert len(opportunities) == 10
+    assert {opportunity.opportunity_type for opportunity in opportunities} == {"middle"}
+    assert all(opportunity.subject_name == "Lundberg" for opportunity in opportunities)
+
+
+def test_canonical_line_middle_ranks_relative_width_before_raw_odds():
+    opportunities = analyze_canonical_offers(
+        [
+            *_odds("over-book", "Lundberg", 7.5, over=1.90, under=None),
+            *_odds("narrow-under", "Lundberg", 8.5, over=None, under=5.00),
+            *_odds("wide-under", "Lundberg", 10.5, over=None, under=1.90),
+        ],
+        max_middle_opportunities_per_market=1,
+    )
+
+    assert len(opportunities) == 1
+    assert {(leg.bookmaker_id, leg.line) for leg in opportunities[0].legs} == {
+        ("over-book", 7.5),
+        ("wide-under", 10.5),
+    }
+
+
+def test_canonical_line_middle_uses_odds_when_relative_width_ties():
+    opportunities = analyze_canonical_offers(
+        [
+            *_odds("cheap-over", "Lundberg", 7.5, over=1.50, under=None),
+            *_odds("cheap-under", "Lundberg", 8.5, over=None, under=1.50),
+            *_odds("better-over", "Lundberg", 7.5, over=2.00, under=None),
+            *_odds("better-under", "Lundberg", 8.5, over=None, under=2.00),
+        ],
+        max_middle_opportunities_per_market=1,
+    )
+
+    assert len(opportunities) == 1
+    assert {(leg.bookmaker_id, leg.line) for leg in opportunities[0].legs} == {
+        ("better-over", 7.5),
+        ("better-under", 8.5),
+    }
+
+
 def test_canonical_line_middle_uses_subject_key_before_display_name():
     opportunities = analyze_canonical_offers(
         [


### PR DESCRIPTION
## Summary
- cap generated middle opportunities to the top configured candidates per event/player/market
- rank middle candidates by relative middle width first, then middle profit, miss/outside margin, raw gap, and minimum odds
- keep profitable same-line arbitrage uncapped
- expose `MAX_MIDDLE_OPPORTUNITIES_PER_MARKET=10` as the default backend setting

## Why
Live player-market cycles were producing tens of thousands of active opportunities because middle generation can explode combinatorially for one player/market. Example: a single player points row could show hundreds of lines, most of them weak/unprofitable middles. This PR reduces analyzer output before persistence so we spend less time analyzing, inserting, serving, and rendering noisy middle candidates.

## Verification
- `cd backend && ./venv/bin/python -m py_compile app/services/canonical_analyzer.py app/config.py app/services/scheduler.py && ./venv/bin/pytest tests/test_canonical_analyzer.py -q`
  - `19 passed in 0.36s`
- `cd backend && ./venv/bin/pytest tests/test_canonical_analyzer.py tests/test_opportunity_analyzer.py tests/test_scheduler.py -q && ./venv/bin/pytest -q`
  - targeted: `87 passed in 4.84s`
  - full backend: `847 passed in 23.49s`
- Adversarial review (`gpt-5.5`): no significant issues found

## Live benchmark note
Ran an isolated real-mode benchmark on a temp SQLite DB and temp benchmark directory:

```text
SCRAPER_MODE=real
SCRAPE_MARKET_SCOPE=player_props
DATABASE_URL=sqlite:////tmp/kvotolovac-cap-middle.db
BENCHMARK_DIR=/tmp/kvotolovac-cap-middle-benchmarks
```

Measured explicit scrape trigger:

```text
cycle_duration_ms=91134
scrape_duration_ms=23052
cycle_overhead_ms=68082
total_raw_items=8099
total_odds=3803
opportunities_found=1536
failures=0/12
```

DB check from that run confirmed:

```text
max middle rows per event/player/market = 10
same-line arbitrage preserved
```

Live payloads vary, so this is not a perfect apples-to-apples timing comparison with the previous uncapped run, but the cap enforcement and output reduction are verified.
