### PR TITLE
Add Superbet football outcome scraper

### DIFF
--- a/backend/app/scrapers/mock_scraper.py
+++ b/backend/app/scrapers/mock_scraper.py
@@ -343,6 +343,19 @@ _FOOTBALL_OUTCOME_MARKETS: dict[str, list[dict]] = {
         {"game": 1, "market": "football_total_goals", "outcome": "under", "odds": 1.74, "line": 2.5, "label": "0-2"},
         {"game": 1, "market": "football_total_goals", "outcome": "over", "odds": 2.20, "line": 2.5, "label": "3+"},
     ],
+    "superbet": [
+        {"game": 0, "market": "football_result", "outcome": "home", "odds": 2.40, "label": "1"},
+        {"game": 0, "market": "football_result", "outcome": "draw", "odds": 3.25, "label": "X"},
+        {"game": 0, "market": "football_result", "outcome": "away", "odds": 2.55, "label": "2"},
+        {"game": 0, "market": "football_double_chance", "outcome": "home_or_draw", "odds": 1.39, "label": "1X"},
+        {"game": 0, "market": "football_double_chance", "outcome": "home_or_away", "odds": 1.26, "label": "12"},
+        {"game": 0, "market": "football_double_chance", "outcome": "draw_or_away", "odds": 1.45, "label": "X2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "under", "odds": 2.05, "line": 2.5, "label": "0-2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "over", "odds": 1.84, "line": 2.5, "label": "3+"},
+        {"game": 1, "market": "football_result", "outcome": "home", "odds": 1.92, "label": "1"},
+        {"game": 1, "market": "football_total_goals", "outcome": "under", "odds": 1.78, "line": 2.5, "label": "0-2"},
+        {"game": 1, "market": "football_total_goals", "outcome": "over", "odds": 2.16, "line": 2.5, "label": "3+"},
+    ],
 }
 
 

--- a/backend/app/scrapers/superbet_scraper.py
+++ b/backend/app/scrapers/superbet_scraper.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 from .base import BaseScraper
 from .http_client import HttpClient
-from ..models.schemas import RawOddsData
+from ..models.schemas import RawOddsData, RawOutcomeOffer
 from ..services.scrape_window import current_utc_time, lookahead_cutoff
 from ..services.text_normalizer import normalize_identity_text
 
@@ -126,6 +126,51 @@ _PLAYER_TURNOVERS_MARKET_NAMES = {
 }
 
 
+# Football outcome-offer markets are surfaced in the SuperBet event
+# subscription payload as full-game match markets. Each is anchored on
+# its **stable numeric market id** (preferred over the localized name,
+# which can drift across releases). The codes inside each market come
+# from ``odds[].metadata.code`` and are scoped per market — there is no
+# cross-market collision because we look up the mapping only after we
+# have already classified the market by id.
+#
+# - ``Konačan ishod`` (id 547): 1X2 result.
+#   Codes: ``"1"`` = home, ``"0"`` = draw (X), ``"2"`` = away.
+# - ``Dupla šansa`` (id 531): double chance.
+#   Codes: ``"10"`` = 1X (home_or_draw), ``"12"`` = 12 (home_or_away),
+#   ``"02"`` = X2 (draw_or_away).
+# - ``Ukupno golova`` (id 200734): total goals ladder. Each over/under
+#   pair is keyed by ``odds[].metadata.specifiers["total"]`` (e.g.
+#   ``"2.5"``). The first MVP slice emits only the **2.5** line, with
+#   side derived from the localized prefix on ``metadata.name`` —
+#   ``Više`` = over, ``Manje`` = under. We compare the parsed float to
+#   ``2.5`` rather than doing string equality so cosmetic variants like
+#   ``"2.50"``/``" 2.5 "`` are handled.
+_FOOTBALL_RESULT_MARKET_ID = 547
+_FOOTBALL_DOUBLE_CHANCE_MARKET_ID = 531
+_FOOTBALL_TOTAL_GOALS_MARKET_ID = 200734
+_FOOTBALL_TARGET_TOTAL_LINE = 2.5
+
+_FOOTBALL_RESULT_OUTCOMES: dict[str, tuple[str, str]] = {
+    "1": ("home", "1"),
+    "0": ("draw", "X"),
+    "2": ("away", "2"),
+}
+
+_FOOTBALL_DOUBLE_CHANCE_OUTCOMES: dict[str, tuple[str, str]] = {
+    "10": ("home_or_draw", "1X"),
+    "12": ("home_or_away", "12"),
+    "02": ("draw_or_away", "X2"),
+}
+
+# Side detection for ``Ukupno golova`` is based on the localized prefix
+# of ``metadata.name`` (e.g. ``"Više 2.5"``/``"Manje 2.5"``). We
+# normalize once via ``normalize_identity_text`` so accent/case shifts
+# do not break the match — ``Više`` -> ``vise``, ``Manje`` -> ``manje``.
+_FOOTBALL_TOTAL_GOALS_OVER_PREFIX = "vise"
+_FOOTBALL_TOTAL_GOALS_UNDER_PREFIX = "manje"
+
+
 @dataclass(frozen=True)
 class SportSpec:
     scope_id: str
@@ -167,6 +212,21 @@ _SPORT_SPECS: dict[str, SportSpec] = {
         sport_name="basketball",
         sport_id=4,
         route_slug="kosarka",
+    ),
+}
+
+# Football is exposed only through the outcome-offer lane
+# (``scrape_outcome_offers``) and must NOT be advertised as a
+# threshold-odds league via ``get_supported_leagues()`` — otherwise the
+# unified pipeline would generate a bogus ``threshold_odds`` capability
+# for ``(basketball, football)`` and call ``scrape_odds("football")``
+# every cycle. Keep this lookup separate from ``_SPORT_SPECS``.
+_OUTCOME_SPORT_SPECS: dict[str, SportSpec] = {
+    "football": SportSpec(
+        scope_id="football",
+        sport_name="football",
+        sport_id=5,
+        route_slug="fudbal",
     ),
 }
 
@@ -221,10 +281,10 @@ def _normalize_league_key(raw_name: str | None) -> str:
     return normalize_identity_text(raw_name)
 
 
-def _extract_league_id(raw_name: str | None) -> str:
+def _extract_league_id(raw_name: str | None, *, default: str = "basketball") -> str:
     normalized = _normalize_league_key(raw_name)
     if not normalized:
-        return "basketball"
+        return default
     return _CANONICAL_LEAGUES.get(normalized, normalized.replace(" ", "_"))
 
 
@@ -481,6 +541,167 @@ def _extract_wrapped_event_id(value: dict) -> int | None:
     return _parse_int(fixture.get("event_id") or fixture.get("offer_id"))
 
 
+def _odd_is_displayable(odd: dict) -> bool:
+    if odd.get("display") is False:
+        return False
+    if odd.get("status") not in (1, "1", "active", "ACTIVE"):
+        return False
+    return True
+
+
+def _football_total_side_from_name(name: str | None) -> str | None:
+    if not isinstance(name, str):
+        return None
+    normalized = normalize_identity_text(name)
+    if not normalized:
+        return None
+    head = normalized.split(" ", 1)[0]
+    if head == _FOOTBALL_TOTAL_GOALS_OVER_PREFIX:
+        return "over"
+    if head == _FOOTBALL_TOTAL_GOALS_UNDER_PREFIX:
+        return "under"
+    return None
+
+
+def _parse_football_event_payload(
+    event_payload: dict,
+    *,
+    context: EventContext,
+    bookmaker_id: str = _BOOKMAKER_ID,
+) -> list[RawOutcomeOffer]:
+    """Emit Superbet football outcome offers from a subscription payload.
+
+    Identity fields (home/away/league/start_time) are taken from
+    ``context`` (built off ``events-by-date``) and never from the per-
+    event detail payload, so the same logical event always normalizes
+    consistently across batches.
+    """
+
+    markets = event_payload.get("markets")
+    if not isinstance(markets, list):
+        return []
+
+    results: list[RawOutcomeOffer] = []
+
+    for market in markets:
+        if not isinstance(market, dict):
+            continue
+        market_id = _parse_int(market.get("id"))
+        if market_id is None:
+            continue
+        if market_id not in (
+            _FOOTBALL_RESULT_MARKET_ID,
+            _FOOTBALL_DOUBLE_CHANCE_MARKET_ID,
+            _FOOTBALL_TOTAL_GOALS_MARKET_ID,
+        ):
+            continue
+
+        odds = market.get("odds")
+        if not isinstance(odds, list):
+            continue
+
+        for odd in odds:
+            if not isinstance(odd, dict) or not _odd_is_displayable(odd):
+                continue
+            price = _parse_float(odd.get("price"))
+            if price is None or price <= 1.0:
+                continue
+            metadata = odd.get("metadata")
+            if not isinstance(metadata, dict):
+                continue
+
+            offer = _parse_football_odd(
+                market_id=market_id,
+                metadata=metadata,
+                price=price,
+                context=context,
+                bookmaker_id=bookmaker_id,
+            )
+            if offer is not None:
+                results.append(offer)
+
+    return results
+
+
+def _parse_football_odd(
+    *,
+    market_id: int,
+    metadata: dict,
+    price: float,
+    context: EventContext,
+    bookmaker_id: str,
+) -> RawOutcomeOffer | None:
+    if market_id == _FOOTBALL_RESULT_MARKET_ID:
+        code = metadata.get("code")
+        mapping = _FOOTBALL_RESULT_OUTCOMES.get(str(code) if code is not None else "")
+        if mapping is None:
+            return None
+        outcome_code, raw_label = mapping
+        return RawOutcomeOffer(
+            bookmaker_id=bookmaker_id,
+            league_id=context.league_id,
+            sport="football",
+            home_team=context.home_team,
+            away_team=context.away_team,
+            source_url=context.source_url,
+            market_type="football_result",
+            outcome_code=outcome_code,
+            odds=price,
+            line=None,
+            raw_label=raw_label,
+            start_time=context.start_time,
+        )
+
+    if market_id == _FOOTBALL_DOUBLE_CHANCE_MARKET_ID:
+        code = metadata.get("code")
+        mapping = _FOOTBALL_DOUBLE_CHANCE_OUTCOMES.get(str(code) if code is not None else "")
+        if mapping is None:
+            return None
+        outcome_code, raw_label = mapping
+        return RawOutcomeOffer(
+            bookmaker_id=bookmaker_id,
+            league_id=context.league_id,
+            sport="football",
+            home_team=context.home_team,
+            away_team=context.away_team,
+            source_url=context.source_url,
+            market_type="football_double_chance",
+            outcome_code=outcome_code,
+            odds=price,
+            line=None,
+            raw_label=raw_label,
+            start_time=context.start_time,
+        )
+
+    if market_id == _FOOTBALL_TOTAL_GOALS_MARKET_ID:
+        specifiers = metadata.get("specifiers")
+        if not isinstance(specifiers, dict):
+            return None
+        line_value = _parse_float(specifiers.get("total"))
+        if line_value is None or line_value != _FOOTBALL_TARGET_TOTAL_LINE:
+            return None
+        side = _football_total_side_from_name(metadata.get("name"))
+        if side is None:
+            return None
+        raw_label = "3+" if side == "over" else "0-2"
+        return RawOutcomeOffer(
+            bookmaker_id=bookmaker_id,
+            league_id=context.league_id,
+            sport="football",
+            home_team=context.home_team,
+            away_team=context.away_team,
+            source_url=context.source_url,
+            market_type="football_total_goals",
+            outcome_code=side,
+            odds=price,
+            line=_FOOTBALL_TARGET_TOTAL_LINE,
+            raw_label=raw_label,
+            start_time=context.start_time,
+        )
+
+    return None
+
+
 def _iter_event_payloads(messages: list[object]) -> list[dict]:
     payloads: list[dict] = []
     for message in messages:
@@ -646,7 +867,10 @@ class SuperbetScraper(BaseScraper):
             if league_name is None and category_id is not None:
                 league_name = structure_lookup.category_names.get(category_id)
 
-            league_id = _extract_league_id(league_name or spec.scope_id)
+            league_id = _extract_league_id(
+                league_name or spec.scope_id,
+                default=spec.scope_id,
+            )
             start_time = _parse_start_time(event.get("utcDate"))
             contexts[event_id] = EventContext(
                 event_id=event_id,
@@ -751,3 +975,57 @@ class SuperbetScraper(BaseScraper):
             )
 
         return results
+
+    def get_supported_outcome_sports(self) -> list[str]:
+        return sorted(_OUTCOME_SPORT_SPECS)
+
+    async def scrape_outcome_offers(self, sport: str) -> list[RawOutcomeOffer]:
+        spec = _OUTCOME_SPORT_SPECS.get(sport)
+        if spec is None:
+            return []
+
+        # Football classification is anchored on stable numeric market
+        # ids — no market-groups lookup is needed, so we save one HTTP
+        # call per cycle versus the basketball flow.
+        structure_lookup, raw_events = await asyncio.gather(
+            self._get_structure_lookup(spec),
+            self._fetch_events_by_date(spec),
+        )
+
+        contexts = self._build_event_contexts(
+            spec,
+            raw_events,
+            structure_lookup=structure_lookup,
+        )
+        if not contexts:
+            logger.warning("Superbet: no %s events discovered", spec.scope_id)
+            return []
+
+        event_ids = sorted(contexts)
+        detail_semaphore = asyncio.Semaphore(_DETAIL_CONCURRENCY)
+        detail_batches = await asyncio.gather(
+            *(
+                self._fetch_event_batch(batch, semaphore=detail_semaphore)
+                for batch in _chunked(event_ids, spec.detail_batch_size)
+            )
+        )
+
+        detail_by_event: dict[int, dict] = {}
+        for batch in detail_batches:
+            detail_by_event.update(batch)
+
+        offers: list[RawOutcomeOffer] = []
+        for event_id in event_ids:
+            payload = detail_by_event.get(event_id)
+            context = contexts.get(event_id)
+            if payload is None or context is None:
+                continue
+            offers.extend(
+                _parse_football_event_payload(
+                    payload,
+                    context=context,
+                    bookmaker_id=_BOOKMAKER_ID,
+                )
+            )
+
+        return offers

--- a/backend/tests/test_scraper.py
+++ b/backend/tests/test_scraper.py
@@ -135,6 +135,22 @@ async def test_mock_scraper_supports_365_football_outcomes():
 
 
 @pytest.mark.asyncio
+async def test_mock_scraper_supports_superbet_football_outcomes():
+    scraper = MockScraper("superbet")
+    data = await scraper.scrape_outcome_offers("football")
+
+    assert scraper.get_supported_outcome_sports() == ["football"]
+    assert len(data) > 0
+    assert all(isinstance(item, RawOutcomeOffer) for item in data)
+    assert all(item.bookmaker_id == "superbet" for item in data)
+    assert {item.market_type for item in data} == {
+        "football_result",
+        "football_double_chance",
+        "football_total_goals",
+    }
+
+
+@pytest.mark.asyncio
 async def test_mock_scraper_unsupported_league():
     scraper = MockScraper("mozzart")
     data = await scraper.scrape_odds("nba")

--- a/backend/tests/test_superbet_scraper.py
+++ b/backend/tests/test_superbet_scraper.py
@@ -847,3 +847,301 @@ async def test_scrape_odds_retries_missing_batch_events_singly():
     assert any(row.player_name == "Matt Thomas" and row.threshold == 12.5 for row in results)
     requested_batches = [call.kwargs["params"]["events"] for call in http_client.get_sse_json.call_args_list]
     assert requested_batches == ["12629345,12645680", "12645680"]
+
+
+# ── Football outcome offers ─────────────────────────────────────────────
+
+
+from app.scrapers.superbet_scraper import (
+    _OUTCOME_SPORT_SPECS,
+    _parse_football_event_payload,
+)
+from app.models.schemas import RawOutcomeOffer
+
+
+_FOOTBALL_CONTEXT = EventContext(
+    event_id=12850987,
+    league_id="brazil_under_20",
+    home_team="Vila Nova GO U20",
+    away_team="Botafogo SP U20",
+    start_time=START_DT.isoformat(),
+    source_url="https://superbet.rs/kvote/fudbal/vila-nova-go-u20-vs-botafogo-sp-u20-12850987?mdt=o",
+)
+
+
+def _football_payload() -> dict:
+    """Synthesise a subscription payload mirroring the live shape."""
+    return {
+        "event_id": 12850987,
+        "fixture": {
+            "event_name": "Vila Nova GO U20·Botafogo SP U20",
+            "utc_date": START_Z,
+            "category_id": 74,
+            "tournament_id": 86166,
+        },
+        "markets": [
+            {
+                "id": 547,
+                "name": "Konačan ishod",
+                "metadata": {},
+                "odds": [
+                    {"price": 2.35, "status": 1, "display": True,
+                     "metadata": {"code": "1", "name": "1"}},
+                    {"price": 3.30, "status": 1, "display": True,
+                     "metadata": {"code": "0", "name": "X"}},
+                    {"price": 2.62, "status": 1, "display": True,
+                     "metadata": {"code": "2", "name": "2"}},
+                ],
+            },
+            {
+                "id": 531,
+                "name": "Dupla šansa",
+                "metadata": {},
+                "odds": [
+                    {"price": 1.38, "status": 1, "display": True,
+                     "metadata": {"code": "10", "name": "1X"}},
+                    {"price": 1.24, "status": 1, "display": True,
+                     "metadata": {"code": "12", "name": "12"}},
+                    {"price": 1.46, "status": 1, "display": True,
+                     "metadata": {"code": "02", "name": "X2"}},
+                ],
+            },
+            {
+                "id": 200734,
+                "name": "Ukupno golova",
+                "metadata": {},
+                "odds": [
+                    # 1.5 line (must be ignored - only 2.5 is in scope)
+                    {"price": 4.00, "status": 1, "display": True,
+                     "metadata": {"name": "Manje 1.5", "specifiers": {"total": "1.5"}}},
+                    {"price": 1.16, "status": 1, "display": True,
+                     "metadata": {"name": "Više 1.5", "specifiers": {"total": "1.5"}}},
+                    # 2.5 line (in scope)
+                    {"price": 2.15, "status": 1, "display": True,
+                     "metadata": {"name": "Manje 2.5", "specifiers": {"total": "2.5"}}},
+                    {"price": 1.61, "status": 1, "display": True,
+                     "metadata": {"name": "Više 2.5", "specifiers": {"total": "2.5"}}},
+                ],
+            },
+            # Off-scope market should be ignored entirely.
+            {
+                "id": 539,
+                "name": "Oba tima daju gol (GG)",
+                "metadata": {},
+                "odds": [
+                    {"price": 1.55, "status": 1, "display": True,
+                     "metadata": {"code": "GG", "name": "GG"}},
+                ],
+            },
+        ],
+    }
+
+
+def test_parse_football_event_payload_emits_three_target_markets():
+    offers = _parse_football_event_payload(_football_payload(), context=_FOOTBALL_CONTEXT)
+
+    by_key = {(o.market_type, o.outcome_code): o for o in offers}
+    # 1X2 result
+    assert by_key[("football_result", "home")].odds == 2.35
+    assert by_key[("football_result", "home")].raw_label == "1"
+    assert by_key[("football_result", "draw")].odds == 3.30
+    assert by_key[("football_result", "draw")].raw_label == "X"
+    assert by_key[("football_result", "away")].odds == 2.62
+    assert by_key[("football_result", "away")].raw_label == "2"
+    # Double chance
+    assert by_key[("football_double_chance", "home_or_draw")].odds == 1.38
+    assert by_key[("football_double_chance", "home_or_draw")].raw_label == "1X"
+    assert by_key[("football_double_chance", "home_or_away")].odds == 1.24
+    assert by_key[("football_double_chance", "home_or_away")].raw_label == "12"
+    assert by_key[("football_double_chance", "draw_or_away")].odds == 1.46
+    assert by_key[("football_double_chance", "draw_or_away")].raw_label == "X2"
+    # Total goals 2.5 only
+    assert by_key[("football_total_goals", "over")].odds == 1.61
+    assert by_key[("football_total_goals", "over")].line == 2.5
+    assert by_key[("football_total_goals", "over")].raw_label == "3+"
+    assert by_key[("football_total_goals", "under")].odds == 2.15
+    assert by_key[("football_total_goals", "under")].line == 2.5
+    assert by_key[("football_total_goals", "under")].raw_label == "0-2"
+    # Off-scope and off-line offers are excluded
+    assert all(not (o.market_type == "football_total_goals" and o.line == 1.5) for o in offers)
+    # Identity is preserved from context, not detail
+    assert all(o.home_team == "Vila Nova GO U20" for o in offers)
+    assert all(o.away_team == "Botafogo SP U20" for o in offers)
+    assert all(o.league_id == "brazil_under_20" for o in offers)
+    assert all(o.start_time == _FOOTBALL_CONTEXT.start_time for o in offers)
+    assert all(o.source_url == _FOOTBALL_CONTEXT.source_url for o in offers)
+    assert all(o.bookmaker_id == "superbet" for o in offers)
+    assert all(o.sport == "football" for o in offers)
+
+
+def test_parse_football_event_payload_skips_inactive_or_zero_odds():
+    payload = _football_payload()
+    payload["markets"][0]["odds"][0]["status"] = 0  # 1 = home, status off
+    payload["markets"][0]["odds"][1]["display"] = False  # X = draw, hidden
+    payload["markets"][2]["odds"][2]["price"] = 1.0  # under 2.5 at price 1.0
+
+    offers = _parse_football_event_payload(payload, context=_FOOTBALL_CONTEXT)
+    by_key = {(o.market_type, o.outcome_code) for o in offers}
+    assert ("football_result", "home") not in by_key
+    assert ("football_result", "draw") not in by_key
+    assert ("football_result", "away") in by_key
+    assert ("football_total_goals", "over") in by_key
+    assert ("football_total_goals", "under") not in by_key
+
+
+def test_parse_football_event_payload_tolerates_total_string_variants():
+    """The parser must accept ``"2.50"`` / ``" 2.5 "`` as the 2.5 line."""
+    payload = _football_payload()
+    # Replace the 2.5 odds with cosmetic variants
+    payload["markets"][2]["odds"] = [
+        {"price": 2.10, "status": 1, "display": True,
+         "metadata": {"name": "Manje 2.5", "specifiers": {"total": " 2.5 "}}},
+        {"price": 1.65, "status": 1, "display": True,
+         "metadata": {"name": "Više 2.5", "specifiers": {"total": "2.50"}}},
+    ]
+    offers = _parse_football_event_payload(payload, context=_FOOTBALL_CONTEXT)
+    by_key = {(o.market_type, o.outcome_code): o for o in offers}
+    assert by_key[("football_total_goals", "over")].line == 2.5
+    assert by_key[("football_total_goals", "over")].odds == 1.65
+    assert by_key[("football_total_goals", "under")].line == 2.5
+    assert by_key[("football_total_goals", "under")].odds == 2.10
+
+
+def test_parse_football_event_payload_uses_context_identity_not_detail():
+    """B1-style invariant: identity comes from EventContext, never from
+    the per-event subscription payload — even if the detail disagrees."""
+    payload = _football_payload()
+    # Pollute fixture with a different team name, league, and time
+    payload["fixture"] = {
+        "event_name": "Wrong Home·Wrong Away",
+        "utc_date": "2099-12-31T23:59:59Z",
+        "category_id": 999,
+        "tournament_id": 999,
+    }
+    offers = _parse_football_event_payload(payload, context=_FOOTBALL_CONTEXT)
+    assert offers, "expected non-empty offers"
+    assert all(o.home_team == _FOOTBALL_CONTEXT.home_team for o in offers)
+    assert all(o.away_team == _FOOTBALL_CONTEXT.away_team for o in offers)
+    assert all(o.start_time == _FOOTBALL_CONTEXT.start_time for o in offers)
+    assert all(o.league_id == _FOOTBALL_CONTEXT.league_id for o in offers)
+
+
+def test_parse_football_event_payload_ignores_unknown_codes():
+    payload = _football_payload()
+    payload["markets"][0]["odds"].append(
+        {"price": 5.0, "status": 1, "display": True,
+         "metadata": {"code": "9", "name": "?"}},
+    )
+    payload["markets"][1]["odds"].append(
+        {"price": 5.0, "status": 1, "display": True,
+         "metadata": {"code": "00", "name": "??"}},
+    )
+    offers = _parse_football_event_payload(payload, context=_FOOTBALL_CONTEXT)
+    # The original 3 result + 3 double chance + 2 totals (2.5) = 8 offers
+    assert len(offers) == 8
+
+
+def test_outcome_spec_does_not_pollute_basketball_league_list():
+    """Football must not appear in get_supported_leagues() (basketball lane)."""
+    scraper = SuperbetScraper(http_client=AsyncMock())
+    assert scraper.get_supported_leagues() == ["basketball"]
+    assert scraper.get_supported_outcome_sports() == ["football"]
+    assert "football" in _OUTCOME_SPORT_SPECS
+
+
+def test_extract_league_id_default_kwarg_falls_back_to_sport_scope():
+    """When the raw league name normalizes to empty, the fallback must
+    honour the caller-provided default — not the basketball constant.
+    Otherwise a football event with a degenerate league name (e.g.
+    a label that normalizes to '') would be tagged league_id='basketball'
+    and split off from the rest of the football canonical pool."""
+    assert _extract_league_id("", default="football") == "football"
+    assert _extract_league_id(None, default="football") == "football"
+    # A non-empty but normalize-to-empty label still falls back
+    assert _extract_league_id("---", default="football") == "football"
+    # Basketball callers (no kwarg) keep their existing behaviour
+    assert _extract_league_id("") == "basketball"
+    assert _extract_league_id(None) == "basketball"
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_only_supports_football():
+    scraper = SuperbetScraper(http_client=AsyncMock())
+    assert await scraper.scrape_outcome_offers("basketball") == []
+    assert await scraper.scrape_outcome_offers("tennis") == []
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_football_end_to_end():
+    """Verifies discover -> SSE -> parse pipeline for football and that
+    the market-groups call is NOT made for the football lane."""
+
+    async def fake_get_json(url: str, *, params=None, headers=None):
+        del headers
+        if url == _STRUCTURE_URL:
+            return {
+                "data": {
+                    "tournaments": [
+                        {"id": 86166, "localNames": {"sr-Latn-RS": "Brasileirao Serie A"}},
+                    ],
+                    "categories": [
+                        {"id": 74, "localNames": {"sr-Latn-RS": "Brazil"}},
+                    ],
+                }
+            }
+        if url == _MARKET_GROUPS_URL.format(sport_id=5):
+            raise AssertionError(
+                "Football lane must not request market-groups (no group-name "
+                "lookup is needed when classification is by market id)"
+            )
+        if url == _EVENTS_BY_DATE_URL:
+            assert params is not None
+            assert params["sportId"] == "5"
+            assert params["offerState"] == "prematch"
+            return {
+                "data": [
+                    {
+                        "eventId": 12850987,
+                        "sportId": 5,
+                        "matchName": "Vila Nova GO U20·Botafogo SP U20",
+                        "tournamentId": 86166,
+                        "categoryId": 74,
+                        "utcDate": START_Z,
+                    }
+                ]
+            }
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    async def fake_get_sse_json(url: str, *, params=None, headers=None, max_messages=1, read_timeout=None):
+        del headers
+        assert url == _EVENT_SUBSCRIPTION_URL
+        assert params == {"events": "12850987"}
+        assert max_messages == 1
+        assert read_timeout == 10.0
+        return [[_football_payload()]]
+
+    http_client = AsyncMock()
+    http_client.get_json.side_effect = fake_get_json
+    http_client.get_sse_json.side_effect = fake_get_sse_json
+
+    scraper = SuperbetScraper(http_client=http_client)
+    offers = await scraper.scrape_outcome_offers("football")
+
+    assert {o.market_type for o in offers} == {
+        "football_result",
+        "football_double_chance",
+        "football_total_goals",
+    }
+    assert {o.bookmaker_id for o in offers} == {"superbet"}
+    assert {o.sport for o in offers} == {"football"}
+    assert {o.home_team for o in offers} == {"Vila Nova GO U20"}
+    assert {o.away_team for o in offers} == {"Botafogo SP U20"}
+    assert {o.league_id for o in offers} == {"brasileirao_serie_a"}
+    assert {o.source_url for o in offers} == {
+        "https://superbet.rs/kvote/fudbal/vila-nova-go-u20-vs-botafogo-sp-u20-12850987?mdt=o"
+    }
+    # Total goals only at 2.5
+    totals = [o for o in offers if o.market_type == "football_total_goals"]
+    assert {o.line for o in totals} == {2.5}
+    assert {o.outcome_code for o in totals} == {"over", "under"}
+

--- a/frontend/src/api/mockData.ts
+++ b/frontend/src/api/mockData.ts
@@ -154,6 +154,7 @@ export const mockMatches: Match[] = [
       { id: 'merkurxtip', name: 'MERKUR X TIP' },
       { id: 'betole', name: 'BetOle' },
       { id: '365', name: '365' },
+      { id: 'superbet', name: 'Superbet' },
     ],
   },
   {
@@ -173,6 +174,7 @@ export const mockMatches: Match[] = [
       { id: 'merkurxtip', name: 'MERKUR X TIP' },
       { id: 'betole', name: 'BetOle' },
       { id: '365', name: '365' },
+      { id: 'superbet', name: 'Superbet' },
     ],
   },
   {
@@ -280,6 +282,17 @@ export const mockFootballOutcomeOffers: OutcomeOffer[] = [
   { id: 1072, match_id: 'football-match-2', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_double_chance', outcome_code: 'draw_or_away', odds: 1.49, line: null, raw_label: 'X2', scraped_at: ago(1) },
   { id: 1073, match_id: 'football-match-2', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.74, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
   { id: 1074, match_id: 'football-match-2', bookmaker_id: '365', bookmaker_name: '365', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.20, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
+  { id: 1075, match_id: 'football-match-1', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_result', outcome_code: 'home', odds: 2.40, line: null, raw_label: '1', scraped_at: ago(1) },
+  { id: 1076, match_id: 'football-match-1', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_result', outcome_code: 'draw', odds: 3.25, line: null, raw_label: 'X', scraped_at: ago(1) },
+  { id: 1077, match_id: 'football-match-1', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_result', outcome_code: 'away', odds: 2.55, line: null, raw_label: '2', scraped_at: ago(1) },
+  { id: 1078, match_id: 'football-match-1', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_double_chance', outcome_code: 'home_or_draw', odds: 1.39, line: null, raw_label: '1X', scraped_at: ago(1) },
+  { id: 1079, match_id: 'football-match-1', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_double_chance', outcome_code: 'home_or_away', odds: 1.26, line: null, raw_label: '12', scraped_at: ago(1) },
+  { id: 1080, match_id: 'football-match-1', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_double_chance', outcome_code: 'draw_or_away', odds: 1.45, line: null, raw_label: 'X2', scraped_at: ago(1) },
+  { id: 1081, match_id: 'football-match-1', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_total_goals', outcome_code: 'under', odds: 2.05, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
+  { id: 1082, match_id: 'football-match-1', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_total_goals', outcome_code: 'over', odds: 1.84, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
+  { id: 1083, match_id: 'football-match-2', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_result', outcome_code: 'home', odds: 1.92, line: null, raw_label: '1', scraped_at: ago(1) },
+  { id: 1084, match_id: 'football-match-2', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.78, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
+  { id: 1085, match_id: 'football-match-2', bookmaker_id: 'superbet', bookmaker_name: 'Superbet', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.16, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
 ];
 
 export const mockOpportunities: Opportunity[] = [


### PR DESCRIPTION
Adds the football outcome-offer lane to Superbet, parallel to the existing basketball threshold-odds lane.

## Live verification

- **Matches:** 235
- **Odds:** 1,761
  - football_result: 705 (235 × {home, draw, away})
  - football_double_chance: 692
  - football_total_goals: 364 (line 2.5 only; 182 over + 182 under)

## Implementation

Reuses the Fastly structure + events-by-date + per-event SSE detail pipeline (sport_id=5). Skips the market-groups lookup because football classification is anchored on stable numeric market ids.

Football markets emitted as `RawOutcomeOffer`:

| Market | id | Codes |
|---|---|---|
| `football_result` | 547 | `metadata.code` ∈ {1, 0, 2} → home/draw/away |
| `football_double_chance` | 531 | `metadata.code` ∈ {10, 12, 02} → home_or_draw/home_or_away/draw_or_away |
| `football_total_goals` | 200734 | line from `metadata.specifiers.total` (parsed via `_parse_float` for cosmetic variants), side from localized prefix on `metadata.name` ("Više" → over, "Manje" → under). Only the **2.5** line is emitted. |

## Design constraints

- **Capability isolation** — football is registered under a separate `_OUTCOME_SPORT_SPECS["football"]` lookup, never in `_SPORT_SPECS`. `get_supported_leagues()` continues to return `["basketball"]` so the unified pipeline does not surface a spurious `(basketball, football)` threshold-odds capability and does not call `scrape_odds("football")` every cycle. Pinned by `test_outcome_spec_does_not_pollute_basketball_league_list`.
- **B1 identity invariant** — event identity (home/away/league/start_time/source_url) comes from `EventContext` built from events-by-date, never from the per-event subscription detail. Pinned by `test_parse_football_event_payload_uses_context_identity_not_detail`.
- **Default-kwarg fallback** — `_extract_league_id` got a `*, default="basketball"` kwarg so existing basketball callers stay unchanged and the football lane can pass `default=spec.scope_id` to avoid a degenerate league name (one that normalizes to empty) leaking out as `league_id="basketball"`. Pinned by `test_extract_league_id_default_kwarg_falls_back_to_sport_scope`.

## Mock coherence

- Backend: `superbet` block in `_FOOTBALL_OUTCOME_MARKETS` + matching `test_mock_scraper_supports_superbet_football_outcomes`.
- Frontend: `superbet` added to football matches' `available_bookmakers` and 11 OutcomeOffer rows ids 1075–1085.

## Tests

- Backend full suite: **1015/1015 pass**.
- New superbet football tests: 9 new tests covering parser happy path, status/display gating, total-line string variants, B1 context-authoritative invariant, unknown-code rejection, sport-list isolation, sport-not-supported short-circuit, end-to-end mock HTTP (asserts the market-groups call is NOT made), and the league-id default-kwarg fallback.
- Frontend build + lint: clean.

## Pre-implementation rubber-duck + post-implementation code-review

- Rubber-duck caught the capability-leak risk (adding football to `_SPORT_SPECS` would have surfaced as a basketball threshold-odds league). Fixed by introducing the separate `_OUTCOME_SPORT_SPECS` lookup.
- Code-review on the staged diff caught a follow-on risk: the new `_extract_league_id(default=...)` kwarg was unused by `_build_event_contexts`, so a non-empty league name that normalizes to empty would still default to `"basketball"` for football events. Fixed by passing `default=spec.scope_id` at the call site, with a regression test.