### PR TITLE
Add Mozzart football outcome scraper

### DIFF
--- a/backend/app/scrapers/mock_scraper.py
+++ b/backend/app/scrapers/mock_scraper.py
@@ -260,6 +260,19 @@ _FOOTBALL_GAMES = [
 ]
 
 _FOOTBALL_OUTCOME_MARKETS: dict[str, list[dict]] = {
+    "mozzart": [
+        {"game": 0, "market": "football_result", "outcome": "home", "odds": 2.48, "label": "1"},
+        {"game": 0, "market": "football_result", "outcome": "draw", "odds": 3.18, "label": "X"},
+        {"game": 0, "market": "football_result", "outcome": "away", "odds": 2.62, "label": "2"},
+        {"game": 0, "market": "football_double_chance", "outcome": "home_or_draw", "odds": 1.41, "label": "1X"},
+        {"game": 0, "market": "football_double_chance", "outcome": "home_or_away", "odds": 1.29, "label": "12"},
+        {"game": 0, "market": "football_double_chance", "outcome": "draw_or_away", "odds": 1.47, "label": "X2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "under", "odds": 1.80, "line": 2.5, "label": "0-2"},
+        {"game": 0, "market": "football_total_goals", "outcome": "over", "odds": 1.90, "line": 2.5, "label": "3+"},
+        {"game": 1, "market": "football_result", "outcome": "home", "odds": 1.98, "label": "1"},
+        {"game": 1, "market": "football_total_goals", "outcome": "under", "odds": 1.76, "line": 2.5, "label": "0-2"},
+        {"game": 1, "market": "football_total_goals", "outcome": "over", "odds": 2.18, "line": 2.5, "label": "3+"},
+    ],
     "maxbet": [
         {"game": 0, "market": "football_result", "outcome": "home", "odds": 2.50, "label": "1"},
         {"game": 0, "market": "football_result", "outcome": "draw", "odds": 3.15, "label": "X"},

--- a/backend/app/scrapers/mozzart_scraper.py
+++ b/backend/app/scrapers/mozzart_scraper.py
@@ -6,7 +6,8 @@ from datetime import datetime, timezone
 
 from .base import BaseScraper
 from .http_client import HttpClient
-from ..models.schemas import RawOddsData
+from ..models.schemas import RawOddsData, RawOutcomeOffer
+from ..services.text_normalizer import normalize_identity_text
 
 logger = logging.getLogger(__name__)
 
@@ -48,15 +49,38 @@ _PLAYER_GROUP_KEYWORDS = [
 ]
 
 _BASKETBALL_SPORT_ID = 2
+_FOOTBALL_SPORT_ID = 1
 _MATCHES_MATCH_TYPE = 0
 _SPECIALS_MATCH_TYPE = 2
 _MATCHES_DATE = "all"
 _PAGE_SIZE = 50
+_FOOTBALL_TOTAL_GOALS_LINE = 2.5
 _GAME_TOTAL_GROUP_NAMES = {
     "ukupno poena na meču",
     "ukupno poena na mecu",
 }
 _HANDICAP_GROUP_NAMES = {"hendikep"}
+_FOOTBALL_RESULT_GROUP_NAMES = {"konacan ishod"}
+_FOOTBALL_DOUBLE_CHANCE_GROUP_NAMES = {"dupla sansa"}
+_FOOTBALL_TOTAL_GOALS_GROUP_NAMES = {"ukupno golova na mecu"}
+_FOOTBALL_RESULT_OUTCOMES = {
+    "1": "home",
+    "x": "draw",
+    "2": "away",
+}
+_FOOTBALL_DOUBLE_CHANCE_OUTCOMES = {
+    "1x": "home_or_draw",
+    "12": "home_or_away",
+    "x2": "draw_or_away",
+}
+_FOOTBALL_TOTAL_GOALS_OUTCOMES = {
+    "0-2": "under",
+    "3": "over",
+}
+_FOOTBALL_TOTAL_GOALS_LABELS = {
+    "under": "0-2",
+    "over": "3+",
+}
 _CANONICAL_LEAGUES = {
     "nba": "nba",
     "usa nba": "nba",
@@ -102,13 +126,14 @@ def _build_matches_request_body(
     current_page: int = 0,
     competition_ids: list[int] | None = None,
     page_size: int = _PAGE_SIZE,
+    sport_id: int = _BASKETBALL_SPORT_ID,
 ) -> dict:
     return {
         "date": _MATCHES_DATE,
         "sort": "bycompetition",
         "currentPage": current_page,
         "pageSize": page_size,
-        "sportId": _BASKETBALL_SPORT_ID,
+        "sportId": sport_id,
         "competitionIds": competition_ids or [],
         "search": "",
         "matchTypeId": _MATCHES_MATCH_TYPE,
@@ -147,6 +172,11 @@ def _extract_league_id(competition_name: str | None) -> str:
     return raw.replace(" ", "_") or "basketball"
 
 
+def _extract_football_league_id(competition_name: str | None) -> str:
+    normalized = normalize_identity_text(competition_name)
+    return normalized.replace(" ", "_") or "football"
+
+
 def _parse_threshold(raw_value: object) -> float | None:
     try:
         threshold = float(raw_value)
@@ -165,6 +195,14 @@ def _parse_signed_threshold(raw_value: object) -> float | None:
         return float(raw_value)
     except (ValueError, TypeError):
         return None
+
+
+def _coerce_positive_odds(value: object) -> float | None:
+    try:
+        odds = float(value)
+    except (TypeError, ValueError):
+        return None
+    return odds if odds > 0 else None
 
 
 def _assign_over_under(odds: dict[str, float | None], subgame_name: str, value: float) -> None:
@@ -367,6 +405,77 @@ def _parse_handicap_items(items: list[dict]) -> list[RawOddsData]:
     return results
 
 
+def _football_label_key(raw_label: object) -> str:
+    return normalize_identity_text(str(raw_label or ""), keep_hyphens=True).replace(" ", "")
+
+
+def _parse_football_outcome_match(match: dict) -> list[RawOutcomeOffer]:
+    home = ((match.get("home") or {}).get("name") or "").strip()
+    visitor = ((match.get("visitor") or {}).get("name") or "").strip()
+    if not home or not visitor:
+        return []
+
+    competition = (match.get("competition") or {}).get("name")
+    league_id = _extract_football_league_id(competition)
+    start_time = _parse_start_time(match.get("startTime"))
+
+    results: list[RawOutcomeOffer] = []
+    for group in match.get("oddsGroup") or []:
+        group_name = normalize_identity_text(group.get("groupName"))
+        if group_name in _FOOTBALL_RESULT_GROUP_NAMES:
+            market_type = "football_result"
+            outcome_lookup = _FOOTBALL_RESULT_OUTCOMES
+            line = None
+        elif group_name in _FOOTBALL_DOUBLE_CHANCE_GROUP_NAMES:
+            market_type = "football_double_chance"
+            outcome_lookup = _FOOTBALL_DOUBLE_CHANCE_OUTCOMES
+            line = None
+        elif group_name in _FOOTBALL_TOTAL_GOALS_GROUP_NAMES:
+            market_type = "football_total_goals"
+            outcome_lookup = _FOOTBALL_TOTAL_GOALS_OUTCOMES
+            line = _FOOTBALL_TOTAL_GOALS_LINE
+        else:
+            continue
+
+        for odd in group.get("odds") or []:
+            if odd.get("oddStatus") != "ACTIVE":
+                continue
+
+            raw_label = ((odd.get("subgame") or {}).get("name") or "").strip()
+            outcome_code = outcome_lookup.get(_football_label_key(raw_label))
+            odds = _coerce_positive_odds(odd.get("value"))
+            if outcome_code is None or odds is None:
+                continue
+
+            if market_type == "football_total_goals":
+                raw_label = _FOOTBALL_TOTAL_GOALS_LABELS[outcome_code]
+
+            results.append(
+                RawOutcomeOffer(
+                    bookmaker_id="mozzart",
+                    league_id=league_id,
+                    sport="football",
+                    home_team=home,
+                    away_team=visitor,
+                    market_type=market_type,
+                    outcome_code=outcome_code,
+                    odds=odds,
+                    line=line,
+                    raw_label=raw_label,
+                    start_time=start_time,
+                )
+            )
+
+    return results
+
+
+def _parse_football_outcome_items(items: list[dict]) -> list[RawOutcomeOffer]:
+    results: list[RawOutcomeOffer] = []
+    for match in items:
+        results.extend(_parse_football_outcome_match(match))
+    return results
+
+
 class MozzartScraper(BaseScraper):
     """Real scraper for Mozzart player props and game total over/under odds."""
 
@@ -397,12 +506,20 @@ class MozzartScraper(BaseScraper):
 
         return data.get("items", [])
 
-    async def _fetch_match_items(self) -> list[dict]:
+    async def _fetch_match_items(
+        self,
+        *,
+        sport_id: int = _BASKETBALL_SPORT_ID,
+        label: str = "match",
+    ) -> list[dict]:
         items: list[dict] = []
         current_page = 0
 
         while True:
-            body = _build_matches_request_body(current_page=current_page)
+            body = _build_matches_request_body(
+                current_page=current_page,
+                sport_id=sport_id,
+            )
             try:
                 data = await self._http.post_json(
                     _MATCHES_API_URL,
@@ -410,7 +527,7 @@ class MozzartScraper(BaseScraper):
                     headers=_MATCHES_HEADERS,
                 )
             except Exception:
-                logger.exception("Mozzart match scrape failed on page %d", current_page)
+                logger.exception("Mozzart %s scrape failed on page %d", label, current_page)
                 return items
 
             page_items = data.get("items", [])
@@ -422,6 +539,9 @@ class MozzartScraper(BaseScraper):
                 return items
 
             current_page += 1
+
+    def get_supported_outcome_sports(self) -> list[str]:
+        return ["football"]
 
     async def scrape_odds(self, league_id: str) -> list[RawOddsData]:
         if league_id != "basketball":
@@ -448,6 +568,26 @@ class MozzartScraper(BaseScraper):
             len(game_total_results),
             len(handicap_results),
             len(special_items),
+            len(match_items),
+        )
+        return results
+
+    async def scrape_outcome_offers(self, sport: str) -> list[RawOutcomeOffer]:
+        if sport != "football":
+            return []
+
+        match_items = await self._fetch_match_items(
+            sport_id=_FOOTBALL_SPORT_ID,
+            label="football match",
+        )
+        if not match_items:
+            logger.warning("Mozzart returned 0 football prematch matches")
+            return []
+
+        results = _parse_football_outcome_items(match_items)
+        logger.info(
+            "Mozzart scraped %d football outcome offers from %d prematch matches",
+            len(results),
             len(match_items),
         )
         return results

--- a/backend/tests/test_mozzart_scraper.py
+++ b/backend/tests/test_mozzart_scraper.py
@@ -8,19 +8,23 @@ import pytest
 
 from app.scrapers.mozzart_scraper import (
     MozzartScraper,
+    _BASKETBALL_SPORT_ID,
+    _FOOTBALL_SPORT_ID,
     _MATCHES_API_URL,
     _SPECIALS_API_URL,
     _MATCHES_HEADERS,
     _DEFAULT_HEADERS,
+    _build_matches_request_body,
     _extract_league_id,
     _extract_player_and_market,
+    _parse_football_outcome_match,
     _parse_game_total_items,
     _parse_handicap_items,
     _parse_items,
     _parse_signed_threshold,
     _parse_start_time,
 )
-from app.models.schemas import RawOddsData
+from app.models.schemas import RawOddsData, RawOutcomeOffer
 
 SPECIALS_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "mozzart_specials.json"
 MATCHES_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "mozzart_matches.json"
@@ -623,3 +627,217 @@ async def test_scraper_interface():
     assert scraper.get_bookmaker_id() == "mozzart"
     assert scraper.get_bookmaker_name() == "Mozzart"
     assert "basketball" in scraper.get_supported_leagues()
+
+
+# ── Football outcome offers ────────────────────────────────
+
+
+def _football_odd(label: str, value: float, *, status: str = "ACTIVE") -> dict:
+    return {
+        "oddStatus": status,
+        "subgame": {"name": label},
+        "value": value,
+    }
+
+
+def _football_match(*, odds_groups: list[dict] | None = None) -> dict:
+    return {
+        "id": 687289,
+        "sport": {"id": 1, "name": "Fudbal"},
+        "competition": {"id": 12211, "name": "SVETSKO  PRVENSTVO"},
+        "startTime": 1781204400000,
+        "home": {"id": 12890, "name": "Mexico"},
+        "visitor": {"id": 12883, "name": "South Africa"},
+        "oddsGroup": odds_groups
+        if odds_groups is not None
+        else [
+            {
+                "groupName": "Konačan ishod",
+                "odds": [
+                    _football_odd("1", 1.52),
+                    _football_odd("X", 4.30),
+                    _football_odd("2", 6.25),
+                ],
+            },
+            {
+                "groupName": "Dupla šansa",
+                "odds": [
+                    _football_odd("1X", 1.12),
+                    _football_odd("12", 1.22),
+                    _football_odd("X2", 2.55),
+                ],
+            },
+            {
+                "groupName": "Ukupno golova na meču",
+                "odds": [
+                    _football_odd("2+", 1.28),
+                    _football_odd("0-2", 1.80),
+                    _football_odd("3+", 1.90),
+                ],
+            },
+            {
+                "groupName": "Oba tima daju gol",
+                "odds": [_football_odd("GG", 2.00), _football_odd("NG", 1.72)],
+            },
+        ],
+    }
+
+
+def test_build_matches_request_body_defaults_to_basketball_and_can_target_football():
+    default_body = _build_matches_request_body()
+    football_body = _build_matches_request_body(current_page=2, sport_id=_FOOTBALL_SPORT_ID)
+
+    assert default_body["sportId"] == _BASKETBALL_SPORT_ID
+    assert football_body["sportId"] == _FOOTBALL_SPORT_ID
+    assert football_body["currentPage"] == 2
+    assert football_body["matchTypeId"] == 0
+
+
+def test_parse_football_outcome_match_emits_list_only_target_markets():
+    offers = _parse_football_outcome_match(_football_match())
+
+    assert len(offers) == 8
+    assert all(isinstance(offer, RawOutcomeOffer) for offer in offers)
+    assert all(offer.bookmaker_id == "mozzart" for offer in offers)
+    assert all(offer.sport == "football" for offer in offers)
+    assert all(offer.home_team == "Mexico" for offer in offers)
+    assert all(offer.away_team == "South Africa" for offer in offers)
+    assert all(offer.league_id == "svetsko_prvenstvo" for offer in offers)
+    assert all(offer.start_time == "2026-06-11T19:00:00+00:00" for offer in offers)
+
+    assert {
+        (offer.market_type, offer.outcome_code, offer.line, offer.raw_label, offer.odds)
+        for offer in offers
+    } == {
+        ("football_result", "home", None, "1", 1.52),
+        ("football_result", "draw", None, "X", 4.30),
+        ("football_result", "away", None, "2", 6.25),
+        ("football_double_chance", "home_or_draw", None, "1X", 1.12),
+        ("football_double_chance", "home_or_away", None, "12", 1.22),
+        ("football_double_chance", "draw_or_away", None, "X2", 2.55),
+        ("football_total_goals", "under", 2.5, "0-2", 1.80),
+        ("football_total_goals", "over", 2.5, "3+", 1.90),
+    }
+
+
+def test_parse_football_outcome_match_normalizes_diacritics_and_labels():
+    match = _football_match(
+        odds_groups=[
+            {
+                "groupName": "Konacan ishod",
+                "odds": [_football_odd(" x ", 3.2)],
+            },
+            {
+                "groupName": "Dupla sansa",
+                "odds": [_football_odd(" x2 ", 1.5)],
+            },
+            {
+                "groupName": "Ukupno golova na mecu",
+                "odds": [_football_odd("0 - 2", 1.75), _football_odd("3 +", 2.05)],
+            },
+        ],
+    )
+
+    assert {
+        (offer.market_type, offer.outcome_code, offer.raw_label, offer.line)
+        for offer in _parse_football_outcome_match(match)
+    } == {
+        ("football_result", "draw", "x", None),
+        ("football_double_chance", "draw_or_away", "x2", None),
+        ("football_total_goals", "under", "0-2", 2.5),
+        ("football_total_goals", "over", "3+", 2.5),
+    }
+
+
+def test_parse_football_outcome_match_skips_non_target_or_invalid_odds():
+    match = _football_match(
+        odds_groups=[
+            {
+                "groupName": "Konačan ishod",
+                "odds": [
+                    _football_odd("1", 0),
+                    _football_odd("X", 3.2, status="SUSPENDED"),
+                    _football_odd("2", 2.4),
+                ],
+            },
+            {
+                "groupName": "Ukupno golova na meču",
+                "odds": [
+                    _football_odd("2+", 1.4),
+                    _football_odd("3+", -1),
+                    _football_odd("0-2", 1.7),
+                ],
+            },
+        ],
+    )
+
+    assert {
+        (offer.market_type, offer.outcome_code, offer.odds)
+        for offer in _parse_football_outcome_match(match)
+    } == {
+        ("football_result", "away", 2.4),
+        ("football_total_goals", "under", 1.7),
+    }
+
+
+def test_parse_football_outcome_match_requires_home_and_away():
+    match = _football_match()
+    match["home"] = None
+    assert _parse_football_outcome_match(match) == []
+
+
+def test_parse_football_outcome_match_falls_back_to_football_league():
+    match = _football_match()
+    match["competition"] = None
+
+    offers = _parse_football_outcome_match(match)
+
+    assert offers
+    assert {offer.league_id for offer in offers} == {"football"}
+
+
+def test_capability_isolation_for_mozzart():
+    scraper = MozzartScraper()
+
+    assert scraper.get_supported_leagues() == ["basketball"]
+    assert scraper.get_supported_outcome_sports() == ["football"]
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_uses_only_paginated_matches_endpoint():
+    page_one = [_football_match()] * 50
+    page_two = [_football_match()]
+
+    async def fake_post_json(url: str, *, json_body=None, headers=None):
+        del headers
+        assert url == _MATCHES_API_URL
+        assert json_body is not None
+        assert json_body["sportId"] == _FOOTBALL_SPORT_ID
+        assert json_body["matchTypeId"] == 0
+        if json_body["currentPage"] == 0:
+            return {"items": page_one}
+        if json_body["currentPage"] == 1:
+            return {"items": page_two}
+        raise AssertionError(f"Unexpected page: {json_body['currentPage']}")
+
+    http_client = AsyncMock()
+    http_client.post_json.side_effect = fake_post_json
+
+    offers = await MozzartScraper(http_client=http_client).scrape_outcome_offers("football")
+
+    assert len(offers) == 51 * 8
+    assert http_client.post_json.call_count == 2
+    assert {
+        call.kwargs["json_body"]["currentPage"]
+        for call in http_client.post_json.call_args_list
+    } == {0, 1}
+
+
+@pytest.mark.asyncio
+async def test_scrape_outcome_offers_unsupported_sport_does_not_fetch():
+    http_client = AsyncMock()
+
+    offers = await MozzartScraper(http_client=http_client).scrape_outcome_offers("tennis")
+
+    assert offers == []
+    http_client.post_json.assert_not_called()

--- a/backend/tests/test_scraper_benchmarks.py
+++ b/backend/tests/test_scraper_benchmarks.py
@@ -106,7 +106,10 @@ async def test_failed_scraper_increments_failure_rate(monkeypatch, client: Async
     resp = await client.get("/api/v1/scraper-benchmarks")
     body = resp.json()
     by_bm = {s["bookmaker_id"]: s for s in body["scrapers"]}
-    # Both bookmakers used the patched method; both fail.
+    # Meridian only has the threshold-odds lane, so the patched scrape_odds
+    # makes it fail every attempted task. Mozzart also advertises football
+    # outcome offers in mock mode; that list-only lane still succeeds.
     assert by_bm["meridian"]["failure_rate"] == 1.0
-    assert by_bm["mozzart"]["failure_rate"] == 1.0
+    assert by_bm["mozzart"]["failure_rate"] == 0.5
     assert by_bm["meridian"]["raw_items"] == 0
+    assert by_bm["mozzart"]["raw_items"] > 0

--- a/frontend/src/api/mockData.ts
+++ b/frontend/src/api/mockData.ts
@@ -148,6 +148,7 @@ export const mockMatches: Match[] = [
     start_time: hours(2.25),
     status: 'upcoming',
     available_bookmakers: [
+      { id: 'mozzart', name: 'Mozzart' },
       { id: 'maxbet', name: 'MaxBet' },
       { id: 'balkanbet', name: 'BalkanBet' },
       { id: 'oktagonbet', name: 'OktagonBet' },
@@ -170,6 +171,7 @@ export const mockMatches: Match[] = [
     start_time: hours(2.5),
     status: 'upcoming',
     available_bookmakers: [
+      { id: 'mozzart', name: 'Mozzart' },
       { id: 'maxbet', name: 'MaxBet' },
       { id: 'balkanbet', name: 'BalkanBet' },
       { id: 'oktagonbet', name: 'OktagonBet' },
@@ -318,6 +320,18 @@ export const mockFootballOutcomeOffers: OutcomeOffer[] = [
   { id: 1102, match_id: 'football-match-2', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_result', outcome_code: 'home', odds: 1.96, line: null, raw_label: '1', scraped_at: ago(2) },
   { id: 1103, match_id: 'football-match-2', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.82, line: 2.5, raw_label: '0-2', scraped_at: ago(2) },
   { id: 1104, match_id: 'football-match-2', bookmaker_id: 'pinnbet', bookmaker_name: 'PinnBet', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.14, line: 2.5, raw_label: '3+', scraped_at: ago(2) },
+  // Mozzart — list-only football shape: result + double chance + 2.5 totals from betting/matches.
+  { id: 1105, match_id: 'football-match-1', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_result', outcome_code: 'home', odds: 2.48, line: null, raw_label: '1', scraped_at: ago(2) },
+  { id: 1106, match_id: 'football-match-1', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_result', outcome_code: 'draw', odds: 3.18, line: null, raw_label: 'X', scraped_at: ago(2) },
+  { id: 1107, match_id: 'football-match-1', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_result', outcome_code: 'away', odds: 2.62, line: null, raw_label: '2', scraped_at: ago(2) },
+  { id: 1108, match_id: 'football-match-1', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_double_chance', outcome_code: 'home_or_draw', odds: 1.41, line: null, raw_label: '1X', scraped_at: ago(2) },
+  { id: 1109, match_id: 'football-match-1', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_double_chance', outcome_code: 'home_or_away', odds: 1.29, line: null, raw_label: '12', scraped_at: ago(2) },
+  { id: 1110, match_id: 'football-match-1', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_double_chance', outcome_code: 'draw_or_away', odds: 1.47, line: null, raw_label: 'X2', scraped_at: ago(2) },
+  { id: 1111, match_id: 'football-match-1', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.80, line: 2.5, raw_label: '0-2', scraped_at: ago(2) },
+  { id: 1112, match_id: 'football-match-1', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_total_goals', outcome_code: 'over', odds: 1.90, line: 2.5, raw_label: '3+', scraped_at: ago(2) },
+  { id: 1113, match_id: 'football-match-2', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_result', outcome_code: 'home', odds: 1.98, line: null, raw_label: '1', scraped_at: ago(2) },
+  { id: 1114, match_id: 'football-match-2', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_total_goals', outcome_code: 'under', odds: 1.76, line: 2.5, raw_label: '0-2', scraped_at: ago(2) },
+  { id: 1115, match_id: 'football-match-2', bookmaker_id: 'mozzart', bookmaker_name: 'Mozzart', market_type: 'football_total_goals', outcome_code: 'over', odds: 2.18, line: 2.5, raw_label: '3+', scraped_at: ago(2) },
 ];
 
 export const mockOpportunities: Opportunity[] = [
@@ -1279,16 +1293,16 @@ export const mockSystemStatus: SystemStatus = {
   total_matches: 6,
   total_odds: mockOddsOffers.length,
   total_opportunities: mockOpportunities.length,
-  active_bookmakers: 11,
+  active_bookmakers: 12,
   scheduler_running: true,
   scan: {
     in_progress: true,
     phase: 'scraping',
     started_at: ago(0),
-    total_tasks: 11,
+    total_tasks: 12,
     completed_tasks: 4,
     failed_tasks: 1,
-    active_tasks: 6,
+    active_tasks: 7,
   },
   bookmaker_status: [
     { id: 'mozzart', name: 'Mozzart', last_scrape: ago(2), is_active: true },


### PR DESCRIPTION
## Summary

Adds **Mozzart football outcome scraping** as the 9th football bookmaker.

This implementation intentionally stays **list-only** to satisfy the no-extra-scrape-time constraint: Mozzart's existing paginated `POST /betting/matches` payload with `sportId: 1` and `medium: PREMATCH_WEB` already carries all target football markets in the list response.

Mapped groups:

- `Konačan ishod` -> `football_result`
- `Dupla šansa` -> `football_double_chance`
- `Ukupno golova na meču` -> `football_total_goals`, line 2.5 only via `0-2` / `3+`

No per-event/detail endpoint is called.

## Live verification

Ran the new scraper against the real Mozzart football list flow:

| Bookmaker | Matches | Odds | Result | Double chance | Totals 2.5 |
|---|---:|---:|---:|---:|---:|
| Mozzart | 688 | 5,484 | 2,064 | 2,044 | 1,376 |

## Family running totals (9 football bookmakers)

| # | Bookmaker | PR | Matches | Odds |
|---|---|---:|---:|---:|
| 1 | SoccerBet | #84 | 135 | 1077 |
| 2 | MerkurXTip | #85 | 103 | 824 |
| 3 | OktagonBet | #86 | 154 | 1224 |
| 4 | BetOle | #87 | 155 | 1232 |
| 5 | 365 | #88 | 78 | 624 |
| 6 | Superbet | #89 | 235 | 1761 |
| 7 | AdmiralBet | #90 | 80 | 640 |
| 8 | PinnBet (partial) | #91 | 134 | 670 |
| **9** | **Mozzart** | **this** | **688** | **5484** |

## Implementation notes

- Keeps basketball behavior isolated: `scrape_odds("basketball")` still uses specials + basketball matches.
- Football is advertised only through `get_supported_outcome_sports()` and `scrape_outcome_offers("football")`; `get_supported_leagues()` remains `["basketball"]`.
- Uses `normalize_identity_text` for Serbian group/label matching so diacritic/unaccented payload variants classify consistently.
- Skips `2+` because it is not the requested O/U 2.5 pair.
- Updates mock mode and frontend mock data so Mozzart appears on football matches with representative list-only rows.
- Adjusts the benchmark failure-rate test because Mozzart mock mode now has two lanes: basketball can fail while the football outcome lane still succeeds.

## Verification

- `cd backend && ./venv/bin/pytest tests/test_mozzart_scraper.py -q` — 49 passed.
- `cd backend && ./venv/bin/pytest -q` — 1080 passed.
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — clean.
- `git diff --check` — clean.
- Live smoke against Mozzart endpoint — counts above.

## Review

Three code-review passes found no significant issues:

- GPT-5.5
- Claude Opus 4.7
- Claude Opus 4.7 High
