### PR TITLE
Add 365 football outcome scraping

### DIFF
--- a/backend/app/scrapers/bookmaker365_scraper.py
+++ b/backend/app/scrapers/bookmaker365_scraper.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 
 from .base import BaseScraper
 from .http_client import HttpClient
-from ..models.schemas import RawOddsData
+from ..models.schemas import RawOddsData, RawOutcomeOffer
 from ..services.scrape_window import current_utc_time, lookahead_cutoff
 from ..services.text_normalizer import normalize_identity_text
 
@@ -20,6 +20,10 @@ _REGULAR_LEAGUE_PREVIEW_URL = (
 )
 _PLAYER_LEAGUE_PREVIEW_URL = (
     "https://ibet2.365.rs/restapi/offer/sr/sport/SK/league/{league_id}/mob"
+)
+_FOOTBALL_LEAGUES_URL = "https://ibet2.365.rs/restapi/offer/sr/categories/sport/S/l"
+_FOOTBALL_LEAGUE_PREVIEW_URL = (
+    "https://ibet2.365.rs/restapi/offer/sr/sport/S/league/{league_id}/mob"
 )
 
 _DEFAULT_HEADERS: dict[str, str] = {
@@ -138,6 +142,21 @@ _PLAYER_LEAGUE_SUFFIXES = (
     " broj poena skokova asistencija",
     " muckalica igraci",
 )
+
+# Football outcome lane.  365's per-league preview surfaces the same
+# Tipster-style codes that the SoccerBet/MerkurXTip/OktagonBet/BetOle
+# siblings use directly in the match's ``odds`` map — no detail call
+# needed.
+_FOOTBALL_OUTCOME_CODES: dict[str, tuple[str, str, float | None, str]] = {
+    "1": ("football_result", "home", None, "1"),
+    "2": ("football_result", "draw", None, "X"),
+    "3": ("football_result", "away", None, "2"),
+    "7": ("football_double_chance", "home_or_draw", None, "1X"),
+    "8": ("football_double_chance", "home_or_away", None, "12"),
+    "9": ("football_double_chance", "draw_or_away", None, "X2"),
+    "22": ("football_total_goals", "under", 2.5, "0-2"),
+    "24": ("football_total_goals", "over", 2.5, "3+"),
+}
 _CANONICAL_LEAGUES: dict[str, str] = {
     "nba play off": "nba",
     "nba play in": "nba",
@@ -181,10 +200,10 @@ def _normalize_league_key(raw_name: str | None) -> str:
     return normalized
 
 
-def _extract_league_id(raw_name: str | None) -> str:
+def _extract_league_id(raw_name: str | None, *, default: str = "basketball") -> str:
     normalized = _normalize_league_key(raw_name)
     if not normalized:
-        return "basketball"
+        return default
     return _CANONICAL_LEAGUES.get(normalized, normalized.replace(" ", "_"))
 
 
@@ -369,8 +388,52 @@ def _parse_player_match(match: dict, matchup_index: MatchupIndex) -> list[RawOdd
     return results
 
 
+def _coerce_positive_odds(value: object) -> float | None:
+    parsed = _parse_float(value)
+    if parsed is None or parsed <= 0:
+        return None
+    return parsed
+
+
+def _parse_football_outcome_match(match: dict) -> list[RawOutcomeOffer]:
+    home_team = (match.get("home") or "").strip()
+    away_team = (match.get("away") or "").strip()
+    if not home_team or not away_team:
+        return []
+
+    odds_map = match.get("odds") or {}
+    if not isinstance(odds_map, dict):
+        return []
+
+    league_id = _extract_league_id(match.get("leagueName", ""), default="football")
+    start_time = _parse_start_time(match.get("kickOffTime"))
+    results: list[RawOutcomeOffer] = []
+
+    for code, (market_type, outcome_code, line, raw_label) in _FOOTBALL_OUTCOME_CODES.items():
+        odds = _coerce_positive_odds(odds_map.get(code))
+        if odds is None:
+            continue
+        results.append(
+            RawOutcomeOffer(
+                bookmaker_id=_BOOKMAKER_ID,
+                league_id=league_id,
+                sport="football",
+                home_team=home_team,
+                away_team=away_team,
+                market_type=market_type,
+                outcome_code=outcome_code,
+                odds=odds,
+                line=line,
+                raw_label=raw_label,
+                start_time=start_time,
+            )
+        )
+
+    return results
+
+
 class Bookmaker365Scraper(BaseScraper):
-    """365 basketball scraper backed by the public iBet-style offer API."""
+    """365 basketball + football scraper backed by the public iBet-style offer API."""
 
     def __init__(self, http_client: HttpClient | None = None) -> None:
         self._http = http_client or HttpClient(default_headers=_DEFAULT_HEADERS)
@@ -527,5 +590,39 @@ class Bookmaker365Scraper(BaseScraper):
             len(regular_matches),
             len(player_matches),
             len(handicap_results),
+        )
+        return results
+
+    def get_supported_outcome_sports(self) -> list[str]:
+        return ["football"]
+
+    async def scrape_outcome_offers(self, sport: str) -> list[RawOutcomeOffer]:
+        if sport != "football":
+            return []
+
+        leagues = await self._fetch_league_categories(
+            _FOOTBALL_LEAGUES_URL,
+            label="football",
+        )
+        if not leagues:
+            return []
+
+        cutoff_ms = int(lookahead_cutoff(current_utc_time()).timestamp() * 1000)
+        matches = await self._fetch_previews(
+            leagues,
+            url_template=_FOOTBALL_LEAGUE_PREVIEW_URL,
+            label="football",
+            cutoff_ms=cutoff_ms,
+        )
+
+        results: list[RawOutcomeOffer] = []
+        for match in matches:
+            results.extend(_parse_football_outcome_match(match))
+
+        logger.info(
+            "365 scraped %d football outcome offers from %d matches across %d leagues",
+            len(results),
+            len(matches),
+            len(leagues),
         )
         return results

--- a/backend/app/scrapers/mock_scraper.py
+++ b/backend/app/scrapers/mock_scraper.py
@@ -330,6 +330,19 @@ _FOOTBALL_OUTCOME_MARKETS: dict[str, list[dict]] = {
         {"game": 1, "market": "football_total_goals", "outcome": "under", "odds": 1.78, "line": 2.5, "label": "0-2"},
         {"game": 1, "market": "football_total_goals", "outcome": "over", "odds": 2.16, "line": 2.5, "label": "3+"},
     ],
+    "365": [
+        {"game": 0, "market": "football_result", "outcome": "home", "odds": 2.38, "label": "1"},
+        {"game": 0, "market": "football_result", "outcome": "draw", "odds": 3.20, "label": "X"},
+        {"game": 0, "market": "football_result", "outcome": "away", "odds": 2.60, "label": "2"},
+        {"game": 0, "market": "football_double_chance", "outcome": "home_or_draw", "odds": 1.40, "label": "1X"},
+        {"game": 0, "market": "football_double_chance", "outcome": "home_or_away", "odds": 1.27, "label": "12"},
+        {"game": 0, "market": "football_double_chance", "outcome": "draw_or_away", "odds": 1.46, "label": "X2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "under", "odds": 2.04, "line": 2.5, "label": "0-2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "over", "odds": 1.85, "line": 2.5, "label": "3+"},
+        {"game": 1, "market": "football_double_chance", "outcome": "draw_or_away", "odds": 1.49, "label": "X2"},
+        {"game": 1, "market": "football_total_goals", "outcome": "under", "odds": 1.74, "line": 2.5, "label": "0-2"},
+        {"game": 1, "market": "football_total_goals", "outcome": "over", "odds": 2.20, "line": 2.5, "label": "3+"},
+    ],
 }
 
 

--- a/backend/tests/fixtures/bookmaker365_football_categories.json
+++ b/backend/tests/fixtures/bookmaker365_football_categories.json
@@ -1,0 +1,16 @@
+{
+  "categories": [
+    {
+      "id": "2222600",
+      "name": "Liga Šampiona - Play Off",
+      "count": 2,
+      "type": "LEAGUE"
+    },
+    {
+      "id": "2222588",
+      "name": "Liga Evrope - Play Off",
+      "count": 2,
+      "type": "LEAGUE"
+    }
+  ]
+}

--- a/backend/tests/fixtures/bookmaker365_football_league.json
+++ b/backend/tests/fixtures/bookmaker365_football_league.json
@@ -1,0 +1,24 @@
+{
+  "id": "2222612",
+  "name": "Engleska 1",
+  "esMatches": [
+    {
+      "id": 47590194,
+      "sport": "S",
+      "home": "Liverpool",
+      "away": "Chelsea",
+      "leagueName": "Engleska 1",
+      "kickOffTime": 1778326200000,
+      "odds": {
+        "1": 1.88,
+        "2": 4.13,
+        "3": 3.62,
+        "7": 1.29,
+        "8": 1.24,
+        "9": 1.93,
+        "22": 2.91,
+        "24": 1.41
+      }
+    }
+  ]
+}

--- a/backend/tests/test_bookmaker365_scraper.py
+++ b/backend/tests/test_bookmaker365_scraper.py
@@ -9,12 +9,15 @@ import pytest
 
 from app.scrapers.bookmaker365_scraper import (
     Bookmaker365Scraper,
+    _FOOTBALL_LEAGUES_URL,
+    _FOOTBALL_LEAGUE_PREVIEW_URL,
     _PLAYER_LEAGUES_URL,
     _PLAYER_LEAGUE_PREVIEW_URL,
     _REGULAR_LEAGUES_URL,
     _REGULAR_LEAGUE_PREVIEW_URL,
     _build_matchup_index,
     _extract_league_id,
+    _parse_football_outcome_match,
     _parse_player_match,
     _parse_total_match,
     _GAME_TOTAL_LINES,
@@ -24,6 +27,12 @@ from app.scrapers.bookmaker365_scraper import (
 
 REGULAR_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "bookmaker365_regular_league.json"
 PLAYER_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "bookmaker365_player_league.json"
+FOOTBALL_CATEGORIES_FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "bookmaker365_football_categories.json"
+)
+FOOTBALL_LEAGUE_FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "bookmaker365_football_league.json"
+)
 
 REGULAR_LEAGUES_RESPONSE = {
     "categories": [
@@ -301,3 +310,198 @@ async def test_scrape_odds_uses_matched_regular_and_player_leagues(
     requested_urls = {call.args[0] for call in http_client.get_json.call_args_list}
     assert _PLAYER_LEAGUE_PREVIEW_URL.format(league_id="2300414") not in requested_urls
     assert _REGULAR_LEAGUE_PREVIEW_URL.format(league_id="2293537") in requested_urls
+
+
+@pytest.fixture
+def football_categories_data() -> dict:
+    return json.loads(FOOTBALL_CATEGORIES_FIXTURE_PATH.read_text())
+
+
+@pytest.fixture
+def football_league_data() -> dict:
+    return json.loads(FOOTBALL_LEAGUE_FIXTURE_PATH.read_text())
+
+
+def test_parse_football_outcome_match_emits_all_three_markets(football_league_data):
+    match = football_league_data["esMatches"][0]
+
+    results = _parse_football_outcome_match(match)
+
+    by_outcome = {(r.market_type, r.outcome_code): r for r in results}
+    assert (("football_result", "home")) in by_outcome
+    assert by_outcome[("football_result", "home")].odds == pytest.approx(1.88)
+    assert by_outcome[("football_result", "draw")].raw_label == "X"
+    assert by_outcome[("football_result", "away")].odds == pytest.approx(3.62)
+    assert by_outcome[("football_double_chance", "home_or_draw")].odds == pytest.approx(1.29)
+    assert by_outcome[("football_double_chance", "home_or_away")].raw_label == "12"
+    assert by_outcome[("football_double_chance", "draw_or_away")].odds == pytest.approx(1.93)
+    assert by_outcome[("football_total_goals", "under")].line == 2.5
+    assert by_outcome[("football_total_goals", "under")].odds == pytest.approx(2.91)
+    assert by_outcome[("football_total_goals", "over")].line == 2.5
+    assert by_outcome[("football_total_goals", "over")].odds == pytest.approx(1.41)
+
+    sample = next(iter(results))
+    assert sample.bookmaker_id == "365"
+    assert sample.sport == "football"
+    assert sample.home_team == "Liverpool"
+    assert sample.away_team == "Chelsea"
+    assert sample.start_time == "2026-05-09T11:30:00+00:00"
+
+
+def test_parse_football_outcome_match_skips_zero_or_missing_odds():
+    match = {
+        "home": "Home",
+        "away": "Away",
+        "leagueName": "X",
+        "kickOffTime": 1778326200000,
+        "odds": {"1": 1.5, "2": 0, "3": None, "22": -1, "24": "x"},
+    }
+
+    results = _parse_football_outcome_match(match)
+
+    assert {(r.market_type, r.outcome_code) for r in results} == {("football_result", "home")}
+
+
+def test_parse_football_outcome_match_returns_empty_without_teams():
+    match = {
+        "home": "",
+        "away": "Chelsea",
+        "kickOffTime": 1778326200000,
+        "odds": {"1": 1.5, "2": 3.0, "3": 2.0},
+    }
+
+    assert _parse_football_outcome_match(match) == []
+
+
+def test_parse_football_outcome_match_falls_back_to_default_league():
+    # When the league name is missing the parser must fall back to the
+    # generic ``football`` league id, NOT 365's basketball default.
+    match = {
+        "home": "A",
+        "away": "B",
+        "leagueName": None,
+        "kickOffTime": 1778326200000,
+        "odds": {"1": 1.5, "2": 3.0, "3": 2.0},
+    }
+
+    results = _parse_football_outcome_match(match)
+
+    assert {r.league_id for r in results} == {"football"}
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_football_fans_out_per_league(
+    football_categories_data, football_league_data, monkeypatch
+):
+    fixture_start = datetime(2026, 5, 9, 11, 30, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        "app.scrapers.bookmaker365_scraper.current_utc_time",
+        lambda: fixture_start - timedelta(hours=1),
+    )
+    monkeypatch.setattr(
+        "app.scrapers.bookmaker365_scraper.lookahead_cutoff",
+        lambda now: now + timedelta(hours=24),
+    )
+
+    second_league = {
+        "esMatches": [
+            {
+                "id": 99,
+                "sport": "S",
+                "home": "Real Madrid",
+                "away": "Barcelona",
+                "leagueName": "Liga Šampiona - Play Off",
+                "kickOffTime": int(fixture_start.timestamp() * 1000),
+                "odds": {"1": 2.1, "2": 3.5, "3": 3.2, "22": 2.0, "24": 1.8},
+            }
+        ]
+    }
+
+    async def fake_get_json(url: str, *, params=None, headers=None):
+        del params, headers
+        if url == _FOOTBALL_LEAGUES_URL:
+            return football_categories_data
+        if url == _FOOTBALL_LEAGUE_PREVIEW_URL.format(league_id="2222600"):
+            return second_league
+        if url == _FOOTBALL_LEAGUE_PREVIEW_URL.format(league_id="2222588"):
+            return football_league_data
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    http_client = AsyncMock()
+    http_client.rate_limit_per_second = 4.0
+    http_client.get_json.side_effect = fake_get_json
+
+    scraper = Bookmaker365Scraper(http_client=http_client)
+    results = await scraper.scrape_outcome_offers("football")
+
+    by_market = {r.market_type for r in results}
+    assert by_market == {
+        "football_result",
+        "football_double_chance",
+        "football_total_goals",
+    }
+    assert {r.bookmaker_id for r in results} == {"365"}
+    assert {r.home_team for r in results} == {"Liverpool", "Real Madrid"}
+
+    requested_urls = {call.args[0] for call in http_client.get_json.call_args_list}
+    assert _FOOTBALL_LEAGUES_URL in requested_urls
+    assert _FOOTBALL_LEAGUE_PREVIEW_URL.format(league_id="2222600") in requested_urls
+    assert _FOOTBALL_LEAGUE_PREVIEW_URL.format(league_id="2222588") in requested_urls
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_non_football_returns_empty():
+    http_client = AsyncMock()
+    http_client.rate_limit_per_second = 1.0
+
+    scraper = Bookmaker365Scraper(http_client=http_client)
+    results = await scraper.scrape_outcome_offers("basketball")
+
+    assert results == []
+    http_client.get_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_football_drops_matches_after_lookahead(
+    football_categories_data, monkeypatch
+):
+    # cutoff = now + 1h; the kickoff is 24h out, so the match must be
+    # filtered before it ever reaches the parser.
+    fixture_start = datetime(2026, 5, 9, 11, 30, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        "app.scrapers.bookmaker365_scraper.current_utc_time",
+        lambda: fixture_start - timedelta(hours=24),
+    )
+    monkeypatch.setattr(
+        "app.scrapers.bookmaker365_scraper.lookahead_cutoff",
+        lambda now: now + timedelta(hours=1),
+    )
+
+    far_future_league = {
+        "esMatches": [
+            {
+                "id": 1,
+                "sport": "S",
+                "home": "X",
+                "away": "Y",
+                "leagueName": "Liga Šampiona - Play Off",
+                "kickOffTime": int(fixture_start.timestamp() * 1000),
+                "odds": {"1": 1.9},
+            }
+        ]
+    }
+
+    async def fake_get_json(url: str, *, params=None, headers=None):
+        del params, headers
+        if url == _FOOTBALL_LEAGUES_URL:
+            return football_categories_data
+        return far_future_league
+
+    http_client = AsyncMock()
+    http_client.rate_limit_per_second = 4.0
+    http_client.get_json.side_effect = fake_get_json
+
+    scraper = Bookmaker365Scraper(http_client=http_client)
+    results = await scraper.scrape_outcome_offers("football")
+
+    assert results == []

--- a/backend/tests/test_scraper.py
+++ b/backend/tests/test_scraper.py
@@ -119,6 +119,22 @@ async def test_mock_scraper_supports_betole_football_outcomes():
 
 
 @pytest.mark.asyncio
+async def test_mock_scraper_supports_365_football_outcomes():
+    scraper = MockScraper("365")
+    data = await scraper.scrape_outcome_offers("football")
+
+    assert scraper.get_supported_outcome_sports() == ["football"]
+    assert len(data) > 0
+    assert all(isinstance(item, RawOutcomeOffer) for item in data)
+    assert all(item.bookmaker_id == "365" for item in data)
+    assert {item.market_type for item in data} == {
+        "football_result",
+        "football_double_chance",
+        "football_total_goals",
+    }
+
+
+@pytest.mark.asyncio
 async def test_mock_scraper_unsupported_league():
     scraper = MockScraper("mozzart")
     data = await scraper.scrape_odds("nba")

--- a/frontend/src/api/mockData.ts
+++ b/frontend/src/api/mockData.ts
@@ -153,6 +153,7 @@ export const mockMatches: Match[] = [
       { id: 'soccerbet', name: 'SoccerBet' },
       { id: 'merkurxtip', name: 'MERKUR X TIP' },
       { id: 'betole', name: 'BetOle' },
+      { id: '365', name: '365' },
     ],
   },
   {
@@ -171,6 +172,7 @@ export const mockMatches: Match[] = [
       { id: 'soccerbet', name: 'SoccerBet' },
       { id: 'merkurxtip', name: 'MERKUR X TIP' },
       { id: 'betole', name: 'BetOle' },
+      { id: '365', name: '365' },
     ],
   },
   {
@@ -267,6 +269,17 @@ export const mockFootballOutcomeOffers: OutcomeOffer[] = [
   { id: 1061, match_id: 'football-match-2', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_double_chance', outcome_code: 'draw_or_away', odds: 1.51, line: null, raw_label: 'X2', scraped_at: ago(1) },
   { id: 1062, match_id: 'football-match-2', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.78, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
   { id: 1063, match_id: 'football-match-2', bookmaker_id: 'betole', bookmaker_name: 'BetOle', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.16, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
+  { id: 1064, match_id: 'football-match-1', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_result', outcome_code: 'home', odds: 2.38, line: null, raw_label: '1', scraped_at: ago(1) },
+  { id: 1065, match_id: 'football-match-1', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_result', outcome_code: 'draw', odds: 3.20, line: null, raw_label: 'X', scraped_at: ago(1) },
+  { id: 1066, match_id: 'football-match-1', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_result', outcome_code: 'away', odds: 2.60, line: null, raw_label: '2', scraped_at: ago(1) },
+  { id: 1067, match_id: 'football-match-1', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_double_chance', outcome_code: 'home_or_draw', odds: 1.40, line: null, raw_label: '1X', scraped_at: ago(1) },
+  { id: 1068, match_id: 'football-match-1', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_double_chance', outcome_code: 'home_or_away', odds: 1.27, line: null, raw_label: '12', scraped_at: ago(1) },
+  { id: 1069, match_id: 'football-match-1', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_double_chance', outcome_code: 'draw_or_away', odds: 1.46, line: null, raw_label: 'X2', scraped_at: ago(1) },
+  { id: 1070, match_id: 'football-match-1', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_total_goals', outcome_code: 'under', odds: 2.04, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
+  { id: 1071, match_id: 'football-match-1', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_total_goals', outcome_code: 'over', odds: 1.85, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
+  { id: 1072, match_id: 'football-match-2', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_double_chance', outcome_code: 'draw_or_away', odds: 1.49, line: null, raw_label: 'X2', scraped_at: ago(1) },
+  { id: 1073, match_id: 'football-match-2', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.74, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
+  { id: 1074, match_id: 'football-match-2', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.20, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
 ];
 
 export const mockOpportunities: Opportunity[] = [


### PR DESCRIPTION
Extends the 365 scraper with the football outcome lane that already powers MaxBet/SoccerBet/MerkurXTip/OktagonBet/BetOle. Basketball path untouched.

## Markets emitted

- `football_result` (codes `1` / `2` / `3`)
- `football_total_goals` 2.5 (`22` under `0-2`, `24` over `3+`)
- `football_double_chance` (`7` `1X`, `8` `12`, `9` `X2`)

## Endpoints

365 organizes football as ~106 leagues, each with its own per-league preview endpoint:

- `GET https://ibet2.365.rs/restapi/offer/sr/categories/sport/S/l` — league list
- `GET https://ibet2.365.rs/restapi/offer/sr/sport/S/league/{league_id}/mob` — per-league preview

The preview already contains all 8 target codes in `match['odds']` — **no per-match detail call needed** (unlike BetOle, which had to fan out per match).

The discover→preview pattern is the same one the basketball path already uses; this PR reuses `_fetch_league_categories` / `_fetch_previews` for football too, just pointing at sport=`S` URLs.

## Shared change

`_extract_league_id` was extended with a `default` kwarg (was hardcoded to `"basketball"`). The football parser passes `default="football"`. All basketball callers continue to use the default — behavior there is unchanged. Pinned by `test_parse_football_outcome_match_falls_back_to_default_league`.

## Mock coherence

- `backend/app/scrapers/mock_scraper.py` — `_FOOTBALL_OUTCOME_MARKETS` gains a `365` block (11 entries across both games and all 3 markets).
- `frontend/src/api/mockData.ts` — `365` added to football match `available_bookmakers` (matches 1 & 2) plus 11 `OutcomeOffer` rows. `mockBookmakers` and `mockSystemStatus.bookmaker_status` already included `365`.

## Live verification

| Bookmaker | Matches | Offers | result | double_chance | total_goals 2.5 |
|-----------|--------:|-------:|-------:|--------------:|----------------:|
| 365       |      78 |    624 |    234 |           234 |             156 |

(at 24h lookahead)

## Tests

```
cd backend && ./venv/bin/pytest -q
```
1005 passed.

```
cd frontend && npm run build && npm run lint
```
clean.

## Rollout

Tipster/iBet family complete: SoccerBet (#84), MerkurXTip (#85), OktagonBet (#86), BetOle (#87), 365 (this PR). Next family: NSoft (verify if any other bookmaker matches the BalkanBet template), then Superbet/AdmiralBet/PinnBet/Mozzart/Meridian/VolcanoBet.
