### PR TITLE
Add PinnBet football outcome scraper (partial + full modes)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -32,6 +32,9 @@ class Settings(BaseSettings):
     soccerbet_detail_mode: Literal["partial", "full"] = "partial"
     # partial = list feeds only; full = list feeds plus match detail for alternate totals.
     merkurxtip_detail_mode: Literal["partial", "full"] = "partial"
+    # partial = football list feed only (result + 2.5 totals); full = list feed
+    # plus per-event detail fetch to also emit double chance.
+    pinnbet_detail_mode: Literal["partial", "full"] = "partial"
     scrape_lookahead_hours: int = Field(default=24, ge=0)
     benchmark_dir: str = str(
         Path(__file__).resolve().parent.parent / "benchmarks"

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -450,6 +450,7 @@ class ScrapeRuntimeSettings(BaseModel):
     meridian_rate_limit_per_second: float = Field(default=2.0, ge=0)
     soccerbet_detail_mode: ScraperDetailMode = "partial"
     merkurxtip_detail_mode: ScraperDetailMode = "partial"
+    pinnbet_detail_mode: ScraperDetailMode = "partial"
     notification_gap_threshold: float = Field(default=1.5, ge=0)
     persist_inapp_notifications: bool = False
 
@@ -466,6 +467,7 @@ class ScrapeRuntimeSettingsUpdate(BaseModel):
     meridian_rate_limit_per_second: Optional[float] = Field(default=None, ge=0)
     soccerbet_detail_mode: Optional[ScraperDetailMode] = None
     merkurxtip_detail_mode: Optional[ScraperDetailMode] = None
+    pinnbet_detail_mode: Optional[ScraperDetailMode] = None
     notification_gap_threshold: Optional[float] = Field(default=None, ge=0)
     persist_inapp_notifications: Optional[bool] = None
 

--- a/backend/app/scrapers/mock_scraper.py
+++ b/backend/app/scrapers/mock_scraper.py
@@ -110,6 +110,7 @@ _BOOKMAKER_META = {
     "betole": ("BetOle", "https://www.betole.com"),
     "365": ("365", "https://www.365.rs/"),
     "admiralbet": ("AdmiralBet", "https://admiralbet.rs"),
+    "pinnbet": ("PinnBet", "https://www.pinnbet.rs"),
     "volcanobet": ("VolcanoBet", "https://www.volcanobet.rs/sport-v2/prematch/events"),
 }
 
@@ -369,6 +370,17 @@ _FOOTBALL_OUTCOME_MARKETS: dict[str, list[dict]] = {
         {"game": 1, "market": "football_result", "outcome": "home", "odds": 1.94, "label": "1"},
         {"game": 1, "market": "football_total_goals", "outcome": "under", "odds": 1.80, "line": 2.5, "label": "0-2"},
         {"game": 1, "market": "football_total_goals", "outcome": "over", "odds": 2.12, "line": 2.5, "label": "3+"},
+    ],
+    "pinnbet": [
+        # Default partial-mode shape: result + 2.5 totals on game 0 only, no double chance.
+        {"game": 0, "market": "football_result", "outcome": "home", "odds": 2.45, "label": "1"},
+        {"game": 0, "market": "football_result", "outcome": "draw", "odds": 3.18, "label": "X"},
+        {"game": 0, "market": "football_result", "outcome": "away", "odds": 2.62, "label": "2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "under", "odds": 2.08, "line": 2.5, "label": "0-2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "over", "odds": 1.82, "line": 2.5, "label": "3+"},
+        {"game": 1, "market": "football_result", "outcome": "home", "odds": 1.96, "label": "1"},
+        {"game": 1, "market": "football_total_goals", "outcome": "under", "odds": 1.82, "line": 2.5, "label": "0-2"},
+        {"game": 1, "market": "football_total_goals", "outcome": "over", "odds": 2.14, "line": 2.5, "label": "3+"},
     ],
 }
 

--- a/backend/app/scrapers/pinnbet_scraper.py
+++ b/backend/app/scrapers/pinnbet_scraper.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import math
 from datetime import datetime, timezone
+from typing import Literal
 
 from .base import BaseScraper
 from .http_client import HttpClient
+from ..config import settings
 from ..services.scrape_window import (
     current_utc_time,
     format_utc_naive_seconds,
     lookahead_cutoff,
 )
-from ..models.schemas import RawOddsData
+from ..models.schemas import RawOddsData, RawOutcomeOffer
 from ..services.normalizer import normalize_team_name
 from ..services.text_normalizer import normalize_identity_text
 
@@ -19,13 +23,18 @@ logger = logging.getLogger(__name__)
 _BASE_LIST_URL = (
     "https://sportweb.pinnbet.rs/SportBookCacheWeb/api/offer/getWebEventsSelections"
 )
+_BASE_DETAIL_URL = (
+    "https://sportweb.pinnbet.rs/SportBookCacheWeb/api/offer/betsAndGroups"
+)
 
 _PLAYER_SPORT_ID = 3
 _GAME_TOTAL_SPORT_ID = 2
+_FOOTBALL_SPORT_ID = 1
 _OFFICE_ID = "6"
 _LANGUAGE = "sr-Latn"
 _PLAYER_PAGE_ID = 3
 _GAME_TOTAL_PAGE_ID = 35
+_FOOTBALL_PAGE_ID = 3
 
 _MAPPING_TYPE_PLAYER = 5
 _EVENT_MAPPING_TYPES = [1, 2, 3, 4, 5]
@@ -33,6 +42,47 @@ _BET_TYPE_GAME_TOTAL_OT = 167
 _GAME_TOTAL_OT_BET_NAME = "ukupno poena (+ot)"
 _BET_TYPE_HANDICAP_OT = 166
 _HANDICAP_OT_BET_NAME = "hendikep (+ot)"
+
+# Football betTypeId constants — anchored on numeric IDs so localized name
+# drift on the bookmaker side cannot break classification.
+_BET_FOOTBALL_RESULT = 1  # "Konacan ishod"
+_BET_FOOTBALL_TOTAL_GOALS = 2  # "Ukupno golova"
+_BET_FOOTBALL_DOUBLE_CHANCE = 3  # "Dupla sansa"
+
+# Only the 2.5 line is in scope for football_total_goals (matches the
+# canonical line used by every other football outcome scraper).
+_FOOTBALL_TARGET_TOTAL_LINE = 2.5
+
+# Outcome name → (outcome_code, raw_label).  Keys are matched after a
+# strip+upper pass so whitespace/case drift on the bookmaker side does
+# not break classification.
+_FOOTBALL_RESULT_OUTCOMES: dict[str, tuple[str, str]] = {
+    "1": ("home", "1"),
+    "X": ("draw", "X"),
+    "2": ("away", "2"),
+}
+_FOOTBALL_DOUBLE_CHANCE_OUTCOMES: dict[str, tuple[str, str]] = {
+    "1X": ("home_or_draw", "1X"),
+    "12": ("home_or_away", "12"),
+    "X2": ("draw_or_away", "X2"),
+}
+# Total-goals side classification keyed off accent/case-insensitive name.
+# Maps to (outcome_code, canonical raw_label) — the canonical raw_label
+# matches the convention used by the other football outcome scrapers
+# (BetOle/AdmiralBet/etc.) so the unified pipeline groups them.
+_FOOTBALL_TOTAL_SIDES: dict[str, tuple[str, str]] = {
+    "manje": ("under", "0-2"),
+    "vise": ("over", "3+"),
+}
+
+# Per-bookmaker concurrency caps for the per-event football detail
+# fetches (full mode only).  The HttpClient enforces a global rate
+# limit per bookmaker, so any concurrency above
+# ``ceil(rate_limit_per_second)`` cannot speed things up — it just
+# helps mask network latency between rate-limited slots.  When the
+# rate limit is disabled (0), cap at 10 to stay polite.
+_MIN_DETAIL_CONCURRENCY = 2
+_UNLIMITED_DETAIL_CONCURRENCY = 10
 
 _BET_TYPE_MARKETS: dict[int, str] = {
     1200: "player_points",
@@ -457,11 +507,297 @@ def _parse_event_detail(
     return results
 
 
-class PinnBetScraper(BaseScraper):
-    """Scraper for PinnBet basketball player props and OT-inclusive game totals."""
+def _parse_total_line(value: object) -> float | None:
+    """Parse a PinnBet sBV/line value, tolerating ``"2.50"`` / ``" 2.5 "`` / ``2.5``."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    return None
 
-    def __init__(self, http_client: HttpClient | None = None) -> None:
+
+def _resolve_total_line(bet: dict, outcome: dict) -> float | None:
+    """Resolve the totals line for an Ukupno golova bet.
+
+    Prefers the bet-level ``sBV`` (carried at the market level), but
+    falls back to the outcome-level ``sBV``. Returns ``None`` when
+    neither parses, or when the two are present and disagree (defense
+    in depth — we'd rather drop a confusing offer than mis-classify
+    it as 2.5).
+    """
+    bet_line = _parse_total_line(bet.get("sBV"))
+    outcome_line = _parse_total_line(outcome.get("sBV"))
+    if bet_line is not None and outcome_line is not None:
+        if abs(bet_line - outcome_line) > 1e-9:
+            return None
+        return bet_line
+    return bet_line if bet_line is not None else outcome_line
+
+
+def _coerce_positive_odds(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        odds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if odds <= 0:
+        return None
+    return odds
+
+
+_FOOTBALL_BET_TYPES_FROM_LIST: frozenset[int] = frozenset({
+    _BET_FOOTBALL_RESULT,
+    _BET_FOOTBALL_TOTAL_GOALS,
+})
+
+
+def _emit_football_offers_from_bets(
+    *,
+    home_team: str,
+    away_team: str,
+    league_id: str,
+    start_time: str | None,
+    bets: list[dict],
+    bet_type_filter: frozenset[int],
+) -> list[RawOutcomeOffer]:
+    """Emit football outcome offers from a list/detail bets array.
+
+    ``bet_type_filter`` constrains which bet types we consider, which
+    lets the same parser walk both list bets (result + totals only) and
+    detail bets (double chance only) without duplicating logic.
+    """
+    results: list[RawOutcomeOffer] = []
+    for bet in bets:
+        bet_type_id = bet.get("betTypeId")
+        if not isinstance(bet_type_id, int) or bet_type_id not in bet_type_filter:
+            continue
+        if not bet.get("isPlayable"):
+            continue
+
+        if bet_type_id == _BET_FOOTBALL_RESULT:
+            outcome_lookup = _FOOTBALL_RESULT_OUTCOMES
+            market_type = "football_result"
+            line: float | None = None
+        elif bet_type_id == _BET_FOOTBALL_DOUBLE_CHANCE:
+            outcome_lookup = _FOOTBALL_DOUBLE_CHANCE_OUTCOMES
+            market_type = "football_double_chance"
+            line = None
+        elif bet_type_id == _BET_FOOTBALL_TOTAL_GOALS:
+            # Cheap pre-filter: if the bet-level sBV resolves and is not
+            # the target line, skip the whole bet without scanning outcomes.
+            bet_line = _parse_total_line(bet.get("sBV"))
+            if bet_line is not None and abs(bet_line - _FOOTBALL_TARGET_TOTAL_LINE) > 1e-9:
+                continue
+            outcome_lookup = None
+            market_type = "football_total_goals"
+            line = _FOOTBALL_TARGET_TOTAL_LINE
+        else:
+            continue
+
+        for outcome in bet.get("betOutcomes", []):
+            if not outcome.get("isPlayable"):
+                continue
+            odds = _coerce_positive_odds(outcome.get("odd"))
+            if odds is None:
+                continue
+
+            raw_name = (outcome.get("name") or "").strip()
+            if bet_type_id == _BET_FOOTBALL_TOTAL_GOALS:
+                resolved_line = _resolve_total_line(bet, outcome)
+                if resolved_line is None:
+                    continue
+                if abs(resolved_line - _FOOTBALL_TARGET_TOTAL_LINE) > 1e-9:
+                    continue
+                normalized_side = normalize_identity_text(raw_name)
+                mapping = _FOOTBALL_TOTAL_SIDES.get(normalized_side)
+                if mapping is None:
+                    continue
+                outcome_code, raw_label = mapping
+            else:
+                assert outcome_lookup is not None  # narrow for type checkers
+                key = raw_name.upper()
+                mapping = outcome_lookup.get(key)
+                if mapping is None:
+                    continue
+                outcome_code, raw_label = mapping
+
+            results.append(
+                RawOutcomeOffer(
+                    bookmaker_id="pinnbet",
+                    league_id=league_id,
+                    sport="football",
+                    home_team=home_team,
+                    away_team=away_team,
+                    market_type=market_type,
+                    outcome_code=outcome_code,
+                    odds=odds,
+                    line=line,
+                    raw_label=raw_label,
+                    start_time=start_time,
+                )
+            )
+
+    return results
+
+
+def _football_event_identity(event: dict) -> tuple[str, str, str | None]:
+    """Resolve (home, away, start_time) for a PinnBet football list event.
+
+    Returns ``("", "", None)`` when the event name is unparseable.
+    """
+    home_team, away_team = _parse_event_name(event.get("name", ""))
+    if not home_team or not away_team:
+        return "", "", None
+    start_time = _normalize_start_time(event.get("dateTime"))
+    return home_team, away_team, start_time
+
+
+def _parse_football_outcome_event(event: dict) -> list[RawOutcomeOffer]:
+    """Parse a PinnBet football list event into result + 2.5 totals offers.
+
+    Double chance is intentionally NOT emitted here — the list endpoint
+    does not expose betTypeId=3 for football.  The detail endpoint is
+    the only source for double chance and is only fetched in ``full``
+    mode.
+    """
+    home_team, away_team, start_time = _football_event_identity(event)
+    if not home_team or not away_team:
+        return []
+    league_id = _extract_league_id(event, fallback_league_id="football")
+    return _emit_football_offers_from_bets(
+        home_team=home_team,
+        away_team=away_team,
+        league_id=league_id,
+        start_time=start_time,
+        bets=event.get("bets", []),
+        bet_type_filter=_FOOTBALL_BET_TYPES_FROM_LIST,
+    )
+
+
+def _parse_football_double_chance_detail(
+    list_event: dict, detail_payload: dict
+) -> list[RawOutcomeOffer]:
+    """Emit football_double_chance offers from a per-event detail payload.
+
+    Identity (home/away/start_time/league_id) is taken UNCONDITIONALLY
+    from the list event so list-derived and detail-derived offers
+    share the same normalized event key.  The detail payload only
+    contributes its ``bets`` array.
+    """
+    home_team, away_team, start_time = _football_event_identity(list_event)
+    if not home_team or not away_team:
+        return []
+    league_id = _extract_league_id(list_event, fallback_league_id="football")
+    bets = detail_payload.get("bets") or []
+    if not isinstance(bets, list):
+        return []
+    return _emit_football_offers_from_bets(
+        home_team=home_team,
+        away_team=away_team,
+        league_id=league_id,
+        start_time=start_time,
+        bets=bets,
+        bet_type_filter=frozenset({_BET_FOOTBALL_DOUBLE_CHANCE}),
+    )
+
+
+def _football_detail_identity(event: dict) -> tuple[int, int, int, int] | None:
+    """Resolve the (sportId, regionId, competitionId, eventId) tuple needed
+    to build the detail URL.  Returns ``None`` when any field is missing.
+    """
+    try:
+        return (
+            int(event["sportId"]),
+            int(event["regionId"]),
+            int(event["competitionId"]),
+            int(event["id"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _football_event_completeness_score(event: dict) -> int:
+    """Score a list event by how usable it is for downstream parsing.
+
+    Higher is better.  We prefer rows that:
+      * have a parseable detail-id tuple (detail-eligible)
+      * have a ``bets`` array (so list-derived offers are emitted)
+      * carry a competition name (so league_id is non-degenerate)
+
+    This drives "best row wins" dedupe when the list happens to repeat
+    the same eventId across mapping types.
+    """
+    score = 0
+    if _football_detail_identity(event) is not None:
+        score += 4
+    bets = event.get("bets")
+    if isinstance(bets, list) and bets:
+        score += 2
+    if event.get("competitionName"):
+        score += 1
+    return score
+
+
+def _dedupe_football_events(events: list[dict]) -> dict[int, dict]:
+    """Collapse duplicate list rows by event id, keeping the most usable.
+
+    ``eventMappingTypes=1..5`` can return the same eventId multiple
+    times; without dedupe we'd silently emit duplicate list-derived
+    offers and (in full mode) issue redundant detail fetches.
+    """
+    by_id: dict[int, dict] = {}
+    for event in events:
+        try:
+            event_id = int(event["id"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        existing = by_id.get(event_id)
+        if existing is None or (
+            _football_event_completeness_score(event)
+            > _football_event_completeness_score(existing)
+        ):
+            by_id[event_id] = event
+    return by_id
+
+
+def _get_detail_fetch_concurrency(http_client: HttpClient, match_count: int) -> int:
+    if match_count <= 0:
+        return 0
+    if http_client.rate_limit_per_second <= 0:
+        return min(match_count, _UNLIMITED_DETAIL_CONCURRENCY)
+    return min(
+        match_count,
+        max(_MIN_DETAIL_CONCURRENCY, math.ceil(http_client.rate_limit_per_second)),
+    )
+
+
+class PinnBetScraper(BaseScraper):
+    """Scraper for PinnBet basketball player props and OT-inclusive game totals.
+
+    Also emits football outcome offers (result, totals @ 2.5, and — in
+    ``full`` detail mode only — double chance via per-event detail
+    fetch).  Default ``partial`` mode skips the per-event fetch and
+    therefore cannot emit double chance, which the user explicitly
+    accepted as a trade-off for cycle speed.
+    """
+
+    def __init__(
+        self,
+        http_client: HttpClient | None = None,
+        *,
+        detail_mode: Literal["partial", "full"] | None = None,
+    ) -> None:
         self._http = http_client or HttpClient(default_headers=_DEFAULT_HEADERS)
+        self._detail_mode = detail_mode or settings.pinnbet_detail_mode
 
     def get_bookmaker_id(self) -> str:
         return "pinnbet"
@@ -471,6 +807,9 @@ class PinnBetScraper(BaseScraper):
 
     def get_supported_leagues(self) -> list[str]:
         return ["basketball"]
+
+    def get_supported_outcome_sports(self) -> list[str]:
+        return ["football"]
 
     async def _fetch_game_total_events(self) -> list[dict]:
         url = _build_list_url(
@@ -552,3 +891,138 @@ class PinnBetScraper(BaseScraper):
             len(basketball_events),
         )
         return all_results
+
+    async def _fetch_football_events(self) -> list[dict]:
+        url = _build_list_url(
+            _FOOTBALL_SPORT_ID,
+            page_id=_FOOTBALL_PAGE_ID,
+        )
+
+        try:
+            data = await self._http.get_json(url, headers=_DEFAULT_HEADERS)
+        except Exception:
+            logger.warning("PinnBet: failed to fetch football prematch events")
+            return []
+
+        if not isinstance(data, list):  # type: ignore[arg-type]
+            logger.warning(
+                "PinnBet: unexpected response type %s for football prematch events",
+                type(data).__name__,
+            )
+            return []
+
+        return [event for event in data if isinstance(event, dict)]
+
+    async def _fetch_football_detail(
+        self,
+        identity: tuple[int, int, int, int],
+        semaphore: asyncio.Semaphore,
+    ) -> dict | None:
+        sport_id, region_id, competition_id, event_id = identity
+        url = (
+            f"{_BASE_DETAIL_URL}/{sport_id}/{region_id}/{competition_id}/{event_id}"
+        )
+        async with semaphore:
+            try:
+                detail = await self._http.get_json(url, headers=_DEFAULT_HEADERS)
+            except Exception:
+                logger.warning(
+                    "PinnBet: failed to fetch football match detail %s/%s/%s/%s",
+                    sport_id,
+                    region_id,
+                    competition_id,
+                    event_id,
+                    exc_info=True,
+                )
+                return None
+        if not isinstance(detail, dict):
+            return None
+        return detail
+
+    async def scrape_outcome_offers(self, sport: str) -> list[RawOutcomeOffer]:
+        """Scrape PinnBet football outcome offers.
+
+        ``partial`` mode (default): fetch the football list endpoint
+        once and emit football_result + football_total_goals @ 2.5.
+        Double chance is NOT emitted because PinnBet's list endpoint
+        does not expose betTypeId=3.
+
+        ``full`` mode: also fan out per-event detail fetches (rate-
+        limited via semaphore) and emit football_double_chance from
+        the detail bets, using identity fields from the LIST event so
+        list-derived and detail-derived offers share the same
+        normalized event.
+        """
+        if sport != "football":
+            return []
+
+        list_events = await self._fetch_football_events()
+        events_by_id = _dedupe_football_events(list_events)
+        if not events_by_id:
+            logger.info("PinnBet: no football matches discovered")
+            return []
+
+        results: list[RawOutcomeOffer] = []
+        for event in events_by_id.values():
+            results.extend(_parse_football_outcome_event(event))
+
+        detail_attempts = 0
+        detail_misses = 0
+        concurrency = 0
+        if self._detail_mode == "full":
+            detail_targets: list[tuple[int, tuple[int, int, int, int]]] = []
+            skipped_for_missing_ids = 0
+            for event_id, event in events_by_id.items():
+                identity = _football_detail_identity(event)
+                if identity is None:
+                    skipped_for_missing_ids += 1
+                    continue
+                detail_targets.append((event_id, identity))
+
+            if skipped_for_missing_ids:
+                logger.warning(
+                    "PinnBet: skipping detail fetch for %d football events with missing IDs",
+                    skipped_for_missing_ids,
+                )
+
+            if detail_targets:
+                concurrency = _get_detail_fetch_concurrency(
+                    self._http, len(detail_targets)
+                )
+                semaphore = asyncio.Semaphore(max(1, concurrency))
+                details = await asyncio.gather(
+                    *(
+                        self._fetch_football_detail(identity, semaphore)
+                        for _, identity in detail_targets
+                    )
+                )
+                detail_attempts = len(detail_targets)
+                for (event_id, _), detail in zip(detail_targets, details):
+                    if detail is None:
+                        detail_misses += 1
+                        continue
+                    list_event = events_by_id[event_id]
+                    results.extend(
+                        _parse_football_double_chance_detail(list_event, detail)
+                    )
+                if detail_misses:
+                    logger.warning(
+                        "PinnBet: %d/%d football detail fetches returned no data; "
+                        "double chance will be missing for those matches",
+                        detail_misses,
+                        detail_attempts,
+                    )
+
+        logger.info(
+            (
+                "PinnBet scraped %d football outcome offers from %d events "
+                "(detail mode=%s, attempts=%d, misses=%d, concurrency=%d)"
+            ),
+            len(results),
+            len(events_by_id),
+            self._detail_mode,
+            detail_attempts,
+            detail_misses,
+            concurrency,
+        )
+        return results

--- a/backend/app/services/runtime_settings.py
+++ b/backend/app/services/runtime_settings.py
@@ -77,6 +77,7 @@ def default_scrape_runtime_settings(
         meridian_rate_limit_per_second=settings.meridian_rate_limit_per_second,
         soccerbet_detail_mode=settings.soccerbet_detail_mode,
         merkurxtip_detail_mode=settings.merkurxtip_detail_mode,
+        pinnbet_detail_mode=settings.pinnbet_detail_mode,
         notification_gap_threshold=settings.notification_gap_threshold,
         persist_inapp_notifications=settings.persist_inapp_notifications,
     )

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1155,6 +1155,8 @@ class Scheduler:
             scraper.set_runtime_detail_mode(runtime_settings.soccerbet_detail_mode)
         if bookmaker_id == "merkurxtip":
             scraper.set_runtime_detail_mode(runtime_settings.merkurxtip_detail_mode)
+        if bookmaker_id == "pinnbet":
+            scraper.set_runtime_detail_mode(runtime_settings.pinnbet_detail_mode)
 
     def _configure_notification_service_for_runtime_settings(
         self,

--- a/backend/tests/fixtures/pinnbet_football.json
+++ b/backend/tests/fixtures/pinnbet_football.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": 2215282,
+    "name": "Bayern Munich - Paris SG",
+    "competitionId": 12345,
+    "competitionName": "UEFA Champions League",
+    "regionId": 287,
+    "sportId": 1,
+    "dateTime": "2026-04-15T19:00:00",
+    "isPlayable": true,
+    "bets": [
+      {
+        "betTypeId": 1,
+        "betTypeName": "Konačan ishod",
+        "sBV": null,
+        "isPlayable": true,
+        "betOutcomes": [
+          {
+            "name": "1",
+            "odd": 1.63,
+            "isPlayable": true,
+            "sBV": null
+          },
+          {
+            "name": "X",
+            "odd": 5.2,
+            "isPlayable": true,
+            "sBV": null
+          },
+          {
+            "name": "2",
+            "odd": 4.45,
+            "isPlayable": true,
+            "sBV": null
+          }
+        ]
+      },
+      {
+        "betTypeId": 2,
+        "betTypeName": "Ukupno golova",
+        "sBV": "1.5",
+        "isPlayable": true,
+        "betOutcomes": [
+          {
+            "name": "manje",
+            "odd": 4.5,
+            "isPlayable": true,
+            "sBV": "1.5"
+          },
+          {
+            "name": "više",
+            "odd": 1.18,
+            "isPlayable": true,
+            "sBV": "1.5"
+          }
+        ]
+      },
+      {
+        "betTypeId": 2,
+        "betTypeName": "Ukupno golova",
+        "sBV": "2.5",
+        "isPlayable": true,
+        "betOutcomes": [
+          {
+            "name": "manje",
+            "odd": 2.3,
+            "isPlayable": true,
+            "sBV": "2.5"
+          },
+          {
+            "name": "više",
+            "odd": 1.55,
+            "isPlayable": true,
+            "sBV": "2.5"
+          }
+        ]
+      },
+      {
+        "betTypeId": 2,
+        "betTypeName": "Ukupno golova",
+        "sBV": "3.5",
+        "isPlayable": true,
+        "betOutcomes": [
+          {
+            "name": "manje",
+            "odd": 1.55,
+            "isPlayable": true,
+            "sBV": "3.5"
+          },
+          {
+            "name": "više",
+            "odd": 2.3,
+            "isPlayable": true,
+            "sBV": "3.5"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/backend/tests/fixtures/pinnbet_football_detail.json
+++ b/backend/tests/fixtures/pinnbet_football_detail.json
@@ -1,0 +1,31 @@
+{
+  "bets": [
+    {
+      "betTypeId": 3,
+      "betTypeName": "Dupla sansa",
+      "sBV": null,
+      "isPlayable": true,
+      "betOutcomes": [
+        {
+          "name": "1X",
+          "odd": 1.22,
+          "isPlayable": true,
+          "sBV": null
+        },
+        {
+          "name": "12",
+          "odd": 1.17,
+          "isPlayable": true,
+          "sBV": null
+        },
+        {
+          "name": "X2",
+          "odd": 2.32,
+          "isPlayable": true,
+          "sBV": null
+        }
+      ]
+    }
+  ],
+  "groups": []
+}

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -190,6 +190,7 @@ async def test_patch_scrape_settings_applies_immediately_when_idle(client: Async
             "meridian_rate_limit_per_second": 4.0,
             "soccerbet_detail_mode": "full",
             "merkurxtip_detail_mode": "full",
+            "pinnbet_detail_mode": "full",
             "notification_gap_threshold": 2.5,
             "persist_inapp_notifications": True,
         },
@@ -205,6 +206,7 @@ async def test_patch_scrape_settings_applies_immediately_when_idle(client: Async
     assert data["applied"]["analysis_markets"] == ["*:player_*"]
     assert data["applied"]["scrape_interval_minutes"] == 7
     assert data["applied"]["soccerbet_detail_mode"] == "full"
+    assert data["applied"]["pinnbet_detail_mode"] == "full"
 
     get_resp = await client.get("/api/v1/settings/scrape")
     assert get_resp.json()["applied"]["enabled_bookmakers"] == ["mozzart"]

--- a/backend/tests/test_pinnbet_scraper.py
+++ b/backend/tests/test_pinnbet_scraper.py
@@ -18,12 +18,26 @@ from app.scrapers.pinnbet_scraper import (
     _get_player_event_ids,
     _normalize_start_time,
     _resolve_matchup_from_short_name,
+    _parse_football_outcome_event,
+    _parse_football_double_chance_detail,
+    _parse_total_line,
+    _resolve_total_line,
+    _dedupe_football_events,
+    _football_detail_identity,
+    _football_event_completeness_score,
+    _BASE_DETAIL_URL,
+    _FOOTBALL_PAGE_ID,
+    _FOOTBALL_SPORT_ID,
 )
-from app.models.schemas import RawOddsData
+from app.models.schemas import RawOddsData, RawOutcomeOffer
 
 EVENTS_FIXTURE = Path(__file__).parent / "fixtures" / "pinnbet_events.json"
 BETS_FIXTURE = Path(__file__).parent / "fixtures" / "pinnbet_bets.json"
 TOTALS_FIXTURE = Path(__file__).parent / "fixtures" / "pinnbet_game_totals.json"
+FOOTBALL_FIXTURE = Path(__file__).parent / "fixtures" / "pinnbet_football.json"
+FOOTBALL_DETAIL_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "pinnbet_football_detail.json"
+)
 
 
 def _player_threshold_bet(
@@ -890,3 +904,581 @@ async def test_scraper_skips_stub_player_bets_without_detail_fallback(
     assert len(game_totals) == 11
     assert len(handicaps) == 1
     assert len(captured_urls) == 2
+
+
+# ── Football outcome lane ─────────────────────────────────
+
+
+@pytest.fixture
+def football_data() -> list[dict]:
+    with open(FOOTBALL_FIXTURE) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def football_detail_data() -> dict:
+    with open(FOOTBALL_DETAIL_FIXTURE) as f:
+        return json.load(f)
+
+
+def test_parse_football_outcome_event_emits_result_and_2_5_totals_only(football_data):
+    event = football_data[0]
+    offers = _parse_football_outcome_event(event)
+
+    by_market: dict[str, list[RawOutcomeOffer]] = {}
+    for o in offers:
+        by_market.setdefault(o.market_type, []).append(o)
+
+    # Partial mode never sees double chance — list parser must not emit it.
+    assert "football_double_chance" not in by_market
+    assert sorted(by_market) == ["football_result", "football_total_goals"]
+    assert {o.outcome_code for o in by_market["football_result"]} == {
+        "home",
+        "draw",
+        "away",
+    }
+    totals = by_market["football_total_goals"]
+    assert {t.outcome_code for t in totals} == {"over", "under"}
+    assert all(t.line == 2.5 for t in totals)
+    assert {t.raw_label for t in totals} == {"0-2", "3+"}
+
+    sample = by_market["football_result"][0]
+    assert sample.bookmaker_id == "pinnbet"
+    assert sample.sport == "football"
+    assert sample.home_team == "Bayern Munich"
+    assert sample.away_team == "Paris SG"
+    # PinnBet naive datetimes treated as UTC and emitted with explicit offset
+    assert sample.start_time == "2026-04-15T19:00:00+00:00"
+
+
+def test_parse_football_outcome_event_skips_non_2_5_lines(football_data):
+    event = football_data[0]
+    offers = _parse_football_outcome_event(event)
+    totals = [o for o in offers if o.market_type == "football_total_goals"]
+    assert len(totals) == 2
+    assert all(t.line == 2.5 for t in totals)
+
+
+def test_parse_football_outcome_event_skips_non_playable_bets(football_data):
+    event = football_data[0]
+    for bet in event["bets"]:
+        bet["isPlayable"] = False
+    assert _parse_football_outcome_event(event) == []
+
+
+def test_parse_football_outcome_event_skips_non_playable_outcomes(football_data):
+    event = football_data[0]
+    for bet in event["bets"]:
+        if bet.get("betTypeId") == 1:
+            for outcome in bet["betOutcomes"]:
+                outcome["isPlayable"] = False
+            break
+    offers = _parse_football_outcome_event(event)
+    assert [o for o in offers if o.market_type == "football_result"] == []
+    # Totals at 2.5 still come through.
+    assert any(o.market_type == "football_total_goals" for o in offers)
+
+
+def test_parse_football_outcome_event_skips_zero_or_negative_odds(football_data):
+    event = football_data[0]
+    for bet in event["bets"]:
+        if bet.get("betTypeId") == 1:
+            for outcome in bet["betOutcomes"]:
+                outcome["odd"] = 0
+            break
+    offers = _parse_football_outcome_event(event)
+    assert [o for o in offers if o.market_type == "football_result"] == []
+
+
+def test_parse_football_outcome_event_normalizes_outcome_names(football_data):
+    event = football_data[0]
+    # Stress: stray whitespace + lowercase on result outcomes; stripped+upper
+    # in the parser must still classify them.
+    for bet in event["bets"]:
+        if bet.get("betTypeId") == 1:
+            bet["betOutcomes"][0]["name"] = " 1 "
+            bet["betOutcomes"][1]["name"] = "x"
+            break
+    offers = _parse_football_outcome_event(event)
+    result_codes = {
+        o.outcome_code for o in offers if o.market_type == "football_result"
+    }
+    assert result_codes == {"home", "draw", "away"}
+
+
+def test_parse_football_outcome_event_classifies_totals_diacritic_insensitive(
+    football_data,
+):
+    event = football_data[0]
+    # Stress: "Više"/"Manje" with stray whitespace must still classify, AND
+    # the unaccented "vise" form (some bookmaker payloads strip diacritics)
+    # must also normalize via normalize_identity_text.
+    for bet in event["bets"]:
+        if bet.get("betTypeId") == 2 and bet.get("sBV") == "2.5":
+            for outcome in bet["betOutcomes"]:
+                if outcome["name"] == "više":
+                    outcome["name"] = "  vise  "
+                elif outcome["name"] == "manje":
+                    outcome["name"] = "Manje"
+            break
+    offers = _parse_football_outcome_event(event)
+    totals = [o for o in offers if o.market_type == "football_total_goals"]
+    assert {t.outcome_code for t in totals} == {"over", "under"}
+    assert {t.raw_label for t in totals} == {"3+", "0-2"}
+
+
+def test_parse_football_outcome_event_drops_offer_when_event_name_unparseable(
+    football_data,
+):
+    event = football_data[0]
+    event["name"] = "NoSeparator"
+    assert _parse_football_outcome_event(event) == []
+
+
+def test_parse_football_outcome_event_skips_unknown_outcome_codes(football_data):
+    event = football_data[0]
+    for bet in event["bets"]:
+        if bet.get("betTypeId") == 1:
+            for outcome in bet["betOutcomes"]:
+                outcome["name"] = "WAT"
+            break
+    offers = _parse_football_outcome_event(event)
+    assert [o for o in offers if o.market_type == "football_result"] == []
+
+
+def test_parse_football_outcome_event_falls_back_to_default_league(football_data):
+    event = football_data[0]
+    event["competitionName"] = None
+    event["competitionId"] = None
+    offers = _parse_football_outcome_event(event)
+    assert offers
+    assert all(o.league_id == "football" for o in offers)
+
+
+def test_parse_football_outcome_event_falls_back_for_degenerate_competition(
+    football_data,
+):
+    event = football_data[0]
+    event["competitionName"] = "---"
+    event["competitionId"] = None
+    offers = _parse_football_outcome_event(event)
+    assert offers
+    assert all(o.league_id == "football" for o in offers)
+
+
+def test_parse_total_line_tolerates_string_variants():
+    assert _parse_total_line("2.5") == 2.5
+    assert _parse_total_line("2.50") == 2.5
+    assert _parse_total_line(" 2.5 ") == 2.5
+    assert _parse_total_line(2.5) == 2.5
+    assert _parse_total_line(0.5) == 0.5
+    assert _parse_total_line(None) is None
+    assert _parse_total_line("") is None
+    assert _parse_total_line("not-a-number") is None
+
+
+def test_resolve_total_line_prefers_bet_level_and_falls_back_to_outcome():
+    assert _resolve_total_line({"sBV": "2.5"}, {"sBV": None}) == 2.5
+    assert _resolve_total_line({"sBV": None}, {"sBV": "2.5"}) == 2.5
+    assert _resolve_total_line({"sBV": "2.5"}, {"sBV": "2.5"}) == 2.5
+    # Disagreement → drop, defense in depth.
+    assert _resolve_total_line({"sBV": "2.5"}, {"sBV": "3.5"}) is None
+    assert _resolve_total_line({"sBV": None}, {"sBV": None}) is None
+
+
+def test_parse_football_outcome_event_uses_outcome_level_sbv_when_bet_level_missing(
+    football_data,
+):
+    event = football_data[0]
+    for bet in event["bets"]:
+        if bet.get("betTypeId") == 2 and bet.get("sBV") == "2.5":
+            bet["sBV"] = None  # drop bet-level line, outcome-level "2.5" remains
+            break
+    offers = _parse_football_outcome_event(event)
+    totals = [o for o in offers if o.market_type == "football_total_goals"]
+    assert {t.outcome_code for t in totals} == {"over", "under"}
+    assert all(t.line == 2.5 for t in totals)
+
+
+def test_parse_football_double_chance_detail_emits_three_offers(
+    football_data, football_detail_data
+):
+    list_event = football_data[0]
+    offers = _parse_football_double_chance_detail(list_event, football_detail_data)
+    assert len(offers) == 3
+    assert {o.outcome_code for o in offers} == {
+        "home_or_draw",
+        "home_or_away",
+        "draw_or_away",
+    }
+    assert {o.raw_label for o in offers} == {"1X", "12", "X2"}
+    assert all(o.market_type == "football_double_chance" for o in offers)
+    # Identity must come from the LIST event, never the detail payload.
+    assert all(o.home_team == "Bayern Munich" for o in offers)
+    assert all(o.away_team == "Paris SG" for o in offers)
+    assert all(o.start_time == "2026-04-15T19:00:00+00:00" for o in offers)
+    assert all(o.league_id == "uefa champions league" for o in offers)
+    assert all(o.line is None for o in offers)
+
+
+def test_parse_football_double_chance_detail_ignores_hostile_detail_metadata(
+    football_data, football_detail_data
+):
+    """B1 invariant — even when the detail payload supplies its own
+    home/away/start/league/source metadata that disagrees with the list,
+    the emitted offers MUST anchor on the list-event identity so list-
+    derived and detail-derived offers normalize to the same canonical event.
+    """
+    list_event = football_data[0]
+    hostile_detail = {
+        **football_detail_data,
+        # Fields that a future regression might be tempted to read instead
+        # of the list event.  All of these must be ignored.
+        "name": "Wrong Home - Wrong Away",
+        "homeTeam": "Wrong Home",
+        "awayTeam": "Wrong Away",
+        "competitionName": "Wrong League",
+        "competitionId": 99999,
+        "dateTime": "2099-12-31T23:59:59",
+        "sourceUrl": "https://attacker.invalid/",
+    }
+    offers = _parse_football_double_chance_detail(list_event, hostile_detail)
+    assert len(offers) == 3
+    assert all(o.home_team == "Bayern Munich" for o in offers)
+    assert all(o.away_team == "Paris SG" for o in offers)
+    assert all(o.start_time == "2026-04-15T19:00:00+00:00" for o in offers)
+    assert all(o.league_id == "uefa champions league" for o in offers)
+
+
+def test_parse_football_double_chance_detail_falls_back_when_list_league_is_none(
+    football_data, football_detail_data
+):
+    """B1 invariant edge case — when a list field that contributes to
+    identity is absent (here ``competitionName``), the parser must fall
+    back to the football scope's default league_id, NOT pull it from the
+    detail payload.  Pins the "even when the list field is None" branch.
+    """
+    list_event = {**football_data[0], "competitionName": None, "competitionId": None}
+    hostile_detail = {
+        **football_detail_data,
+        "competitionName": "Detail-Provided League",
+        "competitionId": 42,
+    }
+    offers = _parse_football_double_chance_detail(list_event, hostile_detail)
+    assert offers
+    assert all(o.league_id == "football" for o in offers)
+    assert all(o.home_team == "Bayern Munich" for o in offers)
+    assert all(o.away_team == "Paris SG" for o in offers)
+
+
+def test_parse_football_double_chance_detail_drops_when_event_name_unparseable(
+    football_data, football_detail_data
+):
+    list_event = {**football_data[0], "name": "NoSeparator"}
+    assert _parse_football_double_chance_detail(list_event, football_detail_data) == []
+
+
+def test_parse_football_double_chance_detail_handles_missing_bets_array(football_data):
+    list_event = football_data[0]
+    assert _parse_football_double_chance_detail(list_event, {}) == []
+    assert _parse_football_double_chance_detail(list_event, {"bets": None}) == []
+    assert _parse_football_double_chance_detail(list_event, {"bets": "garbage"}) == []
+
+
+def test_dedupe_football_events_picks_best_row_for_duplicate_event_id():
+    less_complete = {
+        "id": 999,
+        "name": "Foo - Bar",
+        "dateTime": "2026-04-15T19:00:00",
+        "competitionId": None,
+        "regionId": None,
+        "sportId": 1,
+    }
+    more_complete = {
+        "id": 999,
+        "name": "Foo - Bar",
+        "dateTime": "2026-04-15T19:00:00",
+        "competitionId": 12,
+        "competitionName": "Friendly",
+        "regionId": 7,
+        "sportId": 1,
+        "bets": [{"betTypeId": 1, "isPlayable": True, "betOutcomes": []}],
+    }
+    by_id = _dedupe_football_events([less_complete, more_complete])
+    assert list(by_id.keys()) == [999]
+    assert by_id[999] is more_complete
+
+    # Order shouldn't matter — best row still wins.
+    by_id = _dedupe_football_events([more_complete, less_complete])
+    assert by_id[999] is more_complete
+
+
+def test_dedupe_football_events_skips_events_without_id():
+    by_id = _dedupe_football_events(
+        [
+            {"name": "no-id", "dateTime": "2026-04-15T19:00:00"},
+            {"id": "not-int", "name": "x"},
+            {"id": 1, "name": "Foo - Bar", "dateTime": "2026-04-15T19:00:00"},
+        ]
+    )
+    assert list(by_id.keys()) == [1]
+
+
+def test_football_detail_identity_returns_none_for_missing_fields():
+    assert (
+        _football_detail_identity(
+            {"sportId": 1, "regionId": 2, "competitionId": 3, "id": 4}
+        )
+        == (1, 2, 3, 4)
+    )
+    assert _football_detail_identity({"sportId": 1, "regionId": 2, "competitionId": 3}) is None
+    assert _football_detail_identity(
+        {"sportId": 1, "regionId": 2, "competitionId": None, "id": 4}
+    ) is None
+    assert _football_detail_identity(
+        {"sportId": "x", "regionId": 2, "competitionId": 3, "id": 4}
+    ) is None
+
+
+def test_football_event_completeness_score_orders_rows():
+    rich = {
+        "id": 1,
+        "sportId": 1,
+        "regionId": 2,
+        "competitionId": 3,
+        "competitionName": "League",
+        "bets": [{}],
+    }
+    no_bets = {**rich, "bets": []}
+    no_competition = {**rich, "competitionName": None}
+    no_ids = {"id": 1, "sportId": 1, "regionId": None, "competitionId": None}
+    assert _football_event_completeness_score(rich) > _football_event_completeness_score(no_bets)
+    assert _football_event_completeness_score(rich) > _football_event_completeness_score(no_competition)
+    assert _football_event_completeness_score(rich) > _football_event_completeness_score(no_ids)
+
+
+def test_get_supported_outcome_sports_isolates_football_from_basketball_capability():
+    scraper = PinnBetScraper()
+    # threshold-odds lane: basketball only — football MUST NOT leak here,
+    # otherwise the unified pipeline would call scrape_odds("football") every cycle.
+    assert scraper.get_supported_leagues() == ["basketball"]
+    # outcome-offer lane: football
+    assert scraper.get_supported_outcome_sports() == ["football"]
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_returns_empty_for_non_football_without_http():
+    scraper = PinnBetScraper(detail_mode="full")
+    with patch.object(scraper._http, "get_json", new_callable=AsyncMock) as mock_get:
+        results = await scraper.scrape_outcome_offers("basketball")
+    assert results == []
+    mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_partial_mode_uses_only_list_endpoint(
+    football_data, football_detail_data
+):
+    scraper = PinnBetScraper(detail_mode="partial")
+    captured: list[str] = []
+
+    async def mock_get(url, **kwargs):
+        captured.append(url)
+        if "getWebEventsSelections" in url:
+            return football_data
+        raise AssertionError(
+            f"Unexpected detail call in partial mode: {url}"
+        )
+
+    with patch.object(scraper._http, "get_json", side_effect=mock_get):
+        results = await scraper.scrape_outcome_offers("football")
+
+    assert len(captured) == 1
+    parsed = urlparse(captured[0])
+    assert parsed.path.endswith("/api/offer/getWebEventsSelections")
+    qs = parse_qs(parsed.query)
+    assert qs["pageId"] == [str(_FOOTBALL_PAGE_ID)]
+    assert qs["sportId"] == [str(_FOOTBALL_SPORT_ID)]
+    assert qs["isLive"] == ["false"]
+    assert qs["eventMappingTypes"] == ["1", "2", "3", "4", "5"]
+
+    # Partial mode emits result + 2.5 totals only — no double chance.
+    market_types = {o.market_type for o in results}
+    assert market_types == {"football_result", "football_total_goals"}
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_full_mode_fetches_detail_and_emits_double_chance(
+    football_data, football_detail_data
+):
+    scraper = PinnBetScraper(detail_mode="full")
+    captured_detail_urls: list[str] = []
+
+    async def mock_get(url, **kwargs):
+        if "getWebEventsSelections" in url:
+            return football_data
+        if "/betsAndGroups/" in url:
+            captured_detail_urls.append(url)
+            return football_detail_data
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    with patch.object(scraper._http, "get_json", side_effect=mock_get):
+        results = await scraper.scrape_outcome_offers("football")
+
+    # Full mode issues exactly one detail fetch per deduped event with full IDs.
+    assert len(captured_detail_urls) == 1
+    expected = (
+        f"{_BASE_DETAIL_URL}/{_FOOTBALL_SPORT_ID}/287/12345/2215282"
+    )
+    assert captured_detail_urls[0] == expected
+
+    market_types = {o.market_type for o in results}
+    assert market_types == {
+        "football_result",
+        "football_total_goals",
+        "football_double_chance",
+    }
+    dc = [o for o in results if o.market_type == "football_double_chance"]
+    assert {o.outcome_code for o in dc} == {
+        "home_or_draw",
+        "home_or_away",
+        "draw_or_away",
+    }
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_full_mode_skips_detail_when_ids_missing(
+    football_data,
+):
+    scraper = PinnBetScraper(detail_mode="full")
+    # Drop competition/region IDs so detail URL cannot be built.
+    event = {**football_data[0], "regionId": None, "competitionId": None}
+
+    async def mock_get(url, **kwargs):
+        if "getWebEventsSelections" in url:
+            return [event]
+        raise AssertionError(f"Unexpected detail call: {url}")
+
+    with patch.object(scraper._http, "get_json", side_effect=mock_get):
+        results = await scraper.scrape_outcome_offers("football")
+
+    # List-derived offers still emitted; double chance absent.
+    market_types = {o.market_type for o in results}
+    assert "football_double_chance" not in market_types
+    assert "football_result" in market_types
+    assert "football_total_goals" in market_types
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_full_mode_tolerates_detail_failure(
+    football_data,
+):
+    scraper = PinnBetScraper(detail_mode="full")
+
+    async def mock_get(url, **kwargs):
+        if "getWebEventsSelections" in url:
+            return football_data
+        if "/betsAndGroups/" in url:
+            raise Exception("boom")
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    with patch.object(scraper._http, "get_json", side_effect=mock_get):
+        results = await scraper.scrape_outcome_offers("football")
+
+    # Detail failure must not poison list-derived offers.
+    market_types = {o.market_type for o in results}
+    assert "football_double_chance" not in market_types
+    assert "football_result" in market_types
+    assert "football_total_goals" in market_types
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_dedupes_events_before_emitting(
+    football_data,
+):
+    scraper = PinnBetScraper(detail_mode="partial")
+    # Same eventId duplicated — must not double-emit list-derived offers.
+    duplicated = [football_data[0], {**football_data[0]}]
+
+    async def mock_get(url, **kwargs):
+        if "getWebEventsSelections" in url:
+            return duplicated
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    with patch.object(scraper._http, "get_json", side_effect=mock_get):
+        results = await scraper.scrape_outcome_offers("football")
+
+    # Single emission per (market, outcome_code).
+    seen = set()
+    for o in results:
+        key = (o.market_type, o.outcome_code)
+        assert key not in seen, f"Duplicate offer emitted: {key}"
+        seen.add(key)
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_handles_list_failure():
+    scraper = PinnBetScraper(detail_mode="full")
+    with patch.object(scraper._http, "get_json", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = Exception("boom")
+        results = await scraper.scrape_outcome_offers("football")
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_handles_non_list_response():
+    scraper = PinnBetScraper(detail_mode="full")
+    with patch.object(scraper._http, "get_json", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = {"error": "bad request"}
+        results = await scraper.scrape_outcome_offers("football")
+    assert results == []
+
+
+def test_set_runtime_detail_mode_overrides_init_default():
+    scraper = PinnBetScraper(detail_mode="partial")
+    assert scraper._detail_mode == "partial"
+    scraper.set_runtime_detail_mode("full")
+    assert scraper._detail_mode == "full"
+    scraper.set_runtime_detail_mode("partial")
+    assert scraper._detail_mode == "partial"
+
+
+def test_scheduler_applies_pinnbet_detail_mode_from_runtime_settings():
+    """Pin the scheduler branch that wires ``runtime_settings.pinnbet_detail_mode``
+    onto the registered PinnBet scraper.  Without this branch in
+    ``_apply_runtime_scraper_settings``, runtime overrides would silently
+    no-op on the scraper instance.
+    """
+    from app.models.schemas import ScrapeRuntimeSettings
+    from app.services.scheduler import Scheduler
+
+    scraper = PinnBetScraper(detail_mode="partial")
+    assert scraper._detail_mode == "partial"
+
+    runtime_settings = ScrapeRuntimeSettings(
+        enabled_bookmakers=["pinnbet"],
+        enabled_sports=["basketball", "football"],
+        scrape_market_scope="all",
+        analysis_markets=["all"],
+        scrape_lookahead_hours=24,
+        scrape_interval_minutes=10,
+        max_middle_opportunities_per_market=10,
+        rate_limit_per_second=1.0,
+        meridian_rate_limit_per_second=2.0,
+        soccerbet_detail_mode="partial",
+        merkurxtip_detail_mode="partial",
+        pinnbet_detail_mode="full",
+        notification_gap_threshold=1.5,
+        persist_inapp_notifications=False,
+    )
+
+    Scheduler(interval_minutes=1)._apply_runtime_scraper_settings(scraper, runtime_settings)
+    assert scraper._detail_mode == "full"
+
+    runtime_settings_partial = runtime_settings.model_copy(
+        update={"pinnbet_detail_mode": "partial"}
+    )
+    Scheduler(interval_minutes=1)._apply_runtime_scraper_settings(
+        scraper, runtime_settings_partial
+    )
+    assert scraper._detail_mode == "partial"

--- a/frontend/src/api/mockData.ts
+++ b/frontend/src/api/mockData.ts
@@ -38,6 +38,7 @@ export const mockBookmakers: Bookmaker[] = [
   { id: 'superbet', name: 'Superbet', is_active: true },
   { id: 'betole', name: 'BetOle', is_active: true },
   { id: '365', name: '365', is_active: true },
+  { id: 'pinnbet', name: 'PinnBet', is_active: true },
   { id: 'volcanobet', name: 'VolcanoBet', is_active: true },
 ];
 
@@ -156,6 +157,7 @@ export const mockMatches: Match[] = [
       { id: '365', name: '365' },
       { id: 'superbet', name: 'Superbet' },
       { id: 'admiralbet', name: 'AdmiralBet' },
+      { id: 'pinnbet', name: 'PinnBet' },
     ],
   },
   {
@@ -177,6 +179,7 @@ export const mockMatches: Match[] = [
       { id: '365', name: '365' },
       { id: 'superbet', name: 'Superbet' },
       { id: 'admiralbet', name: 'AdmiralBet' },
+      { id: 'pinnbet', name: 'PinnBet' },
     ],
   },
   {
@@ -306,6 +309,15 @@ export const mockFootballOutcomeOffers: OutcomeOffer[] = [
   { id: 1094, match_id: 'football-match-2', bookmaker_id: 'admiralbet', bookmaker_name: 'AdmiralBet', market_type: 'football_result', outcome_code: 'home', odds: 1.94, line: null, raw_label: '1', scraped_at: ago(1) },
   { id: 1095, match_id: 'football-match-2', bookmaker_id: 'admiralbet', bookmaker_name: 'AdmiralBet', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.80, line: 2.5, raw_label: '0-2', scraped_at: ago(1) },
   { id: 1096, match_id: 'football-match-2', bookmaker_id: 'admiralbet', bookmaker_name: 'AdmiralBet', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.12, line: 2.5, raw_label: '3+', scraped_at: ago(1) },
+  // PinnBet — partial-mode shape: result + 2.5 totals on game 0, partial on game 1.  No double chance (default mode).
+  { id: 1097, match_id: 'football-match-1', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_result', outcome_code: 'home', odds: 2.45, line: null, raw_label: '1', scraped_at: ago(2) },
+  { id: 1098, match_id: 'football-match-1', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_result', outcome_code: 'draw', odds: 3.18, line: null, raw_label: 'X', scraped_at: ago(2) },
+  { id: 1099, match_id: 'football-match-1', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_result', outcome_code: 'away', odds: 2.62, line: null, raw_label: '2', scraped_at: ago(2) },
+  { id: 1100, match_id: 'football-match-1', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_total_goals', outcome_code: 'under', odds: 2.08, line: 2.5, raw_label: '0-2', scraped_at: ago(2) },
+  { id: 1101, match_id: 'football-match-1', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_total_goals', outcome_code: 'over', odds: 1.82, line: 2.5, raw_label: '3+', scraped_at: ago(2) },
+  { id: 1102, match_id: 'football-match-2', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_result', outcome_code: 'home', odds: 1.96, line: null, raw_label: '1', scraped_at: ago(2) },
+  { id: 1103, match_id: 'football-match-2', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.82, line: 2.5, raw_label: '0-2', scraped_at: ago(2) },
+  { id: 1104, match_id: 'football-match-2', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.14, line: 2.5, raw_label: '3+', scraped_at: ago(2) },
 ];
 
 export const mockOpportunities: Opportunity[] = [
@@ -1289,6 +1301,7 @@ export const mockSystemStatus: SystemStatus = {
     { id: 'superbet', name: 'Superbet', last_scrape: ago(6), is_active: true },
     { id: 'betole', name: 'BetOle', last_scrape: ago(4), is_active: true },
     { id: '365', name: '365', last_scrape: ago(1), is_active: true },
+    { id: 'pinnbet', name: 'PinnBet', last_scrape: ago(2), is_active: true },
     { id: 'volcanobet', name: 'VolcanoBet', last_scrape: ago(4), is_active: true },
   ],
 };
@@ -1306,6 +1319,7 @@ export const mockScrapeSettings: ScrapeSettingsResponse = {
     meridian_rate_limit_per_second: 2,
     soccerbet_detail_mode: 'partial',
     merkurxtip_detail_mode: 'partial',
+    pinnbet_detail_mode: 'partial',
     notification_gap_threshold: 1.5,
     persist_inapp_notifications: false,
   },
@@ -1321,6 +1335,7 @@ export const mockScrapeSettings: ScrapeSettingsResponse = {
     meridian_rate_limit_per_second: 2,
     soccerbet_detail_mode: 'partial',
     merkurxtip_detail_mode: 'partial',
+    pinnbet_detail_mode: 'partial',
     notification_gap_threshold: 1.5,
     persist_inapp_notifications: false,
   },

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -339,6 +339,7 @@ export interface ScrapeRuntimeSettings {
   meridian_rate_limit_per_second: number;
   soccerbet_detail_mode: ScraperDetailMode;
   merkurxtip_detail_mode: ScraperDetailMode;
+  pinnbet_detail_mode: ScraperDetailMode;
   notification_gap_threshold: number;
   persist_inapp_notifications: boolean;
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -687,6 +687,23 @@ function SettingsForm({
                 />
               </SettingRow>
 
+              <SettingRow
+                label="Detail mode · PinnBet"
+                description="Full mode also fetches per-event football detail to add double chance."
+              >
+                <SelectControl
+                  value={draft.pinnbet_detail_mode}
+                  options={options.detail_modes}
+                  getLabel={(mode) => detailModeLabels[mode]}
+                  onChange={(mode) =>
+                    setDraft((current) => ({
+                      ...current,
+                      pinnbet_detail_mode: mode,
+                    }))
+                  }
+                />
+              </SettingRow>
+
               <SettingRow label="Min gap to notify" description="Smaller values can create more pings.">
                 <NumberControl
                   value={draft.notification_gap_threshold}


### PR DESCRIPTION
## Summary

Adds **football outcome scraping for PinnBet**, the 8th football bookmaker in the Tipster/iBet+ family.

PinnBet's football list endpoint exposes only result (1X2) and totals; double chance (DC) is only available via per-event detail. To match the user's explicit request and the existing SoccerBet/MerkurXTip detail-mode pattern, this introduces two modes:

- **`partial`** (default): list-only — emits `football_result` + `football_total_goals` (2.5). **No double chance.**
- **`full`**: list + per-event detail with bounded concurrency — adds `football_double_chance` from the detail payload.

`pinnbet_detail_mode` is wired through 4 backend surfaces (`config.py`, `schemas.py`, `runtime_settings.py`, `scheduler.py::_apply_runtime_scraper_settings`) and 3 frontend surfaces (`types.ts`, `mockData.ts`, `Settings.tsx`).

## Live verification

Ran the new scraper against the real PinnBet football endpoint:

| Mode | Matches | Odds | Result | Totals 2.5 | Double chance |
|---|---:|---:|---:|---:|---:|
| `partial` (default) | 134 | 670 | 402 | 268 | 0 |
| `full` | 134 | 1065 | 402 | 268 | 395 |

## Family running totals (8 football bookmakers)

| # | Bookmaker | PR | Matches | Odds |
|---|---|---:|---:|---:|
| 1 | SoccerBet | #84 | 135 | 1077 |
| 2 | MerkurXTip | #85 | 103 | 824 |
| 3 | OktagonBet | #86 | 154 | 1224 |
| 4 | BetOle | #87 | 155 | 1232 |
| 5 | 365 | #88 | 78 | 624 |
| 6 | Superbet | #89 | 235 | 1761 |
| 7 | AdmiralBet | #90 | 80 | 640 |
| **8** | **PinnBet (partial)** | **this** | **134** | **670** |

## Repo invariants enforced (with regression tests)

- **B1 list-metadata-authoritative.** Detail-derived DC offers take `home_team`/`away_team`/`start_time`/`league_id` UNCONDITIONALLY from the list event — even when the list field is `None`. Pinned by `test_parse_football_double_chance_detail_ignores_hostile_detail_metadata` and `..._falls_back_when_list_league_is_none`.
- **Capability isolation.** `get_supported_leagues()` continues to return `["basketball"]` only; football is advertised solely via `get_supported_outcome_sports()`. Pinned by `test_capability_isolation_for_pinnbet`.
- **Defensive totals.** Bet-level pre-filter on `sBV` PLUS `_resolve_total_line` outcome-level cross-check; rows are dropped on disagreement (mirrors AdmiralBet's `_resolve_total_line` pattern).
- **Graceful detail failures.** Per-event detail fetch errors are swallowed/logged — the cycle still emits partial-mode offers cleanly.
- **`normalize_identity_text` for totals sides.** Handles `"manje"`, `"Više"`, and the unaccented `"vise"` form used by some payloads.
- **Scheduler runtime override.** `Scheduler._apply_runtime_scraper_settings` has an explicit `pinnbet` branch calling `set_runtime_detail_mode`. Pinned by `test_scheduler_applies_pinnbet_detail_mode_from_runtime_settings`.
- **Best-row dedupe.** `_dedupe_football_events` keeps the most-complete row per `eventId` (detail-id +4, bets +2, competitionName +1) before list emission.
- **Totals scope.** Only line `2.5` is emitted in this first pass.

## Mock & frontend coherence

- `mock_scraper.py::_BOOKMAKER_META` now includes `pinnbet` (this entry was previously missing — pre-existing drift). Added a partial-mode football block to `_FOOTBALL_OUTCOME_MARKETS`.
- `frontend/src/api/mockData.ts`: `pinnbet` now appears in `mockBookmakers`, `mockSystemStatus.bookmaker_status`, both football matches' `available_bookmakers`, and 8 representative OutcomeOffer rows.
- `frontend/src/pages/Settings.tsx`: new "Detail mode · PinnBet" SettingRow, side-by-side with the existing SoccerBet/MerkurXTip rows.

## Verification

- `cd backend && ./venv/bin/pytest -q` — **1071 passed** (88 PinnBet tests, of which 34 are new football tests).
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — clean (159 modules, 481 kB JS).
- Live smoke test against the real endpoint in both modes (counts above).

## Code-review pass

A code-review pass against `main` (gpt-5.5) flagged 3 medium issues, all addressed in the latest commit:

1. Scheduler PinnBet branch was untested → added `test_scheduler_applies_pinnbet_detail_mode_from_runtime_settings`.
2. B1 invariant under-tested (no hostile detail / no list-`None` case) → added two regression tests with hostile detail metadata and nullable list `competitionName`.
3. Diacritic test missed unaccented `vise` → strengthened `test_parse_football_outcome_event_classifies_totals_diacritic_insensitive` to use `"  vise  "`.

## Out of scope

- Other markets beyond result/totals/DC (intentional, mirrors prior football slices).
- Totals lines other than 2.5 (intentional, pinned by tests).
