### PR TITLE
Generalize women event marker matching

### DIFF
--- a/backend/app/services/event_resolver.py
+++ b/backend/app/services/event_resolver.py
@@ -26,6 +26,7 @@ from .outcome_normalizer import (
     _event_key_from_raw,
     _same_team_context,
     _team_similarity,
+    _team_qualifiers,
 )
 from .text_normalizer import normalize_identity_text
 
@@ -97,24 +98,40 @@ class SameTimeCanonicalMergeProposal:
     score: float
 
 
-def _significant_team_tokens(team_name: str) -> set[str]:
+_WOMEN_MARKER_TOKENS = frozenset({"w", "wom", "women", "z"})
+
+
+def _comparison_team_text(team_name: str, *, sport: str | None = None) -> str:
+    tokens = normalize_identity_text(team_name).split()
+    qualifiers = _team_qualifiers(team_name, sport=sport)
+    if "women" in qualifiers:
+        tokens = [token for token in tokens if token not in _WOMEN_MARKER_TOKENS]
+    return " ".join(tokens)
+
+
+def _significant_team_tokens(team_name: str, *, sport: str | None = None) -> set[str]:
     return {
         token
-        for token in normalize_identity_text(team_name).split()
+        for token in _comparison_team_text(team_name, sport=sport).split()
         if token not in _LOW_SIGNAL_TEAM_TOKENS
     }
 
 
-def _symmetric_canonical_team_score(left_name: str, right_name: str) -> float:
-    left_key = normalize_identity_text(left_name)
-    right_key = normalize_identity_text(right_name)
+def _symmetric_canonical_team_score(
+    left_name: str,
+    right_name: str,
+    *,
+    sport: str | None = None,
+) -> float:
+    left_key = _comparison_team_text(left_name, sport=sport)
+    right_key = _comparison_team_text(right_name, sport=sport)
     if not left_key or not right_key:
         return 0.0
     if left_key == right_key:
         return 100.0
 
-    left_tokens = _significant_team_tokens(left_name)
-    right_tokens = _significant_team_tokens(right_name)
+    left_tokens = _significant_team_tokens(left_name, sport=sport)
+    right_tokens = _significant_team_tokens(right_name, sport=sport)
     if not left_tokens or not right_tokens:
         return 0.0
     if left_tokens == right_tokens:
@@ -135,9 +152,14 @@ def _symmetric_canonical_team_score(left_name: str, right_name: str) -> float:
     )
 
 
-def _is_unsafe_compound_subset_match(left_name: str, right_name: str) -> bool:
-    left_tokens = _significant_team_tokens(left_name)
-    right_tokens = _significant_team_tokens(right_name)
+def _is_unsafe_compound_subset_match(
+    left_name: str,
+    right_name: str,
+    *,
+    sport: str | None = None,
+) -> bool:
+    left_tokens = _significant_team_tokens(left_name, sport=sport)
+    right_tokens = _significant_team_tokens(right_name, sport=sport)
     return bool(
         left_tokens
         and right_tokens
@@ -153,9 +175,17 @@ def _canonical_team_auto_merge_score(
 ) -> float | None:
     if not _same_team_context(source_team_name, target_team_name, sport=sport):
         return None
-    if _is_unsafe_compound_subset_match(source_team_name, target_team_name):
+    if _is_unsafe_compound_subset_match(
+        source_team_name,
+        target_team_name,
+        sport=sport,
+    ):
         return None
-    score = _symmetric_canonical_team_score(source_team_name, target_team_name)
+    score = _symmetric_canonical_team_score(
+        source_team_name,
+        target_team_name,
+        sport=sport,
+    )
     if score < CANONICAL_TEAM_AUTO_MERGE_THRESHOLD:
         return None
     return score
@@ -651,11 +681,15 @@ def _resolver_team_similarity(
     incorrectly merge two distinct cities).
     """
 
-    if sport not in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
-        return _team_similarity(left, right)
-    expanded_left = _expand_dotted_token(left, right)
-    expanded_right = _expand_dotted_token(right, left)
-    return _team_similarity(expanded_left, expanded_right)
+    expanded_left = left
+    expanded_right = right
+    if sport in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
+        expanded_left = _expand_dotted_token(left, right)
+        expanded_right = _expand_dotted_token(right, left)
+    return _team_similarity(
+        _comparison_team_text(expanded_left, sport=sport),
+        _comparison_team_text(expanded_right, sport=sport),
+    )
 
 
 def _orientation_scores(
@@ -685,7 +719,12 @@ def _orientation_scores(
         )
     return sorted(scores, key=lambda score: score.avg_score, reverse=True)
 
-def _is_subset_or_equal_token_pair(left_name: str, right_name: str) -> bool:
+def _is_subset_or_equal_token_pair(
+    left_name: str,
+    right_name: str,
+    *,
+    sport: str | None = None,
+) -> bool:
     """True iff one team's significant tokens are a subset/equal of the other's.
 
     Used to guard fuzzy event auto-merge against false positives where two
@@ -694,8 +733,8 @@ def _is_subset_or_equal_token_pair(left_name: str, right_name: str) -> bool:
     ``Hermine Nantes Basket``) are typically the same team with an extra
     qualifier and are safe to auto-merge at lowered score thresholds.
     """
-    left_tokens = _significant_team_tokens(left_name)
-    right_tokens = _significant_team_tokens(right_name)
+    left_tokens = _significant_team_tokens(left_name, sport=sport)
+    right_tokens = _significant_team_tokens(right_name, sport=sport)
     if not left_tokens or not right_tokens:
         return False
     return left_tokens <= right_tokens or right_tokens <= left_tokens
@@ -707,6 +746,8 @@ def _weak_side_pair_is_subset_or_equal(
     right_home: str,
     right_away: str,
     score: _OrientationScore,
+    *,
+    sport: str | None = None,
 ) -> bool:
     if score.orientation == "as_listed":
         home_pair = (left_home, right_home)
@@ -715,7 +756,7 @@ def _weak_side_pair_is_subset_or_equal(
         home_pair = (left_home, right_away)
         away_pair = (left_away, right_home)
     weak_pair = home_pair if score.home_score <= score.away_score else away_pair
-    return _is_subset_or_equal_token_pair(*weak_pair)
+    return _is_subset_or_equal_token_pair(*weak_pair, sport=sport)
 
 
 def _source_match_score(source: _RawEventSource, candidate: EventCandidate) -> float:
@@ -952,8 +993,16 @@ def extract_event_candidates(
     )
 
 
-def _shared_significant_tokens(left_name: str, right_name: str) -> set[str]:
-    return _significant_team_tokens(left_name) & _significant_team_tokens(right_name)
+def _shared_significant_tokens(
+    left_name: str,
+    right_name: str,
+    *,
+    sport: str | None = None,
+) -> set[str]:
+    return _significant_team_tokens(left_name, sport=sport) & _significant_team_tokens(
+        right_name,
+        sport=sport,
+    )
 
 
 def _passes_anchored_low_conf(
@@ -965,11 +1014,11 @@ def _passes_anchored_low_conf(
 ) -> bool:
     """Lower-threshold corroborated merge for same-slot pairs.
 
-    Restricted to basketball (``_TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE``):
-    football has its own outcome_normalizer pairing flow and the basketball-
-    tuned thresholds (avg ≥ 70 / weak ≥ 50) would generate false positives
-    on common patterns such as ``Manchester United`` ↔ ``Manchester City``
-    (same league, shared significant token, weak side ≈ 62).
+    The subset/equal branch is cross-sport so explicit women-marker variants
+    can merge outside basketball. The looser shared-token + same-league branch
+    remains restricted to the historically tuned aggressive sports because it
+    can otherwise merge common false positives such as ``Manchester United`` ↔
+    ``Manchester City``.
 
     Requires:
 
@@ -987,11 +1036,6 @@ def _passes_anchored_low_conf(
       and Austria/Australia regression tests.
     """
 
-    if left_candidate.sport not in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
-        return False
-    if right_candidate.sport not in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
-        return False
-
     if top.avg_score < _ANCHORED_FUZZY_AVG_SCORE:
         return False
     if top.weak_side_score < _ANCHORED_FUZZY_SIDE_SCORE:
@@ -1007,10 +1051,15 @@ def _passes_anchored_low_conf(
         away_pair = (left_candidate.away_team, right_candidate.home_team)
     weak_pair = home_pair if top.home_score <= top.away_score else away_pair
 
-    if _is_subset_or_equal_token_pair(*weak_pair):
+    if _is_subset_or_equal_token_pair(*weak_pair, sport=left_candidate.sport):
         return True
 
-    if not _shared_significant_tokens(*weak_pair):
+    if left_candidate.sport not in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
+        return False
+    if right_candidate.sport not in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
+        return False
+
+    if not _shared_significant_tokens(*weak_pair, sport=left_candidate.sport):
         return False
 
     left_league = left_candidate.source_league_id
@@ -1106,6 +1155,7 @@ def _group_pair_resolution(
                     right_candidate.home_team,
                     right_candidate.away_team,
                     top,
+                    sport=left_candidate.sport,
                 )
                 and top.avg_score >= _HIGH_FUZZY_AVG_SCORE
                 and top.weak_side_score >= _HIGH_FUZZY_SIDE_SCORE

--- a/backend/app/services/event_resolver.py
+++ b/backend/app/services/event_resolver.py
@@ -23,9 +23,9 @@ from .normalizer import generate_match_id
 from .outcome_normalizer import (
     _AGGRESSIVE_MERGE_SPORTS,
     _build_football_event_resolutions,
+    _comparison_team_text,
     _event_key_from_raw,
     _same_team_context,
-    _strip_explicit_z_women_markers,
     _team_similarity,
     _team_qualifiers,
 )
@@ -97,22 +97,6 @@ class SameTimeCanonicalMergeProposal:
     canonical_home_team: str
     canonical_away_team: str
     score: float
-
-
-_WOMEN_MARKER_TOKENS = frozenset({"w", "wom", "women"})
-
-
-def _comparison_team_text(team_name: str, *, sport: str | None = None) -> str:
-    qualifiers = _team_qualifiers(team_name, sport=sport)
-    comparison_name = (
-        _strip_explicit_z_women_markers(team_name)
-        if "women" in qualifiers
-        else team_name
-    )
-    tokens = normalize_identity_text(comparison_name).split()
-    if "women" in qualifiers:
-        tokens = [token for token in tokens if token not in _WOMEN_MARKER_TOKENS]
-    return " ".join(tokens)
 
 
 def _significant_team_tokens(team_name: str, *, sport: str | None = None) -> set[str]:
@@ -676,8 +660,8 @@ def _resolver_team_similarity(
 ) -> float:
     """Event-resolver-local team similarity that pre-expands dot-truncations.
 
-    Equivalent to :func:`_team_similarity` (kept untouched on purpose so
-    football paths see no regression) for cases without dotted abbreviations.
+    Equivalent to :func:`_team_similarity` for cases without dotted
+    abbreviations.
 
     Sport-gated: dot expansion only fires for sports in
     ``_TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE``. Football has its own
@@ -692,10 +676,7 @@ def _resolver_team_similarity(
     if sport in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
         expanded_left = _expand_dotted_token(left, right)
         expanded_right = _expand_dotted_token(right, left)
-    return _team_similarity(
-        _comparison_team_text(expanded_left, sport=sport),
-        _comparison_team_text(expanded_right, sport=sport),
-    )
+    return _team_similarity(expanded_left, expanded_right, sport=sport)
 
 
 def _orientation_scores(

--- a/backend/app/services/event_resolver.py
+++ b/backend/app/services/event_resolver.py
@@ -25,6 +25,7 @@ from .outcome_normalizer import (
     _build_football_event_resolutions,
     _event_key_from_raw,
     _same_team_context,
+    _strip_explicit_z_women_markers,
     _team_similarity,
     _team_qualifiers,
 )
@@ -98,12 +99,17 @@ class SameTimeCanonicalMergeProposal:
     score: float
 
 
-_WOMEN_MARKER_TOKENS = frozenset({"w", "wom", "women", "z"})
+_WOMEN_MARKER_TOKENS = frozenset({"w", "wom", "women"})
 
 
 def _comparison_team_text(team_name: str, *, sport: str | None = None) -> str:
-    tokens = normalize_identity_text(team_name).split()
     qualifiers = _team_qualifiers(team_name, sport=sport)
+    comparison_name = (
+        _strip_explicit_z_women_markers(team_name)
+        if "women" in qualifiers
+        else team_name
+    )
+    tokens = normalize_identity_text(comparison_name).split()
     if "women" in qualifiers:
         tokens = [token for token in tokens if token not in _WOMEN_MARKER_TOKENS]
     return " ".join(tokens)

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -434,6 +434,30 @@ def _reversed_slots(left: _OutcomeEventResolution, right: _OutcomeEventResolutio
     return left.slot.key == right.slot.reversed_key
 
 
+def _move_resolution_component(
+    resolutions: dict[tuple[str, str, str, str, str], _OutcomeEventResolution],
+    *,
+    source_resolution: _OutcomeEventResolution,
+    target_slot: _OutcomeEventSlot,
+    source_target_orientation: str,
+) -> None:
+    for event_key, resolution in list(resolutions.items()):
+        if resolution.slot.key != source_resolution.slot.key:
+            continue
+        relative_orientation = (
+            _SAME_ORIENTATION
+            if resolution.orientation == source_resolution.orientation
+            else _REVERSED_ORIENTATION
+        )
+        resolutions[event_key] = _OutcomeEventResolution(
+            slot=target_slot,
+            orientation=_orientation_from_pair(
+                source_target_orientation,
+                relative_orientation,
+            ),
+        )
+
+
 def _oriented_pair_team_names(
     pair: _OutcomeEventPair,
 ) -> tuple[tuple[str, str], tuple[str, str]]:
@@ -617,10 +641,14 @@ def _build_football_event_resolutions(
         if left_resolution is not None and right_resolution is not None:
             if _same_slot(left_resolution, right_resolution):
                 continue
-            if pair.orientation == _REVERSED_ORIENTATION and _reversed_slots(left_resolution, right_resolution):
-                resolutions[right_key] = _OutcomeEventResolution(
-                    slot=left_resolution.slot,
-                    orientation=_orientation_from_pair(
+            if pair.orientation == _REVERSED_ORIENTATION and _reversed_slots(
+                left_resolution, right_resolution
+            ):
+                _move_resolution_component(
+                    resolutions,
+                    source_resolution=right_resolution,
+                    target_slot=left_resolution.slot,
+                    source_target_orientation=_orientation_from_pair(
                         left_resolution.orientation,
                         pair.orientation,
                     ),
@@ -634,9 +662,11 @@ def _build_football_event_resolutions(
                     right_resolution,
                 ),
             ):
-                resolutions[right_key] = _OutcomeEventResolution(
-                    slot=left_resolution.slot,
-                    orientation=_orientation_from_pair(
+                _move_resolution_component(
+                    resolutions,
+                    source_resolution=right_resolution,
+                    target_slot=left_resolution.slot,
+                    source_target_orientation=_orientation_from_pair(
                         left_resolution.orientation,
                         pair.orientation,
                     ),

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -448,13 +448,60 @@ def _oriented_pair_team_names(
     )
 
 
-def _pair_has_matching_women_context(pair: _OutcomeEventPair) -> bool:
+def _oriented_pair_team_ids(
+    pair: _OutcomeEventPair,
+    left_resolution: _OutcomeEventResolution,
+    right_resolution: _OutcomeEventResolution,
+) -> tuple[tuple[int, int], tuple[int, int]]:
+    if pair.orientation == _SAME_ORIENTATION:
+        return (
+            (left_resolution.slot.home_team_id, right_resolution.slot.home_team_id),
+            (left_resolution.slot.away_team_id, right_resolution.slot.away_team_id),
+        )
+    return (
+        (left_resolution.slot.home_team_id, right_resolution.slot.away_team_id),
+        (left_resolution.slot.away_team_id, right_resolution.slot.home_team_id),
+    )
+
+
+def _pair_has_compatible_women_context(
+    pair: _OutcomeEventPair,
+    *,
+    oriented_team_ids: tuple[tuple[int, int], tuple[int, int]] | None = None,
+) -> bool:
+    has_women_pair = False
+    for index, (left_name, right_name) in enumerate(_oriented_pair_team_names(pair)):
+        left_qualifiers = _team_qualifiers(left_name, sport=pair.left.sport)
+        right_qualifiers = _team_qualifiers(right_name, sport=pair.left.sport)
+        if left_qualifiers != right_qualifiers:
+            return False
+        if "women" in left_qualifiers:
+            has_women_pair = True
+            continue
+        left_text = _comparison_team_text(left_name, sport=pair.left.sport)
+        right_text = _comparison_team_text(right_name, sport=pair.left.sport)
+        if left_text == right_text:
+            continue
+        if (
+            oriented_team_ids is not None
+            and oriented_team_ids[index][0] == oriented_team_ids[index][1]
+        ):
+            continue
+        return False
+    return has_women_pair
+
+
+def _pair_has_women_marker_variation(pair: _OutcomeEventPair) -> bool:
     for left_name, right_name in _oriented_pair_team_names(pair):
         left_qualifiers = _team_qualifiers(left_name, sport=pair.left.sport)
         right_qualifiers = _team_qualifiers(right_name, sport=pair.left.sport)
-        if left_qualifiers != right_qualifiers or "women" not in left_qualifiers:
-            return False
-    return True
+        if (
+            left_qualifiers == right_qualifiers
+            and "women" in left_qualifiers
+            and normalize_identity_text(left_name) != normalize_identity_text(right_name)
+        ):
+            return True
+    return False
 
 
 def _rank_event_pairs(events: list[_OutcomeEvent]) -> list[_OutcomeEventPair]:
@@ -464,12 +511,14 @@ def _rank_event_pairs(events: list[_OutcomeEvent]) -> list[_OutcomeEventPair]:
 
     accepted: list[_OutcomeEventPair] = []
     for events in events_by_slot.values():
+        all_pairs: list[_OutcomeEventPair] = []
         candidates_by_event: dict[_OutcomeEvent, list[_OutcomeEventPair]] = defaultdict(list)
         for idx, left in enumerate(events):
             for right in events[idx + 1 :]:
                 pair = _pair_candidates(left, right)
                 if pair is None:
                     continue
+                all_pairs.append(pair)
                 candidates_by_event[left].append(pair)
                 candidates_by_event[right].append(pair)
 
@@ -490,6 +539,14 @@ def _rank_event_pairs(events: list[_OutcomeEvent]) -> list[_OutcomeEventPair]:
                 continue
             if best not in accepted:
                 accepted.append(best)
+
+        for pair in all_pairs:
+            if (
+                _pair_has_compatible_women_context(pair)
+                and _pair_has_women_marker_variation(pair)
+                and pair not in accepted
+            ):
+                accepted.append(pair)
 
     return sorted(accepted, key=lambda item: item.score, reverse=True)
 
@@ -523,7 +580,14 @@ def _build_football_event_resolutions(
                     ),
                 )
                 continue
-            if _pair_has_matching_women_context(pair):
+            if _pair_has_compatible_women_context(
+                pair,
+                oriented_team_ids=_oriented_pair_team_ids(
+                    pair,
+                    left_resolution,
+                    right_resolution,
+                ),
+            ):
                 resolutions[right_key] = _OutcomeEventResolution(
                     slot=left_resolution.slot,
                     orientation=_orientation_from_pair(

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -488,6 +488,37 @@ def _oriented_pair_team_ids(
     )
 
 
+def _oriented_pair_team_ids_from_resolutions(
+    pair: _OutcomeEventPair,
+    resolutions: dict[tuple[str, str, str, str, str], _OutcomeEventResolution],
+) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    left_resolution = resolutions.get(_event_key(pair.left))
+    right_resolution = resolutions.get(_event_key(pair.right))
+    if left_resolution is None or right_resolution is None:
+        return None
+    return _oriented_pair_team_ids(pair, left_resolution, right_resolution)
+
+
+def _comparison_team_texts_are_compatible(
+    left_name: str,
+    right_name: str,
+    *,
+    sport: str | None = None,
+    team_ids: tuple[int, int] | None = None,
+) -> bool:
+    if team_ids is not None and team_ids[0] == team_ids[1]:
+        return True
+    left_text = _comparison_team_text(left_name, sport=sport)
+    right_text = _comparison_team_text(right_name, sport=sport)
+    if left_text == right_text:
+        return True
+    left_tokens = _significant_tokens(left_name, sport=sport)
+    right_tokens = _significant_tokens(right_name, sport=sport)
+    if not left_tokens or not right_tokens:
+        return False
+    return left_tokens <= right_tokens or right_tokens <= left_tokens
+
+
 def _pair_has_compatible_women_context(
     pair: _OutcomeEventPair,
     *,
@@ -501,17 +532,13 @@ def _pair_has_compatible_women_context(
             return False
         if "women" in left_qualifiers:
             has_women_pair = True
-            continue
-        left_text = _comparison_team_text(left_name, sport=pair.left.sport)
-        right_text = _comparison_team_text(right_name, sport=pair.left.sport)
-        if left_text == right_text:
-            continue
-        if (
-            oriented_team_ids is not None
-            and oriented_team_ids[index][0] == oriented_team_ids[index][1]
+        if not _comparison_team_texts_are_compatible(
+            left_name,
+            right_name,
+            sport=pair.left.sport,
+            team_ids=oriented_team_ids[index] if oriented_team_ids is not None else None,
         ):
-            continue
-        return False
+            return False
     return has_women_pair
 
 
@@ -574,7 +601,11 @@ def _pair_has_women_marker_variation(pair: _OutcomeEventPair) -> bool:
     return False
 
 
-def _rank_event_pairs(events: list[_OutcomeEvent]) -> list[_OutcomeEventPair]:
+def _rank_event_pairs(
+    events: list[_OutcomeEvent],
+    *,
+    resolutions: dict[tuple[str, str, str, str, str], _OutcomeEventResolution] | None = None,
+) -> list[_OutcomeEventPair]:
     events_by_slot: dict[tuple[str, str], list[_OutcomeEvent]] = defaultdict(list)
     for event in events:
         events_by_slot[(event.sport, event.start_time)].append(event)
@@ -611,8 +642,16 @@ def _rank_event_pairs(events: list[_OutcomeEvent]) -> list[_OutcomeEventPair]:
                 accepted.append(best)
 
         for pair in all_pairs:
+            oriented_team_ids = (
+                _oriented_pair_team_ids_from_resolutions(pair, resolutions)
+                if resolutions is not None
+                else None
+            )
             if (
-                _pair_has_compatible_women_context(pair)
+                _pair_has_compatible_women_context(
+                    pair,
+                    oriented_team_ids=oriented_team_ids,
+                )
                 and _pair_has_women_marker_variation(pair)
                 and pair not in accepted
             ):
@@ -632,7 +671,7 @@ def _build_football_event_resolutions(
             continue
         resolutions[_event_key(event)] = _OutcomeEventResolution(slot=slot)
 
-    for pair in _rank_event_pairs(events):
+    for pair in _rank_event_pairs(events, resolutions=resolutions):
         left_key = _event_key(pair.left)
         right_key = _event_key(pair.right)
         left_resolution = resolutions.get(left_key)

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -187,6 +187,27 @@ def _team_qualifiers(name: str, *, sport: str | None = None) -> set[str]:
     return qualifiers
 
 
+def _strip_explicit_z_women_markers(name: str) -> str:
+    without_parenthesized = re.sub(
+        r"\(\s*[žz]\s*\)",
+        " ",
+        name,
+        flags=re.IGNORECASE,
+    )
+    without_leading_slash = re.sub(
+        r"^\s*[žz]\s*/",
+        "",
+        without_parenthesized,
+        flags=re.IGNORECASE,
+    )
+    return re.sub(
+        r"(^|\s)ž(?=$|\s)",
+        r"\1",
+        without_leading_slash,
+        flags=re.IGNORECASE,
+    )
+
+
 def _same_team_context(left: str, right: str, *, sport: str | None = None) -> bool:
     return _team_qualifiers(left, sport=sport) == _team_qualifiers(right, sport=sport)
 

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -491,6 +491,52 @@ def _pair_has_compatible_women_context(
     return has_women_pair
 
 
+def _women_marker_forms(name: str) -> frozenset[str]:
+    forms: set[str] = set()
+    if re.search(r"\(\s*[žz]\s*\)", name, flags=re.IGNORECASE):
+        forms.add("z:parenthesized")
+    if re.search(r"^\s*[žz]\s*/", name, flags=re.IGNORECASE):
+        forms.add("z:slash-prefix")
+    if re.search(r"(^|\s)ž(?=$|\s)", name, flags=re.IGNORECASE):
+        forms.add("z:standalone")
+
+    tokens = normalize_identity_text(name).split()
+    youth_ages = {"17", "18", "19", "20", "21", "23"}
+    active_qualifier_tokens = _TEAM_QUALIFIER_TOKENS | {"wom"}
+
+    def suffix_has_qualifier(start_index: int) -> bool:
+        index = start_index
+        while index < len(tokens):
+            token = tokens[index]
+            next_token = tokens[index + 1] if index + 1 < len(tokens) else None
+            if token == "team":
+                index += 1
+                continue
+            if token == "u" and next_token in youth_ages:
+                return True
+            if token in active_qualifier_tokens:
+                return True
+            index += 1
+        return False
+
+    for index, token in enumerate(tokens):
+        if token not in _WOMEN_QUALIFIER_ALIASES:
+            continue
+        next_token = tokens[index + 1] if index + 1 < len(tokens) else None
+        is_explicit_prefix = token in {"women", "wom"} and index == 0 and len(tokens) > 1
+        is_suffix = index > 0 and (
+            index == len(tokens) - 1
+            or next_token in {"team", "women"}
+            or suffix_has_qualifier(index + 1)
+        )
+        if is_explicit_prefix:
+            forms.add(f"{token}:prefix")
+        if is_suffix:
+            forms.add(f"{token}:suffix")
+
+    return frozenset(forms)
+
+
 def _pair_has_women_marker_variation(pair: _OutcomeEventPair) -> bool:
     for left_name, right_name in _oriented_pair_team_names(pair):
         left_qualifiers = _team_qualifiers(left_name, sport=pair.left.sport)
@@ -498,7 +544,7 @@ def _pair_has_women_marker_variation(pair: _OutcomeEventPair) -> bool:
         if (
             left_qualifiers == right_qualifiers
             and "women" in left_qualifiers
-            and normalize_identity_text(left_name) != normalize_identity_text(right_name)
+            and _women_marker_forms(left_name) != _women_marker_forms(right_name)
         ):
             return True
     return False

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -48,6 +48,7 @@ _TEAM_QUALIFIER_TOKENS = {
 # this set because it is a common location abbreviation in football; only
 # explicit marker syntax such as "(Ž)" or "Ž/" is treated as women.
 _WOMEN_QUALIFIER_ALIASES = frozenset({"w", "wom", "women"})
+_WOMEN_MARKER_TOKENS = frozenset({"w", "wom", "women"})
 _AGGRESSIVE_MERGE_SPORTS = frozenset({"basketball"})
 _EXPLICIT_Z_WOMEN_MARKER_RE = re.compile(
     r"(^|\s)ž(?=$|\s)|\(\s*[žz]\s*\)|^\s*[žz]\s*/",
@@ -111,23 +112,23 @@ class _OutcomeEventPair:
         return min(self.home_score, self.away_score)
 
 
-def _significant_tokens(name: str) -> set[str]:
+def _significant_tokens(name: str, *, sport: str | None = None) -> set[str]:
     return {
         token
-        for token in normalize_identity_text(name).split()
+        for token in _comparison_team_text(name, sport=sport).split()
         if token not in _LOW_SIGNAL_TEAM_TOKENS
     }
 
 
-def _team_similarity(left: str, right: str) -> float:
-    left_key = normalize_identity_text(left)
-    right_key = normalize_identity_text(right)
+def _team_similarity(left: str, right: str, *, sport: str | None = None) -> float:
+    left_key = _comparison_team_text(left, sport=sport)
+    right_key = _comparison_team_text(right, sport=sport)
     if not left_key or not right_key:
         return 0.0
     if left_key == right_key:
         return 100.0
-    left_tokens = _significant_tokens(left)
-    right_tokens = _significant_tokens(right)
+    left_tokens = _significant_tokens(left, sport=sport)
+    right_tokens = _significant_tokens(right, sport=sport)
     if left_tokens and left_tokens == right_tokens:
         return 100.0
     return float(fuzz.token_sort_ratio(left_key, right_key))
@@ -167,12 +168,17 @@ def _team_qualifiers(name: str, *, sport: str | None = None) -> set[str]:
                 qualifiers.add(token)
             continue
         if token in _WOMEN_QUALIFIER_ALIASES:
+            is_explicit_prefix = (
+                token in {"women", "wom"}
+                and index == 0
+                and len(tokens) > 1
+            )
             is_suffix = index > 0 and (
                 index == len(tokens) - 1
                 or next_token in {"team", "women"}
                 or suffix_has_qualifier(index + 1)
             )
-            if is_suffix:
+            if is_explicit_prefix or is_suffix:
                 qualifiers.add("women")
             continue
         if token == "z":
@@ -206,6 +212,19 @@ def _strip_explicit_z_women_markers(name: str) -> str:
         without_leading_slash,
         flags=re.IGNORECASE,
     )
+
+
+def _comparison_team_text(team_name: str, *, sport: str | None = None) -> str:
+    qualifiers = _team_qualifiers(team_name, sport=sport)
+    comparison_name = (
+        _strip_explicit_z_women_markers(team_name)
+        if "women" in qualifiers
+        else team_name
+    )
+    tokens = normalize_identity_text(comparison_name).split()
+    if "women" in qualifiers:
+        tokens = [token for token in tokens if token not in _WOMEN_MARKER_TOKENS]
+    return " ".join(tokens)
 
 
 def _same_team_context(left: str, right: str, *, sport: str | None = None) -> bool:
@@ -284,8 +303,12 @@ def _pair_candidates(left: _OutcomeEvent, right: _OutcomeEvent) -> _OutcomeEvent
             _OutcomeEventPair(
                 left=left,
                 right=right,
-                home_score=_team_similarity(left.home_team, right.home_team),
-                away_score=_team_similarity(left.away_team, right.away_team),
+                home_score=_team_similarity(
+                    left.home_team, right.home_team, sport=left.sport
+                ),
+                away_score=_team_similarity(
+                    left.away_team, right.away_team, sport=left.sport
+                ),
                 orientation=_SAME_ORIENTATION,
             )
         )
@@ -294,8 +317,12 @@ def _pair_candidates(left: _OutcomeEvent, right: _OutcomeEvent) -> _OutcomeEvent
             _OutcomeEventPair(
                 left=left,
                 right=right,
-                home_score=_team_similarity(left.home_team, right.away_team),
-                away_score=_team_similarity(left.away_team, right.home_team),
+                home_score=_team_similarity(
+                    left.home_team, right.away_team, sport=left.sport
+                ),
+                away_score=_team_similarity(
+                    left.away_team, right.home_team, sport=left.sport
+                ),
                 orientation=_REVERSED_ORIENTATION,
             )
         )

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -434,6 +434,29 @@ def _reversed_slots(left: _OutcomeEventResolution, right: _OutcomeEventResolutio
     return left.slot.key == right.slot.reversed_key
 
 
+def _oriented_pair_team_names(
+    pair: _OutcomeEventPair,
+) -> tuple[tuple[str, str], tuple[str, str]]:
+    if pair.orientation == _SAME_ORIENTATION:
+        return (
+            (pair.left.home_team, pair.right.home_team),
+            (pair.left.away_team, pair.right.away_team),
+        )
+    return (
+        (pair.left.home_team, pair.right.away_team),
+        (pair.left.away_team, pair.right.home_team),
+    )
+
+
+def _pair_has_matching_women_context(pair: _OutcomeEventPair) -> bool:
+    for left_name, right_name in _oriented_pair_team_names(pair):
+        left_qualifiers = _team_qualifiers(left_name, sport=pair.left.sport)
+        right_qualifiers = _team_qualifiers(right_name, sport=pair.left.sport)
+        if left_qualifiers != right_qualifiers or "women" not in left_qualifiers:
+            return False
+    return True
+
+
 def _rank_event_pairs(events: list[_OutcomeEvent]) -> list[_OutcomeEventPair]:
     events_by_slot: dict[tuple[str, str], list[_OutcomeEvent]] = defaultdict(list)
     for event in events:
@@ -494,7 +517,19 @@ def _build_football_event_resolutions(
             if pair.orientation == _REVERSED_ORIENTATION and _reversed_slots(left_resolution, right_resolution):
                 resolutions[right_key] = _OutcomeEventResolution(
                     slot=left_resolution.slot,
-                    orientation=_orientation_from_pair(left_resolution.orientation, pair.orientation),
+                    orientation=_orientation_from_pair(
+                        left_resolution.orientation,
+                        pair.orientation,
+                    ),
+                )
+                continue
+            if _pair_has_matching_women_context(pair):
+                resolutions[right_key] = _OutcomeEventResolution(
+                    slot=left_resolution.slot,
+                    orientation=_orientation_from_pair(
+                        left_resolution.orientation,
+                        pair.orientation,
+                    ),
                 )
             continue
 

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 import logging
+import re
 
 from rapidfuzz import fuzz
 
@@ -43,15 +44,15 @@ _TEAM_QUALIFIER_TOKENS = {
     "women",
     "youth",
 }
-# Extra qualifier tokens / aliases that are only honored for sports in the
-# aggressive-merge allowlist. Keeping them out of the base set avoids
-# regressing pairing for other sports (notably football) where ``z`` is a
-# common Slavic city abbreviation (Zvornik, Zenica, Zemun, Zrenjanin) and
-# ``wom`` is a non-standard form that does not appear in the canonical
-# football registries — collapsing them onto ``women`` there would silently
-# block legitimate same-team pairings.
-_AGGRESSIVE_QUALIFIER_ALIASES = frozenset({"wom", "z"})
+# Cross-sport aliases for explicit women markers. Plain ASCII "z" is not in
+# this set because it is a common location abbreviation in football; only
+# explicit marker syntax such as "(Ž)" or "Ž/" is treated as women.
+_WOMEN_QUALIFIER_ALIASES = frozenset({"w", "wom", "women"})
 _AGGRESSIVE_MERGE_SPORTS = frozenset({"basketball"})
+_EXPLICIT_Z_WOMEN_MARKER_RE = re.compile(
+    r"(^|\s)ž(?=$|\s)|\(\s*[žz]\s*\)|^\s*[žz]\s*/",
+    re.IGNORECASE,
+)
 _SAME_ORIENTATION = "same"
 _REVERSED_ORIENTATION = "reversed"
 
@@ -136,12 +137,10 @@ def _team_qualifiers(name: str, *, sport: str | None = None) -> set[str]:
     tokens = normalize_identity_text(name).split()
     qualifiers: set[str] = set()
     youth_ages = {"17", "18", "19", "20", "21", "23"}
-    aggressive = sport in _AGGRESSIVE_MERGE_SPORTS
-    active_qualifier_tokens = (
-        _TEAM_QUALIFIER_TOKENS | _AGGRESSIVE_QUALIFIER_ALIASES
-        if aggressive
-        else _TEAM_QUALIFIER_TOKENS
-    )
+    active_qualifier_tokens = _TEAM_QUALIFIER_TOKENS | {"wom"}
+
+    if _EXPLICIT_Z_WOMEN_MARKER_RE.search(name):
+        qualifiers.add("women")
 
     def suffix_has_qualifier(start_index: int) -> bool:
         index = start_index
@@ -167,30 +166,20 @@ def _team_qualifiers(name: str, *, sport: str | None = None) -> set[str]:
             if index > 0 and (index == len(tokens) - 1 or next_token == "team" or suffix_has_qualifier(index + 1)):
                 qualifiers.add(token)
             continue
-        if aggressive and token in {"w", "wom", "z"}:
-            # Aliases for the "women" qualifier when they appear as a trailing
-            # suffix marker (e.g. "Sao Jose W", "Sao Jose Wom.", "Sao Jose (Ž)"
-            # whose normalised form is "sao jose z" after diacritic stripping).
-            # Restrict to suffix position so legitimate name initials such as
-            # "Z. Velickovic" do not flip a team's gender. The single-letter
-            # "z" alias additionally requires at least three tokens — this
-            # rules out 2-token names like "Real Z" / "Bayern Z" that would
-            # otherwise be tagged as women's teams purely on the trailing
-            # letter while keeping the user-reported "Sao Jose Z" pattern
-            # (3 tokens) covered.
-            #
-            # Sport-gated to ``_AGGRESSIVE_MERGE_SPORTS``: the same patterns
-            # collide with city abbreviations in non-target sports (e.g.
-            # football "FK Borac Z" = Zvornik), so for those sports the legacy
-            # behavior is preserved (``w`` → qualifier ``w``; ``wom``/``z``
-            # ignored).
+        if token in _WOMEN_QUALIFIER_ALIASES:
             is_suffix = index > 0 and (
                 index == len(tokens) - 1
                 or next_token in {"team", "women"}
                 or suffix_has_qualifier(index + 1)
             )
-            if is_suffix and (token != "z" or len(tokens) >= 3):
+            if is_suffix:
                 qualifiers.add("women")
+            continue
+        if token == "z":
+            # Plain ASCII Z is intentionally not a universal women alias.
+            # The explicit-marker regex above handles "(Ž)", "(Z)", "Ž/",
+            # and "Z/" without breaking football abbreviations such as
+            # "FK Borac Z" for Zvornik.
             continue
         if token not in active_qualifier_tokens:
             continue

--- a/backend/tests/test_event_resolver.py
+++ b/backend/tests/test_event_resolver.py
@@ -17,6 +17,7 @@ from app.services.event_resolver import (
     EventCandidate,
     _CandidateGroup,
     _PairResolution,
+    _comparison_team_text,
     _contextual_merge_source_ids,
     _event_review_case,
     SameTimeCanonicalSlot,
@@ -2122,6 +2123,11 @@ def test_team_qualifiers_explicit_z_marker_is_cross_sport_but_plain_z_is_not():
     assert _team_qualifiers("Sao Jose (Ž)", sport="football") == {"women"}
     assert _team_qualifiers("Ž/Sao Jose Dos Campos", sport="football") == {"women"}
     assert _team_qualifiers("Z/Sao Jose Dos Campos", sport="volleyball") == {"women"}
+
+
+def test_comparison_text_preserves_plain_z_when_explicit_marker_is_present():
+    assert _comparison_team_text("FK Borac Z (Ž)", sport="football") == "fk borac z"
+    assert _comparison_team_text("FK Borac (Ž)", sport="football") == "fk borac"
 
 
 def test_team_qualifiers_wom_alias_applies_cross_sport():

--- a/backend/tests/test_event_resolver.py
+++ b/backend/tests/test_event_resolver.py
@@ -25,6 +25,7 @@ from app.services.event_resolver import (
     resolve_and_persist_events,
 )
 from app.services.normalizer import generate_match_id
+from app.services.outcome_normalizer import _same_team_context, _team_qualifiers
 from app.services.team_registry import create_canonical_team
 from app.store import odds_store
 
@@ -1386,25 +1387,28 @@ async def test_event_resolver_women_marker_merges_w_and_wom_variants(
 async def test_event_resolver_women_marker_recognises_terminal_z(
     team_registry_file,
 ):
-    """A terminal standalone ``Z`` token (``Sao Jose (Ž)`` after diacritic
+    """An explicit standalone ``Ž`` marker (``Sao Jose (Ž)`` after diacritic
     strip) is treated as a women qualifier and pairs with ``Sao Jose Wom.``.
     """
 
-    sao_jose_z = create_canonical_team(display_name="Sao Jose Z", sport="basketball")
+    sao_jose_z = create_canonical_team(display_name="Sao Jose (Ž)", sport="basketball")
     sao_jose_wom = create_canonical_team(
         display_name="Sao Jose Wom.", sport="basketball"
     )
-    santo_andre = create_canonical_team(
-        display_name="Santo Andre", sport="basketball"
+    santo_andre_z = create_canonical_team(
+        display_name="Santo Andre (Ž)", sport="basketball"
+    )
+    santo_andre_wom = create_canonical_team(
+        display_name="Santo Andre Wom.", sport="basketball"
     )
     league_id = "lbf"
     await _seed_bookmakers("mozzart", "meridian", "superbet")
     await _seed_league(league_id, "basketball")
     z_match_id = generate_match_id(
-        sao_jose_z.team_id, santo_andre.team_id, START_TIME, "basketball"
+        sao_jose_z.team_id, santo_andre_z.team_id, START_TIME, "basketball"
     )
     wom_match_id = generate_match_id(
-        sao_jose_wom.team_id, santo_andre.team_id, START_TIME, "basketball"
+        sao_jose_wom.team_id, santo_andre_wom.team_id, START_TIME, "basketball"
     )
     normalized = [
         _basketball_odds(
@@ -1412,9 +1416,9 @@ async def test_event_resolver_women_marker_recognises_terminal_z(
             match_id=z_match_id,
             league_id=league_id,
             home_team_id=sao_jose_z.team_id,
-            away_team_id=santo_andre.team_id,
+            away_team_id=santo_andre_z.team_id,
             home_team=sao_jose_z.team_name,
-            away_team=santo_andre.team_name,
+            away_team=santo_andre_z.team_name,
             threshold=12.5,
         ),
         _basketball_odds(
@@ -1422,9 +1426,9 @@ async def test_event_resolver_women_marker_recognises_terminal_z(
             match_id=wom_match_id,
             league_id=league_id,
             home_team_id=sao_jose_wom.team_id,
-            away_team_id=santo_andre.team_id,
+            away_team_id=santo_andre_wom.team_id,
             home_team=sao_jose_wom.team_name,
-            away_team=santo_andre.team_name,
+            away_team=santo_andre_wom.team_name,
             threshold=13.5,
         ),
         _basketball_odds(
@@ -1432,9 +1436,9 @@ async def test_event_resolver_women_marker_recognises_terminal_z(
             match_id=wom_match_id,
             league_id=league_id,
             home_team_id=sao_jose_wom.team_id,
-            away_team_id=santo_andre.team_id,
+            away_team_id=santo_andre_wom.team_id,
             home_team=sao_jose_wom.team_name,
-            away_team=santo_andre.team_name,
+            away_team=santo_andre_wom.team_name,
             threshold=14.5,
         ),
     ]
@@ -1470,6 +1474,96 @@ async def test_event_resolver_women_marker_recognises_terminal_z(
     event = await odds_store.get_resolved_event(events[0].id)
     assert event is not None
     assert event.method == "auto_fuzzy_high"
+
+
+def test_event_resolver_merges_reported_sao_jose_women_fragments():
+    candidates = [
+        EventCandidate(
+            match_id="sao-jose-wom",
+            bookmaker_id=bookmaker_id,
+            sport="football",
+            start_time=START_TIME,
+            home_team_id=1,
+            away_team_id=2,
+            home_team="Sao Jose Wom.",
+            away_team="Santo Andre Wom.",
+            source_league_id="brazil_1_z",
+            source_league_name="Brazil 1 Z",
+        )
+        for bookmaker_id in ("admiralbet", "betole", "oktagonbet", "pinnbet")
+    ] + [
+        EventCandidate(
+            match_id="sao-jose-dos-campos-w",
+            bookmaker_id="merkurxtip",
+            sport="football",
+            start_time=START_TIME,
+            home_team_id=3,
+            away_team_id=4,
+            home_team="Sao Jose Dos Campos W",
+            away_team="Santo Andre Wom.",
+            source_league_id="lbf_women",
+            source_league_name="LBF Women",
+        ),
+        EventCandidate(
+            match_id="sao-jose-z",
+            bookmaker_id="superbet",
+            sport="football",
+            start_time=START_TIME,
+            home_team_id=5,
+            away_team_id=6,
+            home_team="Sao Jose Campos (Ž)",
+            away_team="Santo Andre (Ž)",
+            source_league_id="brazil_lbf_z",
+            source_league_name="Brazil LBF Z",
+        ),
+        EventCandidate(
+            match_id="sao-jose-z-slash",
+            bookmaker_id="volcanobet",
+            sport="football",
+            start_time=START_TIME,
+            home_team_id=7,
+            away_team_id=8,
+            home_team="Ž/Sao Jose Dos Campos",
+            away_team="Ž/Santo Andre Apaba",
+            source_league_id="brazil_1_z",
+            source_league_name="Brazil 1 Z",
+        ),
+        EventCandidate(
+            match_id="sao-jose-z-slash",
+            bookmaker_id="balkanbet",
+            sport="football",
+            start_time=START_TIME,
+            home_team_id=7,
+            away_team_id=8,
+            home_team="Sao Jose Dos Campos SP",
+            away_team="Santo Andre/Apaba",
+            source_league_id="balkanbet_tournament_44979",
+            source_league_name="Balkanbet Tournament 44979",
+        ),
+    ]
+
+    resolutions, review_cases = build_event_resolution_groups(candidates)
+
+    assert review_cases == []
+    assert len(resolutions) == 1
+    event = resolutions[0]
+    assert event.method == "auto_fuzzy_high"
+    assert {member.bookmaker_id for member in event.members} == {
+        "admiralbet",
+        "betole",
+        "oktagonbet",
+        "pinnbet",
+        "merkurxtip",
+        "superbet",
+        "volcanobet",
+        "balkanbet",
+    }
+    assert {member.match_id for member in event.members} == {
+        "sao-jose-wom",
+        "sao-jose-dos-campos-w",
+        "sao-jose-z",
+        "sao-jose-z-slash",
+    }
 
 
 @pytest.mark.asyncio
@@ -2009,101 +2103,45 @@ def test_expand_dotted_token_ambiguous_geographic_prefix_blocked():
     ), "Non-ambiguous trailing-dot tokens still resolve."
 
 
-def test_team_qualifiers_z_alias_does_not_apply_to_football():
-    """Round-2 regression: the ``z``-suffix → ``women`` alias is sport-gated
-    to ``_AGGRESSIVE_MERGE_SPORTS``. In football, ``z`` is a common Slavic
-    city abbreviation (Zvornik, Zenica, Zemun, Zrenjanin) and aliasing it
-    to ``women`` would silently block legitimate same-team pairings.
-    Pre-fix, ``_team_qualifiers`` returned ``{women}`` for any 3+ token
-    name ending in literal ``z``, so ``FK Borac Z`` (an abbreviation for
-    ``FK Borac Zvornik``) and bare ``FK Borac Zvornik`` had divergent
-    qualifier sets and ``_same_team_context`` rejected them.
+def test_team_qualifiers_explicit_z_marker_is_cross_sport_but_plain_z_is_not():
+    """Explicit ``Ž`` marker syntax is cross-sport, but plain ASCII ``Z`` is
+    still too ambiguous to mean women by itself.
     """
 
-    from app.services.outcome_normalizer import (  # noqa: PLC0415
-        _same_team_context,
-        _team_qualifiers,
-    )
-
-    # The core regression: in football the trailing ``z`` token must NOT
-    # be aliased to women, so qualifier sets stay equal across the
-    # abbreviated and full forms (both empty).
     assert _team_qualifiers("FK Borac Z", sport="football") == set()
     assert _team_qualifiers("FK Borac Zvornik", sport="football") == set()
     assert _team_qualifiers("FK Crvena Zvezda Z", sport="football") == set()
     assert _team_qualifiers("FK Crvena Zvezda", sport="football") == set()
-
-    # Therefore ``_same_team_context`` accepts these pairs in football, so
-    # they remain eligible for cross-bookmaker pairing and canonical-team
-    # merging — restoring pre-PR behavior.
     assert _same_team_context("FK Borac Z", "FK Borac Zvornik", sport="football")
     assert _same_team_context(
         "FK Crvena Zvezda Z", "FK Crvena Zvezda", sport="football"
     )
-
-    # Basketball retains the aggressive women-alias semantics that this PR
-    # added (3+ token guard still applies to avoid ``Real Z``-style
-    # collisions).
-    assert _team_qualifiers("Sao Jose Z", sport="basketball") == {"women"}
-    assert _team_qualifiers("Real Z", sport="basketball") == set(), (
-        "Two-token names must not flip to women on a trailing Z."
-    )
-
-    # Sports outside ``_AGGRESSIVE_MERGE_SPORTS`` (and ``sport=None``)
-    # also stay on the conservative path so any future call site that
-    # forgets to pass sport falls back to safe behavior.
-    assert _team_qualifiers("Sao Jose Z") == set()
+    assert _team_qualifiers("Sao Jose Z", sport="basketball") == set()
     assert _team_qualifiers("Sao Jose Z", sport="tennis") == set()
+    assert _team_qualifiers("Sao Jose (Ž)", sport="basketball") == {"women"}
+    assert _team_qualifiers("Sao Jose (Ž)", sport="football") == {"women"}
+    assert _team_qualifiers("Ž/Sao Jose Dos Campos", sport="football") == {"women"}
+    assert _team_qualifiers("Z/Sao Jose Dos Campos", sport="volleyball") == {"women"}
 
 
-def test_team_qualifiers_wom_alias_does_not_apply_to_football():
-    """Round-2 regression: ``wom`` is also basketball-only. In football the
-    alias is a no-op so legacy pairing behavior is preserved.
-    """
-
-    from app.services.outcome_normalizer import (  # noqa: PLC0415
-        _same_team_context,
-        _team_qualifiers,
-    )
-
-    assert _team_qualifiers("Sao Jose Wom", sport="football") == set()
+def test_team_qualifiers_wom_alias_applies_cross_sport():
+    assert _team_qualifiers("Sao Jose Wom", sport="football") == {"women"}
+    assert _team_qualifiers("Sao Jose Wom", sport="tennis") == {"women"}
     assert _team_qualifiers("Sao Jose Women", sport="football") == {"women"}
-    # Cross-context with sport=None mirrors football (no aggressive aliases
-    # active) so unspecified-sport callers stay on the conservative path.
-    assert _team_qualifiers("Sao Jose Wom") == set()
-    # Basketball still aliases as expected.
+    assert _team_qualifiers("Sao Jose Wom") == {"women"}
     assert _team_qualifiers("Sao Jose Wom", sport="basketball") == {"women"}
     assert _same_team_context(
-        "Sao Jose Wom", "Sao Jose Women", sport="basketball"
+        "Sao Jose Wom", "Sao Jose Women", sport="football"
     )
 
 
 def test_contextual_merge_source_ids_threads_sport_to_helpers():
-    """Round-2 review (Opus 1M) integration regression for the scheduler-driven
-    canonical-team auto-merge path.
+    """Integration regression for scheduler-driven canonical-team auto-merge.
 
-    The Round 1 bug was that ``_team_qualifiers`` returned ``{women}`` for
-    any 3+ token name ending in literal ``z`` for *every* sport, so
-    ``scheduler._candidate_merge_source_ids`` →
-    ``_contextual_merge_source_ids`` →
-    ``_canonical_team_auto_merge_score`` silently rejected legitimate
-    Slavic-football canonical merges. The Round 2 fix sport-gates the
-    qualifier aliases by threading ``sport=case.sport`` through the call
-    chain.
-
-    A realistic football pair like ``FK Crvena Zvezda Z`` ↔
-    ``FK Crvena Zvezda Belgrade`` cannot be reproduced at this layer
-    because the unsafe-subset gate or the fuzzy threshold (88.0) blocks
-    the score regardless of qualifier alignment. So this test uses a
-    deliberately-symmetric pair (``Aalesund Wom`` ↔ ``Aalesund Women``)
-    where the *only* thing that flips the merge decision between
-    basketball and football is whether the ``wom`` → ``women`` alias is
-    active. That makes the test sensitive to a future refactor that drops
-    ``sport=case.sport`` from the
-    ``_canonical_team_auto_merge_score`` call site at
-    ``event_resolver.py`` (currently line ~291): both invocations would
-    silently fall back to the conservative path and the basketball
-    assertion would fail loudly.
+    ``Wom`` and ``Women`` are intentionally cross-sport women markers now, so
+    the same contextual merge should be eligible in basketball and football.
+    The separate plain-``Z`` tests cover the Slavic-football abbreviation case
+    that originally motivated the old basketball-only gate.
     """
 
     basketball_case = TeamReviewDiagnostic(
@@ -2151,17 +2189,8 @@ def test_contextual_merge_source_ids_threads_sport_to_helpers():
         "event teams overlap on ``Bergen Women``."
     )
 
-    # Football: identical case structure, only the sport flips. Without the
-    # sport gate, the football path would call ``_team_qualifiers`` and find
-    # ``Aalesund Wom`` → set() while ``Aalesund Women`` → {women}, the sets
-    # diverge and ``_same_team_context`` rejects the pair. So the merge is
-    # blocked. If a future refactor removes the ``sport=case.sport`` kwarg,
-    # both basketball and football cases would silently use the conservative
-    # path and this assertion would still hold — but the basketball
-    # assertion above would flip from {202} to set(), catching the
-    # regression loudly.
     football_case = basketball_case.model_copy(update={"sport": "football"})
-    assert _contextual_merge_source_ids(football_case) == set(), (
-        "Football case: divergent qualifier sets (``Wom`` is a no-op alias "
-        "in football) must continue to block the canonical-team auto-merge."
+    assert _contextual_merge_source_ids(football_case) == {202}, (
+        "Football women-marker cases should follow the same contextual "
+        "canonical merge path as basketball."
     )

--- a/backend/tests/test_outcome_normalizer.py
+++ b/backend/tests/test_outcome_normalizer.py
@@ -252,6 +252,75 @@ def test_football_event_match_collapses_existing_women_marker_variant_canonicals
     assert _auto_review_alias_count() == 0
 
 
+def test_football_event_match_collapses_one_sided_existing_women_marker_variant(team_registry_file):
+    create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
+    create_canonical_team(display_name="Sao Jose Wom.", sport="football")
+    create_canonical_team(display_name="Santo Andre", sport="football")
+    raw = [
+        _offer(
+            "superbet",
+            "Sao Jose Campos (Ž)",
+            "Santo Andre",
+            outcome_code="over",
+        ),
+        _offer(
+            "pinnbet",
+            "Sao Jose Wom.",
+            "Santo Andre",
+            outcome_code="under",
+        ),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+
+    assert len(normalized) == 2
+    assert {offer.match_id for offer in normalized} == {normalized[0].match_id}
+    assert {
+        (offer.home_team_id, offer.away_team_id) for offer in normalized
+    } == {(normalized[0].home_team_id, normalized[0].away_team_id)}
+    assert unresolved == []
+    assert review_cases == []
+    assert _auto_review_alias_count() == 0
+
+
+def test_football_event_match_collapses_marker_variant_with_multiple_same_style_counterparts(team_registry_file):
+    create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
+    create_canonical_team(display_name="Santo Andre (Ž)", sport="football")
+    create_canonical_team(display_name="Sao Jose Wom.", sport="football")
+    create_canonical_team(display_name="Santo Andre Wom.", sport="football")
+    raw = [
+        _offer(
+            "superbet",
+            "Sao Jose Campos (Ž)",
+            "Santo Andre (Ž)",
+            outcome_code="over",
+        ),
+        _offer(
+            "pinnbet",
+            "Sao Jose Wom.",
+            "Santo Andre Wom.",
+            outcome_code="under",
+        ),
+        _offer(
+            "maxbet",
+            "Sao Jose Wom.",
+            "Santo Andre Wom.",
+            outcome_code="under",
+        ),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+
+    assert len(normalized) == 3
+    assert {offer.match_id for offer in normalized} == {normalized[0].match_id}
+    assert {
+        (offer.home_team_id, offer.away_team_id) for offer in normalized
+    } == {(normalized[0].home_team_id, normalized[0].away_team_id)}
+    assert unresolved == []
+    assert review_cases == []
+    assert _auto_review_alias_count() == 0
+
+
 def test_reversed_football_event_collapses_existing_women_marker_variant_canonicals(team_registry_file):
     create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
     create_canonical_team(display_name="Santo Andre (Ž)", sport="football")

--- a/backend/tests/test_outcome_normalizer.py
+++ b/backend/tests/test_outcome_normalizer.py
@@ -11,7 +11,7 @@ from app.services.outcome_normalizer import (
     _team_qualifiers,
     normalize_outcome_offers_with_diagnostics,
 )
-from app.services.team_registry import create_canonical_team
+from app.services.team_registry import create_canonical_team, remember_team_alias
 
 
 START_TIME = "2030-01-01T20:00:00+00:00"
@@ -381,6 +381,52 @@ def test_football_event_match_moves_whole_component_for_later_marker_pair(team_r
             "Santo Andre",
             outcome_code="under",
         ),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+
+    assert len(normalized) == 3
+    assert {offer.match_id for offer in normalized} == {normalized[0].match_id}
+    assert unresolved == []
+    assert review_cases == []
+    assert _auto_review_alias_count() == 0
+
+
+def test_football_event_match_does_not_bypass_ranking_for_different_women_stems(team_registry_file):
+    create_canonical_team(display_name="Manchester United Women", sport="football")
+    create_canonical_team(display_name="Manchester City Wom.", sport="football")
+    create_canonical_team(display_name="Liverpool Women", sport="football")
+    raw = [
+        _offer("superbet", "Manchester United Women", "Liverpool Women", outcome_code="over"),
+        _offer("pinnbet", "Manchester United Women", "Liverpool Women", outcome_code="under"),
+        _offer("maxbet", "Manchester City Wom.", "Liverpool Women", outcome_code="under"),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+    match_ids = {offer.bookmaker_id: offer.match_id for offer in normalized}
+
+    assert len(normalized) == 3
+    assert match_ids["superbet"] == match_ids["pinnbet"]
+    assert match_ids["maxbet"] != match_ids["superbet"]
+    assert unresolved == []
+    assert review_cases == []
+    assert _auto_review_alias_count() == 0
+
+
+def test_football_event_match_uses_canonical_ids_for_unmarked_alias_side_in_marker_bypass(team_registry_file):
+    create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
+    create_canonical_team(display_name="Sao Jose Dos Campos Wom.", sport="football")
+    create_canonical_team(display_name="Santo Andre", sport="football")
+    remember_team_alias(
+        bookmaker_id="superbet",
+        raw_team_name="St Andre",
+        team_name="Santo Andre",
+        sport="football",
+    )
+    raw = [
+        _offer("superbet", "Sao Jose Campos (Ž)", "St Andre", outcome_code="over"),
+        _offer("pinnbet", "Sao Jose Dos Campos Wom.", "Santo Andre", outcome_code="under"),
+        _offer("maxbet", "Sao Jose Dos Campos Wom.", "Santo Andre", outcome_code="under"),
     ]
 
     normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)

--- a/backend/tests/test_outcome_normalizer.py
+++ b/backend/tests/test_outcome_normalizer.py
@@ -6,7 +6,9 @@ from app.config import settings
 from app.models.schemas import RawOutcomeOffer
 from app.services.normalizer import generate_match_id
 from app.services.outcome_normalizer import (
+    _same_team_context,
     _team_similarity,
+    _team_qualifiers,
     normalize_outcome_offers_with_diagnostics,
 )
 from app.services.team_registry import create_canonical_team
@@ -58,6 +60,11 @@ def test_team_similarity_does_not_force_strict_subset_to_exact_match():
 
 def test_team_similarity_allows_low_signal_prefix_difference():
     assert _team_similarity("Llosetense", "CD Llosetense") == 100.0
+
+
+def test_team_qualifiers_treat_prefix_women_as_explicit_marker():
+    assert _team_qualifiers("Women Sao Jose", sport="football") == {"women"}
+    assert _same_team_context("Women Sao Jose", "Sao Jose Women", sport="football")
 
 
 def test_exact_cross_book_football_event_normalizes_without_auto_aliases(team_registry_file):
@@ -185,6 +192,31 @@ def test_fuzzy_football_event_match_does_not_create_aliases(team_registry_file):
     assert unresolved == []
     assert "CD Llosetense" in _canonical_team_names()
     assert "CSKA Moskva" in _canonical_team_names()
+    assert _auto_review_alias_count() == 0
+
+
+def test_football_event_match_ignores_equivalent_women_marker_text(team_registry_file):
+    raw = [
+        _offer(
+            "superbet",
+            "Sao Jose Campos (Ž)",
+            "Santo Andre (Ž)",
+            outcome_code="over",
+        ),
+        _offer(
+            "pinnbet",
+            "Sao Jose Wom.",
+            "Santo Andre Wom.",
+            outcome_code="under",
+        ),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+
+    assert len(normalized) == 2
+    assert {offer.match_id for offer in normalized} == {normalized[0].match_id}
+    assert unresolved == []
+    assert review_cases == []
     assert _auto_review_alias_count() == 0
 
 

--- a/backend/tests/test_outcome_normalizer.py
+++ b/backend/tests/test_outcome_normalizer.py
@@ -321,6 +321,52 @@ def test_football_event_match_collapses_marker_variant_with_multiple_same_style_
     assert _auto_review_alias_count() == 0
 
 
+def test_football_event_match_collapses_prefix_suffix_women_marker_variants(team_registry_file):
+    create_canonical_team(display_name="Women Sao Jose Campos", sport="football")
+    create_canonical_team(display_name="Sao Jose Women", sport="football")
+    create_canonical_team(display_name="Santo Andre", sport="football")
+    raw = [
+        _offer("superbet", "Women Sao Jose Campos", "Santo Andre", outcome_code="over"),
+        _offer("pinnbet", "Sao Jose Women", "Santo Andre", outcome_code="under"),
+        _offer("maxbet", "Sao Jose Women", "Santo Andre", outcome_code="under"),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+
+    assert len(normalized) == 3
+    assert {offer.match_id for offer in normalized} == {normalized[0].match_id}
+    assert unresolved == []
+    assert review_cases == []
+    assert _auto_review_alias_count() == 0
+
+
+def test_football_event_match_does_not_bypass_ranking_for_same_women_marker_style(team_registry_file):
+    create_canonical_team(display_name="Sao Jose (Ž)", sport="football")
+    create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
+    create_canonical_team(display_name="Sao Jose Dos Campos (Ž)", sport="football")
+    create_canonical_team(display_name="Santo Andre", sport="football")
+    raw = [
+        _offer("superbet", "Sao Jose (Ž)", "Santo Andre", outcome_code="over"),
+        _offer("pinnbet", "Sao Jose Campos (Ž)", "Santo Andre", outcome_code="under"),
+        _offer(
+            "maxbet",
+            "Sao Jose Dos Campos (Ž)",
+            "Santo Andre",
+            outcome_code="under",
+        ),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+    match_ids = {offer.bookmaker_id: offer.match_id for offer in normalized}
+
+    assert len(normalized) == 3
+    assert match_ids["pinnbet"] == match_ids["maxbet"]
+    assert match_ids["superbet"] != match_ids["pinnbet"]
+    assert unresolved == []
+    assert review_cases == []
+    assert _auto_review_alias_count() == 0
+
+
 def test_reversed_football_event_collapses_existing_women_marker_variant_canonicals(team_registry_file):
     create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
     create_canonical_team(display_name="Santo Andre (Ž)", sport="football")

--- a/backend/tests/test_outcome_normalizer.py
+++ b/backend/tests/test_outcome_normalizer.py
@@ -367,6 +367,31 @@ def test_football_event_match_does_not_bypass_ranking_for_same_women_marker_styl
     assert _auto_review_alias_count() == 0
 
 
+def test_football_event_match_moves_whole_component_for_later_marker_pair(team_registry_file):
+    create_canonical_team(display_name="Sao Jose Wom.", sport="football")
+    create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
+    create_canonical_team(display_name="Sao Jose Dos Campos (Ž)", sport="football")
+    create_canonical_team(display_name="Santo Andre", sport="football")
+    raw = [
+        _offer("superbet", "Sao Jose Wom.", "Santo Andre", outcome_code="over"),
+        _offer("pinnbet", "Sao Jose Campos (Ž)", "Santo Andre", outcome_code="under"),
+        _offer(
+            "maxbet",
+            "Sao Jose Dos Campos (Ž)",
+            "Santo Andre",
+            outcome_code="under",
+        ),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+
+    assert len(normalized) == 3
+    assert {offer.match_id for offer in normalized} == {normalized[0].match_id}
+    assert unresolved == []
+    assert review_cases == []
+    assert _auto_review_alias_count() == 0
+
+
 def test_reversed_football_event_collapses_existing_women_marker_variant_canonicals(team_registry_file):
     create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
     create_canonical_team(display_name="Santo Andre (Ž)", sport="football")

--- a/backend/tests/test_outcome_normalizer.py
+++ b/backend/tests/test_outcome_normalizer.py
@@ -220,6 +220,73 @@ def test_football_event_match_ignores_equivalent_women_marker_text(team_registry
     assert _auto_review_alias_count() == 0
 
 
+def test_football_event_match_collapses_existing_women_marker_variant_canonicals(team_registry_file):
+    create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
+    create_canonical_team(display_name="Santo Andre (Ž)", sport="football")
+    create_canonical_team(display_name="Sao Jose Wom.", sport="football")
+    create_canonical_team(display_name="Santo Andre Wom.", sport="football")
+    raw = [
+        _offer(
+            "superbet",
+            "Sao Jose Campos (Ž)",
+            "Santo Andre (Ž)",
+            outcome_code="over",
+        ),
+        _offer(
+            "pinnbet",
+            "Sao Jose Wom.",
+            "Santo Andre Wom.",
+            outcome_code="under",
+        ),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+
+    assert len(normalized) == 2
+    assert {offer.match_id for offer in normalized} == {normalized[0].match_id}
+    assert {
+        (offer.home_team_id, offer.away_team_id) for offer in normalized
+    } == {(normalized[0].home_team_id, normalized[0].away_team_id)}
+    assert unresolved == []
+    assert review_cases == []
+    assert _auto_review_alias_count() == 0
+
+
+def test_reversed_football_event_collapses_existing_women_marker_variant_canonicals(team_registry_file):
+    create_canonical_team(display_name="Sao Jose Campos (Ž)", sport="football")
+    create_canonical_team(display_name="Santo Andre (Ž)", sport="football")
+    create_canonical_team(display_name="Sao Jose Wom.", sport="football")
+    create_canonical_team(display_name="Santo Andre Wom.", sport="football")
+    raw = [
+        _offer(
+            "superbet",
+            "Sao Jose Campos (Ž)",
+            "Santo Andre (Ž)",
+            market_type="football_result",
+            outcome_code="home",
+        ),
+        _offer(
+            "pinnbet",
+            "Santo Andre Wom.",
+            "Sao Jose Wom.",
+            market_type="football_result",
+            outcome_code="home",
+        ),
+    ]
+
+    normalized, unresolved, review_cases = normalize_outcome_offers_with_diagnostics(raw)
+
+    assert len(normalized) == 2
+    assert {offer.match_id for offer in normalized} == {normalized[0].match_id}
+    assert {
+        (offer.bookmaker_id, offer.outcome_code)
+        for offer in normalized
+    } == {("superbet", "home"), ("pinnbet", "away")}
+    assert unresolved == []
+    assert review_cases == []
+    assert _auto_review_alias_count() == 0
+
+
 def test_football_event_match_rejects_mismatched_team_qualifiers(team_registry_file):
     create_canonical_team(display_name="Manchester United", sport="football")
     create_canonical_team(display_name="Liverpool", sport="football")


### PR DESCRIPTION
## Summary
- Treat explicit women markers (`W`, `Wom`, `Women`, `(Ž)`, `(Z)`, `Ž/`, `Z/`) consistently across sports.
- Keep plain ASCII `Z` conservative so football/location abbreviations such as `FK Borac Z` are not interpreted as women markers.
- Normalize women-marker tokens in event resolver comparisons so same-start cross-bookmaker variants collapse into one resolved event without requiring league aliases.

## Verification
- `cd backend && ./venv/bin/python -m py_compile app/services/outcome_normalizer.py app/services/event_resolver.py tests/test_event_resolver.py`
- `cd backend && ./venv/bin/pytest tests/test_event_resolver.py -q` → 27 passed
- `cd backend && ./venv/bin/pytest tests/test_outcome_normalizer.py tests/test_scheduler.py -q` → 87 passed
- `cd backend && ./venv/bin/pytest -q` → 929 passed

## Review
- GPT-5.5, Claude Opus 4.7, and Claude Sonnet 4.6 code-review agents found no significant issues.