### PR TITLE
Add BetOle football outcome scraping

### DIFF
--- a/backend/app/scrapers/betole_scraper.py
+++ b/backend/app/scrapers/betole_scraper.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from .base import BaseScraper
 from .http_client import HttpClient
-from ..models.schemas import RawOddsData
+from ..config import settings
+from ..models.schemas import RawOddsData, RawOutcomeOffer
 from ..services.scrape_window import current_utc_time, lookahead_cutoff
 from ..services.text_normalizer import normalize_identity_text
 
@@ -15,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 _REGULAR_FEED_URL = "https://www.betole.com/restapi/offer/sr/sport/B/mob"
 _PLAYER_FEED_URL = "https://www.betole.com/restapi/offer/sr/sport/SK/mob"
+_FOOTBALL_LIST_URL = "https://www.betole.com/restapi/offer/sr/sport/S/mob"
+_FOOTBALL_DETAIL_URL_TEMPLATE = "https://www.betole.com/restapi/offer/sr/match/{match_id}"
 
 _DEFAULT_HEADERS: dict[str, str] = {
     "Accept": "application/json",
@@ -30,6 +34,23 @@ _DEFAULT_PARAMS: dict[str, str] = {
     "desktopVersion": "2.46.6.3",
     "locale": "sr",
 }
+
+_FOOTBALL_DETAIL_PARAMS: dict[str, str] = {
+    "annex": "0",
+}
+
+
+def _list_params() -> dict[str, str]:
+    """List-feed params with the configured lookahead window.
+
+    Used by the football outcome listing — the regular basketball feed
+    keeps the legacy unfiltered params for backward compatibility.
+    """
+    return {
+        **_DEFAULT_PARAMS,
+        "hours": str(settings.scrape_lookahead_hours),
+    }
+
 
 _BOOKMAKER_ID = "betole"
 
@@ -102,6 +123,43 @@ _CANONICAL_LEAGUES: dict[str, str] = {
 }
 
 
+# ── Football outcome offers ──
+#
+# BetOle is on the same Tipster/iBet white-label as MerkurXTip /
+# OktagonBet / SoccerBet / 365 — it shares the numeric tip-type
+# convention.  The football list feed (``/sport/S/mob``) returns the
+# whole-game result (codes 1/2/3) and the 2.5 totals (22 = 0-2 under,
+# 24 = 3+ over) directly in ``odds``, but does NOT include the double
+# chance picks (codes 7/8/9).  Those only show up in the per-match
+# detail feed (``/restapi/offer/sr/match/{id}``) — the bulk PUT
+# ``/ibet/offer/prematchesByIds.html`` that OktagonBet uses returns an
+# empty body for BetOle even with a session, so the per-match GET is
+# the only available source.
+_FOOTBALL_LIST_OUTCOME_CODES: dict[str, tuple[str, str, float | None, str]] = {
+    "1": ("football_result", "home", None, "1"),
+    "2": ("football_result", "draw", None, "X"),
+    "3": ("football_result", "away", None, "2"),
+    "22": ("football_total_goals", "under", 2.5, "0-2"),
+    "24": ("football_total_goals", "over", 2.5, "3+"),
+}
+
+_FOOTBALL_DETAIL_DOUBLE_CHANCE_CODES: dict[str, tuple[str, str]] = {
+    "7": ("home_or_draw", "1X"),
+    "8": ("home_or_away", "12"),
+    "9": ("draw_or_away", "X2"),
+}
+
+
+# Per-bookmaker concurrency caps for the per-match detail fetches.
+# The HttpClient enforces a global rate limit per bookmaker, so any
+# concurrency above ``ceil(rate_limit_per_second)`` cannot speed
+# things up — it just helps mask network latency between rate-limited
+# slots.  When the rate limit is disabled (0), cap at 10 to stay
+# polite.
+_MIN_DETAIL_CONCURRENCY = 2
+_UNLIMITED_DETAIL_CONCURRENCY = 10
+
+
 def _parse_int(value: object) -> int | None:
     try:
         return int(value)  # type: ignore[arg-type]
@@ -132,11 +190,21 @@ def _normalize_league_key(raw_name: str | None) -> str:
     return normalized
 
 
-def _extract_league_id(raw_name: str | None) -> str:
+def _extract_league_id(raw_name: str | None, *, default: str = "basketball") -> str:
     normalized = _normalize_league_key(raw_name)
     if not normalized:
-        return "basketball"
+        return default
     return _CANONICAL_LEAGUES.get(normalized, normalized.replace(" ", "_"))
+
+
+def _coerce_positive_odds(value: object) -> float | None:
+    try:
+        odds = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if odds <= 0:
+        return None
+    return odds
 
 
 def _within_lookahead(match: dict, cutoff_ms: int) -> bool:
@@ -343,6 +411,97 @@ def _parse_player_match(match: dict, matchup_index: MatchupIndex) -> list[RawOdd
     return results
 
 
+def _parse_football_outcome_match(match: dict) -> list[RawOutcomeOffer]:
+    """Emit list-derived football offers (result + 2.5 totals)."""
+
+    home_team = (match.get("home") or "").strip()
+    away_team = (match.get("away") or "").strip()
+    if not home_team or not away_team:
+        return []
+
+    odds_map = match.get("odds") or {}
+    if not isinstance(odds_map, dict):
+        return []
+
+    league_id = _extract_league_id(match.get("leagueName", ""), default="football")
+    start_time = _parse_start_time(match.get("kickOffTime"))
+    results: list[RawOutcomeOffer] = []
+    for code, (market_type, outcome_code, line, raw_label) in _FOOTBALL_LIST_OUTCOME_CODES.items():
+        odds = _coerce_positive_odds(odds_map.get(code))
+        if odds is None:
+            continue
+        results.append(
+            RawOutcomeOffer(
+                bookmaker_id=_BOOKMAKER_ID,
+                league_id=league_id,
+                sport="football",
+                home_team=home_team,
+                away_team=away_team,
+                market_type=market_type,
+                outcome_code=outcome_code,
+                odds=odds,
+                line=line,
+                raw_label=raw_label,
+                start_time=start_time,
+            )
+        )
+    return results
+
+
+def _parse_football_double_chance_detail_match(match: dict) -> list[RawOutcomeOffer]:
+    """Emit detail-derived football double-chance offers (codes 7/8/9).
+
+    Per-match detail responses also expose the result and totals, but
+    those are already emitted from the cheaper list endpoint — this
+    parser intentionally only mines codes 7/8/9 to avoid emitting two
+    rows per (match, market, outcome) tuple.
+    """
+
+    home_team = (match.get("home") or "").strip()
+    away_team = (match.get("away") or "").strip()
+    if not home_team or not away_team:
+        return []
+
+    odds_map = match.get("odds") or {}
+    if not isinstance(odds_map, dict):
+        return []
+
+    league_id = _extract_league_id(match.get("leagueName", ""), default="football")
+    start_time = _parse_start_time(match.get("kickOffTime"))
+    results: list[RawOutcomeOffer] = []
+    for code, (outcome_code, raw_label) in _FOOTBALL_DETAIL_DOUBLE_CHANCE_CODES.items():
+        odds = _coerce_positive_odds(odds_map.get(code))
+        if odds is None:
+            continue
+        results.append(
+            RawOutcomeOffer(
+                bookmaker_id=_BOOKMAKER_ID,
+                league_id=league_id,
+                sport="football",
+                home_team=home_team,
+                away_team=away_team,
+                market_type="football_double_chance",
+                outcome_code=outcome_code,
+                odds=odds,
+                line=None,
+                raw_label=raw_label,
+                start_time=start_time,
+            )
+        )
+    return results
+
+
+def _get_detail_fetch_concurrency(http_client: HttpClient, match_count: int) -> int:
+    if match_count <= 0:
+        return 0
+    if http_client.rate_limit_per_second <= 0:
+        return min(match_count, _UNLIMITED_DETAIL_CONCURRENCY)
+    return min(
+        match_count,
+        max(_MIN_DETAIL_CONCURRENCY, math.ceil(http_client.rate_limit_per_second)),
+    )
+
+
 class BetOleScraper(BaseScraper):
     def __init__(self, http_client: HttpClient | None = None) -> None:
         self._http = http_client or HttpClient(default_headers=_DEFAULT_HEADERS)
@@ -355,6 +514,9 @@ class BetOleScraper(BaseScraper):
 
     def get_supported_leagues(self) -> list[str]:
         return ["basketball"]
+
+    def get_supported_outcome_sports(self) -> list[str]:
+        return ["football"]
 
     async def _fetch_feed_rows(self, url: str, *, label: str) -> list[dict]:
         try:
@@ -427,5 +589,125 @@ class BetOleScraper(BaseScraper):
             len(handicap_results),
             len(regular_matches),
             unmatched_player_rows,
+        )
+        return results
+
+    async def _fetch_football_list(self) -> list[dict]:
+        try:
+            data = await self._http.get_json(
+                _FOOTBALL_LIST_URL,
+                params=_list_params(),
+                headers=_DEFAULT_HEADERS,
+            )
+        except Exception:
+            logger.warning("BetOle: failed to fetch football listing", exc_info=True)
+            return []
+
+        rows = data.get("esMatches") or []
+        if not isinstance(rows, list):
+            return []
+        return [row for row in rows if isinstance(row, dict)]
+
+    async def _fetch_football_detail(
+        self,
+        match_id: int,
+        semaphore: asyncio.Semaphore,
+    ) -> dict | None:
+        async with semaphore:
+            try:
+                detail = await self._http.get_json(
+                    _FOOTBALL_DETAIL_URL_TEMPLATE.format(match_id=match_id),
+                    params=_FOOTBALL_DETAIL_PARAMS,
+                    headers=_DEFAULT_HEADERS,
+                )
+            except Exception:
+                logger.warning(
+                    "BetOle: failed to fetch football match detail %s",
+                    match_id,
+                    exc_info=True,
+                )
+                return None
+        if not isinstance(detail, dict):
+            return None
+        return detail
+
+    async def scrape_outcome_offers(self, sport: str) -> list[RawOutcomeOffer]:
+        """Scrape football outcome offers (result, double chance, 2.5 totals).
+
+        BetOle's bulk PUT endpoint that the OktagonBet sibling uses
+        (``/ibet/offer/prematchesByIds.html``) returns an empty body
+        for anonymous and cookie-bearing requests alike, so this
+        implementation enriches each list match with a per-match GET
+        to pick up the double chance picks (codes 7/8/9) that are not
+        present in the list payload.  Result and totals are parsed
+        from the cheaper list response to halve the work.
+        """
+
+        if sport != "football":
+            return []
+
+        list_matches = await self._fetch_football_list()
+        list_by_id: dict[int, dict] = {}
+        for match in list_matches:
+            match_id = _parse_int(match.get("id"))
+            if match_id is None:
+                continue
+            list_by_id[match_id] = match
+
+        if not list_by_id:
+            logger.info("BetOle: no football matches discovered")
+            return []
+
+        results: list[RawOutcomeOffer] = []
+        for list_match in list_by_id.values():
+            results.extend(_parse_football_outcome_match(list_match))
+
+        match_ids = list(list_by_id.keys())
+        concurrency = _get_detail_fetch_concurrency(self._http, len(match_ids))
+        semaphore = asyncio.Semaphore(max(1, concurrency))
+        details = await asyncio.gather(
+            *(self._fetch_football_detail(mid, semaphore) for mid in match_ids)
+        )
+
+        missing_detail_ids = 0
+        for match_id, detail in zip(match_ids, details):
+            if detail is None:
+                missing_detail_ids += 1
+                continue
+            list_match = list_by_id[match_id]
+            # Always emit detail-derived offers using the LIST match's
+            # team names, kickoff and league so they share the same
+            # normalized event key as the list-derived result/totals
+            # offers above.  The detail payload's metadata can drift
+            # (whitespace, league capitalization) and would silently
+            # land double-chance offers in a different normalized
+            # event.  We override unconditionally so that even when the
+            # list is missing a field (e.g., leagueName=None), both
+            # parsers fall back to the same default rather than the
+            # detail leaking its own value.
+            merged = {
+                **detail,
+                "home": list_match.get("home"),
+                "away": list_match.get("away"),
+                "kickOffTime": list_match.get("kickOffTime"),
+                "leagueName": list_match.get("leagueName"),
+            }
+            results.extend(_parse_football_double_chance_detail_match(merged))
+
+        if missing_detail_ids:
+            logger.warning(
+                "BetOle: %d/%d football detail fetches returned no data; "
+                "double chance will be missing for those matches",
+                missing_detail_ids,
+                len(match_ids),
+            )
+
+        logger.info(
+            "BetOle scraped %d football outcome offers from %d matches "
+            "(detail fetches: %d, concurrency: %d)",
+            len(results),
+            len(match_ids),
+            len(match_ids) - missing_detail_ids,
+            concurrency,
         )
         return results

--- a/backend/app/scrapers/mock_scraper.py
+++ b/backend/app/scrapers/mock_scraper.py
@@ -317,6 +317,19 @@ _FOOTBALL_OUTCOME_MARKETS: dict[str, list[dict]] = {
         {"game": 1, "market": "football_total_goals", "outcome": "under", "odds": 1.76, "line": 2.5, "label": "0-2"},
         {"game": 1, "market": "football_total_goals", "outcome": "over", "odds": 2.18, "line": 2.5, "label": "3+"},
     ],
+    "betole": [
+        {"game": 0, "market": "football_result", "outcome": "home", "odds": 2.42, "label": "1"},
+        {"game": 0, "market": "football_result", "outcome": "draw", "odds": 3.22, "label": "X"},
+        {"game": 0, "market": "football_result", "outcome": "away", "odds": 2.58, "label": "2"},
+        {"game": 0, "market": "football_double_chance", "outcome": "home_or_draw", "odds": 1.39, "label": "1X"},
+        {"game": 0, "market": "football_double_chance", "outcome": "home_or_away", "odds": 1.26, "label": "12"},
+        {"game": 0, "market": "football_double_chance", "outcome": "draw_or_away", "odds": 1.45, "label": "X2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "under", "odds": 2.06, "line": 2.5, "label": "0-2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "over", "odds": 1.83, "line": 2.5, "label": "3+"},
+        {"game": 1, "market": "football_double_chance", "outcome": "draw_or_away", "odds": 1.51, "label": "X2"},
+        {"game": 1, "market": "football_total_goals", "outcome": "under", "odds": 1.78, "line": 2.5, "label": "0-2"},
+        {"game": 1, "market": "football_total_goals", "outcome": "over", "odds": 2.16, "line": 2.5, "label": "3+"},
+    ],
 }
 
 

--- a/backend/tests/fixtures/betole_football_match.json
+++ b/backend/tests/fixtures/betole_football_match.json
@@ -1,0 +1,20 @@
+{
+  "id": 90328755,
+  "matchCode": 36,
+  "home": "Al Khaleej",
+  "away": "Al Hilal Riyadh",
+  "kickOffTime": 1778004000000,
+  "leagueName": "Saudi Arabia, Saudi Professional League",
+  "leagueId": 2252256,
+  "sport": "S",
+  "odds": {
+    "1": 7.6,
+    "2": 5.5,
+    "3": 1.26,
+    "7": 3.2,
+    "8": 1.1,
+    "9": 1.04,
+    "22": 2.93,
+    "24": 1.35
+  }
+}

--- a/backend/tests/fixtures/betole_football_offer.json
+++ b/backend/tests/fixtures/betole_football_offer.json
@@ -1,0 +1,24 @@
+{
+  "id": "S",
+  "name": null,
+  "type": "SPORT",
+  "esMatches": [
+    {
+      "id": 90328755,
+      "matchCode": 36,
+      "leagueName": "Saudi Arabia, Saudi Professional League",
+      "leagueId": 2252256,
+      "home": "Al Khaleej",
+      "away": "Al Hilal Riyadh",
+      "kickOffTime": 1778004000000,
+      "sport": "S",
+      "odds": {
+        "1": 7.6,
+        "2": 5.5,
+        "3": 1.26,
+        "22": 2.93,
+        "24": 1.35
+      }
+    }
+  ]
+}

--- a/backend/tests/test_betole_scraper.py
+++ b/backend/tests/test_betole_scraper.py
@@ -9,17 +9,24 @@ import pytest
 
 from app.scrapers.betole_scraper import (
     BetOleScraper,
+    _FOOTBALL_DETAIL_URL_TEMPLATE,
+    _FOOTBALL_LIST_URL,
     _PLAYER_FEED_URL,
     _REGULAR_FEED_URL,
     _build_matchup_index,
     _extract_league_id,
+    _parse_football_double_chance_detail_match,
+    _parse_football_outcome_match,
     _parse_handicap_match,
     _parse_player_match,
     _parse_regular_match,
 )
+from app.models.schemas import RawOutcomeOffer
 
 REGULAR_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "betole_regular_league.json"
 PLAYER_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "betole_players_league.json"
+FOOTBALL_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "betole_football_offer.json"
+FOOTBALL_DETAIL_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "betole_football_match.json"
 
 EXTRA_REGULAR_LEAGUE = {
     "id": "2265038",
@@ -384,3 +391,279 @@ async def test_scrape_odds_builds_player_matchups_from_matched_regular_leagues(
     assert {(row.home_team, row.away_team, row.league_id) for row in player_rows} == {
         ("Detroit Pistons", "Orlando Magic", "nba")
     }
+
+
+@pytest.fixture
+def football_list_data() -> dict:
+    with open(FOOTBALL_FIXTURE_PATH) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def football_detail_data() -> dict:
+    with open(FOOTBALL_DETAIL_FIXTURE_PATH) as f:
+        return json.load(f)
+
+
+def test_parse_football_outcome_match_emits_result_and_totals(football_list_data):
+    results = _parse_football_outcome_match(football_list_data["esMatches"][0])
+
+    assert len(results) == 5
+    assert all(isinstance(r, RawOutcomeOffer) for r in results)
+    assert {r.bookmaker_id for r in results} == {"betole"}
+    assert {r.sport for r in results} == {"football"}
+    assert {r.league_id for r in results} == {"saudi_arabia_saudi_professional_league"}
+    assert {r.home_team for r in results} == {"Al Khaleej"}
+    assert {r.away_team for r in results} == {"Al Hilal Riyadh"}
+    assert {r.start_time for r in results} == {"2026-05-05T18:00:00+00:00"}
+    assert {
+        (r.market_type, r.outcome_code, r.line, r.raw_label, r.odds)
+        for r in results
+    } == {
+        ("football_result", "home", None, "1", 7.6),
+        ("football_result", "draw", None, "X", 5.5),
+        ("football_result", "away", None, "2", 1.26),
+        ("football_total_goals", "under", 2.5, "0-2", 2.93),
+        ("football_total_goals", "over", 2.5, "3+", 1.35),
+    }
+
+
+def test_parse_football_double_chance_detail_match_emits_double_chance(football_detail_data):
+    results = _parse_football_double_chance_detail_match(football_detail_data)
+
+    assert len(results) == 3
+    assert all(r.market_type == "football_double_chance" for r in results)
+    assert {r.sport for r in results} == {"football"}
+    assert {r.bookmaker_id for r in results} == {"betole"}
+    assert {
+        (r.outcome_code, r.raw_label, r.odds)
+        for r in results
+    } == {
+        ("home_or_draw", "1X", 3.2),
+        ("home_or_away", "12", 1.1),
+        ("draw_or_away", "X2", 1.04),
+    }
+
+
+def test_parse_football_outcome_match_skips_invalid_rows():
+    match = {
+        "home": "Home",
+        "away": "Away",
+        "leagueName": "Test League",
+        "kickOffTime": 1778002200000,
+        "odds": {
+            "1": 0,
+            "2": -1,
+            "3": "bad",
+            "22": 2.05,
+        },
+    }
+
+    results = _parse_football_outcome_match(match)
+
+    assert len(results) == 1
+    assert results[0].market_type == "football_total_goals"
+    assert results[0].outcome_code == "under"
+
+
+def test_parse_football_outcome_match_requires_teams_and_odds_map():
+    assert _parse_football_outcome_match({"away": "Away", "odds": {"1": 1.9}}) == []
+    assert _parse_football_outcome_match({"home": "Home", "odds": {"1": 1.9}}) == []
+    assert _parse_football_outcome_match({"home": "Home", "away": "Away", "odds": []}) == []
+
+
+def test_parse_football_double_chance_detail_match_requires_teams_and_odds():
+    assert _parse_football_double_chance_detail_match(
+        {"away": "Away", "odds": {"7": 1.5}}
+    ) == []
+    assert _parse_football_double_chance_detail_match(
+        {"home": "Home", "odds": {"7": 1.5}}
+    ) == []
+    assert _parse_football_double_chance_detail_match(
+        {"home": "Home", "away": "Away", "odds": []}
+    ) == []
+    # Non-double-chance codes are ignored even when present.
+    assert _parse_football_double_chance_detail_match(
+        {"home": "Home", "away": "Away", "odds": {"1": 1.9, "22": 2.0}}
+    ) == []
+
+
+def test_extract_league_id_default_kwarg_uses_football():
+    assert _extract_league_id("", default="football") == "football"
+    assert _extract_league_id(None, default="football") == "football"
+
+
+@pytest.mark.asyncio
+async def test_scraper_supports_football_outcomes():
+    scraper = BetOleScraper()
+    assert scraper.get_supported_outcome_sports() == ["football"]
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_football_uses_list_and_per_match_details(
+    football_list_data,
+    football_detail_data,
+):
+    list_calls: list[tuple[str, dict]] = []
+    detail_calls: list[str] = []
+
+    async def fake_get_json(url: str, *, params=None, headers=None):
+        del headers
+        if url == _FOOTBALL_LIST_URL:
+            list_calls.append((url, params or {}))
+            return football_list_data
+        expected_detail = _FOOTBALL_DETAIL_URL_TEMPLATE.format(match_id=90328755)
+        if url == expected_detail:
+            detail_calls.append(url)
+            return football_detail_data
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    http_client = AsyncMock()
+    http_client.rate_limit_per_second = 4.0
+    http_client.get_json.side_effect = fake_get_json
+
+    scraper = BetOleScraper(http_client=http_client)
+    results = await scraper.scrape_outcome_offers("football")
+
+    assert len(results) == 8
+    market_types = {r.market_type for r in results}
+    assert market_types == {
+        "football_result",
+        "football_double_chance",
+        "football_total_goals",
+    }
+    assert {r.bookmaker_id for r in results} == {"betole"}
+    assert {r.sport for r in results} == {"football"}
+    # All 8 offers reference the LIST match metadata, even the detail-derived ones.
+    assert {r.home_team for r in results} == {"Al Khaleej"}
+    assert {r.away_team for r in results} == {"Al Hilal Riyadh"}
+    assert {r.league_id for r in results} == {"saudi_arabia_saudi_professional_league"}
+    assert {r.start_time for r in results} == {"2026-05-05T18:00:00+00:00"}
+    assert len(list_calls) == 1
+    assert list_calls[0][1].get("hours")
+    assert detail_calls == [_FOOTBALL_DETAIL_URL_TEMPLATE.format(match_id=90328755)]
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_football_returns_list_offers_when_detail_fails(
+    football_list_data,
+):
+    async def fake_get_json(url: str, *, params=None, headers=None):
+        del params, headers
+        if url == _FOOTBALL_LIST_URL:
+            return football_list_data
+        raise RuntimeError("detail unavailable")
+
+    http_client = AsyncMock()
+    http_client.rate_limit_per_second = 1.0
+    http_client.get_json.side_effect = fake_get_json
+
+    scraper = BetOleScraper(http_client=http_client)
+    results = await scraper.scrape_outcome_offers("football")
+
+    assert len(results) == 5
+    assert {r.market_type for r in results} == {
+        "football_result",
+        "football_total_goals",
+    }
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_football_overrides_detail_metadata_with_list(
+    football_list_data,
+):
+    drifting_detail = {
+        "id": 90328755,
+        # Detail's home/away differ in spacing/case from the list payload —
+        # if the parser used these, double-chance offers would land in a
+        # different normalized event than the list-derived offers.
+        "home": " AL  KHALEEJ ",
+        "away": "al hilal  RIYADH",
+        "leagueName": "Saudi Arabia, Saudi Professional League (Reserves)",
+        "kickOffTime": 1778004000999,
+        "sport": "S",
+        "odds": {"7": 3.2, "8": 1.1, "9": 1.04},
+    }
+
+    async def fake_get_json(url: str, *, params=None, headers=None):
+        del params, headers
+        if url == _FOOTBALL_LIST_URL:
+            return football_list_data
+        return drifting_detail
+
+    http_client = AsyncMock()
+    http_client.rate_limit_per_second = 4.0
+    http_client.get_json.side_effect = fake_get_json
+
+    scraper = BetOleScraper(http_client=http_client)
+    results = await scraper.scrape_outcome_offers("football")
+
+    dc = [r for r in results if r.market_type == "football_double_chance"]
+    assert len(dc) == 3
+    # Detail-derived offers must reuse the LIST match metadata so the
+    # event normalizer keys them onto the same event as the list-derived
+    # result/totals offers.
+    assert {r.home_team for r in dc} == {"Al Khaleej"}
+    assert {r.away_team for r in dc} == {"Al Hilal Riyadh"}
+    assert {r.league_id for r in dc} == {"saudi_arabia_saudi_professional_league"}
+    assert {r.start_time for r in dc} == {"2026-05-05T18:00:00+00:00"}
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_football_overrides_detail_metadata_when_list_field_missing(
+    football_list_data,
+):
+    # Stomp the list match's leagueName so we exercise the None-fallback
+    # branch.  The list parser will derive league_id="football" (default),
+    # and the detail parser must do the same — not silently fall back to
+    # the detail's leagueName, which would land double-chance in a
+    # different normalized event.
+    list_with_missing_field = json.loads(json.dumps(football_list_data))
+    list_with_missing_field["esMatches"][0]["leagueName"] = None
+
+    leaking_detail = {
+        "id": 90328755,
+        "home": "Al Khaleej",
+        "away": "Al Hilal Riyadh",
+        # Detail still knows the league — must NOT be used.
+        "leagueName": "Saudi Arabia, Saudi Professional League",
+        "kickOffTime": 1778004000000,
+        "sport": "S",
+        "odds": {"7": 3.2, "8": 1.1, "9": 1.04},
+    }
+
+    async def fake_get_json(url: str, *, params=None, headers=None):
+        del params, headers
+        if url == _FOOTBALL_LIST_URL:
+            return list_with_missing_field
+        return leaking_detail
+
+    http_client = AsyncMock()
+    http_client.rate_limit_per_second = 4.0
+    http_client.get_json.side_effect = fake_get_json
+
+    scraper = BetOleScraper(http_client=http_client)
+    results = await scraper.scrape_outcome_offers("football")
+
+    list_results = [
+        r for r in results if r.market_type in {"football_result", "football_total_goals"}
+    ]
+    dc = [r for r in results if r.market_type == "football_double_chance"]
+    assert dc, "expected detail-derived double chance offers"
+    # Both lanes must agree on league_id even when the list is missing
+    # the field — they should both fall back to the default rather than
+    # the detail's value leaking through.
+    assert {r.league_id for r in dc} == {"football"}
+    assert {r.league_id for r in list_results} == {"football"}
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_non_football_returns_empty():
+    http_client = AsyncMock()
+    http_client.rate_limit_per_second = 1.0
+
+    scraper = BetOleScraper(http_client=http_client)
+    results = await scraper.scrape_outcome_offers("basketball")
+
+    assert results == []
+    http_client.get_json.assert_not_called()

--- a/backend/tests/test_scraper.py
+++ b/backend/tests/test_scraper.py
@@ -103,6 +103,22 @@ async def test_mock_scraper_supports_oktagonbet_football_outcomes():
 
 
 @pytest.mark.asyncio
+async def test_mock_scraper_supports_betole_football_outcomes():
+    scraper = MockScraper("betole")
+    data = await scraper.scrape_outcome_offers("football")
+
+    assert scraper.get_supported_outcome_sports() == ["football"]
+    assert len(data) > 0
+    assert all(isinstance(item, RawOutcomeOffer) for item in data)
+    assert all(item.bookmaker_id == "betole" for item in data)
+    assert {item.market_type for item in data} == {
+        "football_result",
+        "football_double_chance",
+        "football_total_goals",
+    }
+
+
+@pytest.mark.asyncio
 async def test_mock_scraper_unsupported_league():
     scraper = MockScraper("mozzart")
     data = await scraper.scrape_odds("nba")

--- a/frontend/src/api/mockData.ts
+++ b/frontend/src/api/mockData.ts
@@ -152,6 +152,7 @@ export const mockMatches: Match[] = [
       { id: 'oktagonbet', name: 'OktagonBet' },
       { id: 'soccerbet', name: 'SoccerBet' },
       { id: 'merkurxtip', name: 'MERKUR X TIP' },
+      { id: 'betole', name: 'BetOle' },
     ],
   },
   {
@@ -169,6 +170,7 @@ export const mockMatches: Match[] = [
       { id: 'oktagonbet', name: 'OktagonBet' },
       { id: 'soccerbet', name: 'SoccerBet' },
       { id: 'merkurxtip', name: 'MERKUR X TIP' },
+      { id: 'betole', name: 'BetOle' },
     ],
   },
   {
@@ -254,6 +256,17 @@ export const mockFootballOutcomeOffers: OutcomeOffer[] = [
   { id: 1050, match_id: 'football-match-1', bookmaker_id: 'oktagonbet', bookmaker_name: 'OktagonBet', market_type: 'football_total_goals', outcome_code: 'over', odds: 1.84, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
   { id: 1051, match_id: 'football-match-2', bookmaker_id: 'oktagonbet', bookmaker_name: 'OktagonBet', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.76, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
   { id: 1052, match_id: 'football-match-2', bookmaker_id: 'oktagonbet', bookmaker_name: 'OktagonBet', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.18, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
+  { id: 1053, match_id: 'football-match-1', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_result', outcome_code: 'home', odds: 2.42, line: null, raw_label: '1', scraped_at: ago(1) },
+  { id: 1054, match_id: 'football-match-1', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_result', outcome_code: 'draw', odds: 3.22, line: null, raw_label: 'X', scraped_at: ago(1) },
+  { id: 1055, match_id: 'football-match-1', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_result', outcome_code: 'away', odds: 2.58, line: null, raw_label: '2', scraped_at: ago(1) },
+  { id: 1056, match_id: 'football-match-1', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_double_chance', outcome_code: 'home_or_draw', odds: 1.39, line: null, raw_label: '1X', scraped_at: ago(1) },
+  { id: 1057, match_id: 'football-match-1', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_double_chance', outcome_code: 'home_or_away', odds: 1.26, line: null, raw_label: '12', scraped_at: ago(1) },
+  { id: 1058, match_id: 'football-match-1', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_double_chance', outcome_code: 'draw_or_away', odds: 1.45, line: null, raw_label: 'X2', scraped_at: ago(1) },
+  { id: 1059, match_id: 'football-match-1', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_total_goals', outcome_code: 'under', odds: 2.06, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
+  { id: 1060, match_id: 'football-match-1', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_total_goals', outcome_code: 'over', odds: 1.83, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
+  { id: 1061, match_id: 'football-match-2', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_double_chance', outcome_code: 'draw_or_away', odds: 1.51, line: null, raw_label: 'X2', scraped_at: ago(1) },
+  { id: 1062, match_id: 'football-match-2', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.78, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
+  { id: 1063, match_id: 'football-match-2', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.16, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
 ];
 
 export const mockOpportunities: Opportunity[] = [


### PR DESCRIPTION
Extends the BetOle scraper with the football outcome lane that already powers MaxBet/SoccerBet/MerkurXTip/OktagonBet. Basketball path untouched.

## Markets emitted

- `football_result` (codes `1` / `2` / `3`)
- `football_total_goals` 2.5 (`22` under `0-2`, `24` over `3+`)
- `football_double_chance` (`7` `1X`, `8` `12`, `9` `X2`)

## Endpoints

- List: `GET https://www.betole.com/restapi/offer/sr/sport/S/mob?annex=0&desktopVersion=2.46.6.3&locale=sr&hours=<lookahead>`
- Per-match detail (for double chance only): `GET https://www.betole.com/restapi/offer/sr/match/{id}?annex=0`

The OktagonBet-style bulk `PUT /ibet/offer/prematchesByIds.html` returns HTTP 200 + a 0-byte body for BetOle even with cookies/headers — the `/ibet/` namespace is auth-gated. So we fan out per-match GETs concurrently, sized as `max(2, ceil(rate_limit_per_second))` capped at match count (or 10 when rate is disabled). The per-bookmaker `HttpClient` rate-limit lock still serializes the actual requests, so concurrency above the rate ceiling can only mask network latency between rate slots.

## B1 design constraint

When emitting detail-derived double-chance offers, identity fields (`home`, `away`, `kickOffTime`, `leagueName`) are unconditionally taken from the LIST match — even when the list field is `None` — so both lanes hash to the same normalized event. Detail metadata can drift (whitespace, casing, ms precision), and conditional override would have leaked the detail's `leagueName` whenever the list lacked it, splitting result/totals from double-chance into two separate normalized events. Caught and fixed in the code-review pass before merge. Pinned by:

- `test_scrape_outcome_offers_football_overrides_detail_metadata_with_list`
- `test_scrape_outcome_offers_football_overrides_detail_metadata_when_list_field_missing`

## Mock coherence

- `backend/app/scrapers/mock_scraper.py` — `_FOOTBALL_OUTCOME_MARKETS` gains a `betole` block (11 entries across both games and all 3 markets).
- `frontend/src/api/mockData.ts` — `betole` added to football match `available_bookmakers` (matches 1 & 2) plus 11 `OutcomeOffer` rows.

## Live verification

| Bookmaker | Matches | Offers | result | double_chance | total_goals 2.5 |
|-----------|--------:|-------:|-------:|--------------:|----------------:|
| BetOle    |     155 |   1232 |    464 |           458 |             310 |

## Tests

```
cd backend && ./venv/bin/pytest -q
```
997 passed.

```
cd frontend && npm run build && npm run lint
```
clean.

## Rollout

Tipster/iBet family progress: SoccerBet (#84), MerkurXTip (#85), OktagonBet (#86), BetOle (this PR), `365` next.
