### PR TITLE
Add self-explaining benchmark snapshots

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -522,6 +522,81 @@ class ScrapeResponse(BaseModel):
 
 
 # ── Scraper benchmarks ─────────────────────────────────────
+class BenchmarkRuntimeMetadataOut(BaseModel):
+    """Runtime configuration captured with a benchmark snapshot."""
+
+    scraper_mode: str
+    enabled_bookmakers: list[str] = Field(default_factory=list)
+    enabled_sports: list[str] = Field(default_factory=list)
+    scrape_market_scope: ScrapeMarketScope = "all"
+    analysis_markets: list[str] = Field(default_factory=list)
+    scrape_lookahead_hours: int = 0
+    rate_limit_per_second: float = 0
+    meridian_rate_limit_per_second: float = 0
+    detail_modes: dict[str, ScraperDetailMode] = Field(default_factory=dict)
+    proxies_configured: bool = False
+    proxy_count: int = 0
+
+
+class HttpTimingBenchmarkOut(BaseModel):
+    """Compact HTTP timing aggregate for benchmark snapshots."""
+
+    logical_requests: int = 0
+    attempts: int = 0
+    retries: int = 0
+    errors: int = 0
+    total_elapsed_ms: int = 0
+    total_rate_limit_wait_ms: int = 0
+    total_network_ms: int = 0
+    min_latency_ms: Optional[int] = None
+    avg_latency_ms: float = 0.0
+    max_latency_ms: Optional[int] = None
+    status_classes: dict[str, int] = Field(default_factory=dict)
+
+
+class ScraperRequestBenchmarkOut(HttpTimingBenchmarkOut):
+    """HTTP timing aggregate scoped to one scraper capability/method."""
+
+    lane: Optional[str] = None
+    sport: Optional[str] = None
+    league_id: Optional[str] = None
+    method: str
+
+
+class OutcomeNormalizationBenchmarkOut(BaseModel):
+    """Subphase metrics for football outcome-offer normalization."""
+
+    runs: int = 0
+    raw_outcome_offer_count: int = 0
+    normalized_outcome_offer_count: int = 0
+    unresolved_outcome_offer_count: int = 0
+    football_unique_event_count: int = 0
+    auto_created_football_team_count: int = 0
+    auto_create_football_teams_ms: int = 0
+    football_event_resolution_ms: int = 0
+    football_event_pair_ranking_ms: int = 0
+    football_event_slot_lookup_ms: int = 0
+    football_event_slot_mutation_ms: int = 0
+    row_normalization_ms: int = 0
+
+
+class EventResolverBenchmarkOut(BaseModel):
+    """Subphase metrics for resolved-event extraction/grouping/persistence."""
+
+    extract_event_candidates_ms: int = 0
+    football_raw_resolution_candidates_ms: int = 0
+    build_event_resolution_groups_ms: int = 0
+    persist_event_resolution_groups_ms: int = 0
+    candidate_count: int = 0
+    exact_group_count: int = 0
+    pair_check_count: int = 0
+    accepted_fuzzy_pair_count: int = 0
+    review_case_count: int = 0
+    persisted_resolved_event_count: int = 0
+    persisted_member_count: int = 0
+    persisted_review_case_count: int = 0
+
+
 class ScraperBenchmarkOut(BaseModel):
     """Per-scraper aggregates for the most recent scrape cycle."""
 
@@ -533,6 +608,8 @@ class ScraperBenchmarkOut(BaseModel):
     leagues_attempted: int
     leagues_failed: int
     failure_rate: float
+    http: HttpTimingBenchmarkOut = Field(default_factory=HttpTimingBenchmarkOut)
+    requests: list[ScraperRequestBenchmarkOut] = Field(default_factory=list)
 
 
 class CycleBenchmarkOut(BaseModel):
@@ -545,6 +622,14 @@ class CycleBenchmarkOut(BaseModel):
     total_raw_items: int = 0
     total_matches: int = 0
     total_odds: int = 0
+    metadata: Optional[BenchmarkRuntimeMetadataOut] = None
+    phase_durations_ms: dict[str, int] = Field(default_factory=dict)
+    outcome_normalization: OutcomeNormalizationBenchmarkOut = Field(
+        default_factory=OutcomeNormalizationBenchmarkOut
+    )
+    event_resolver: EventResolverBenchmarkOut = Field(
+        default_factory=EventResolverBenchmarkOut
+    )
     scrapers: list[ScraperBenchmarkOut] = Field(default_factory=list)
 
 

--- a/backend/app/scrapers/http_client.py
+++ b/backend/app/scrapers/http_client.py
@@ -8,12 +8,18 @@ from typing import Any
 
 import httpx
 
+from ..services.scraper_benchmarks import recorder as benchmark_recorder
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 30.0
 _DEFAULT_MAX_RETRIES = 3
 _DEFAULT_BACKOFF_BASE = 1.0
 _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return int((time.perf_counter() - started_at) * 1000)
 
 
 class HttpClient:
@@ -72,9 +78,10 @@ class HttpClient:
                     logger.warning("Cannot close rotated HTTP client without a running event loop")
             self._client = None
 
-    async def _acquire_request_slot(self) -> None:
+    async def _acquire_request_slot(self) -> int:
+        started_at = time.perf_counter()
         if self._min_interval <= 0:
-            return
+            return 0
         if self._rate_limit_lock is None:
             self._rate_limit_lock = asyncio.Lock()
         async with self._rate_limit_lock:
@@ -82,6 +89,7 @@ class HttpClient:
             if elapsed < self._min_interval:
                 await asyncio.sleep(self._min_interval - elapsed)
             self._last_request_time = time.monotonic()
+        return _elapsed_ms(started_at)
 
     async def post_json(
         self,
@@ -97,52 +105,77 @@ class HttpClient:
         ``application/x-www-form-urlencoded`` body (``json_body`` is ignored).
         """
         last_error: Exception | None = None
+        benchmark_started_at = time.perf_counter()
+        attempts_made = 0
+        total_rate_limit_wait_ms = 0
+        total_network_ms = 0
+        status_codes: list[int] = []
+        success = False
 
-        for attempt in range(self._max_retries + 1):
-            try:
-                client = await self._get_client()
-                merged_headers = {**self._default_headers, **(headers or {})}
-                await self._acquire_request_slot()
+        try:
+            for attempt in range(self._max_retries + 1):
+                try:
+                    client = await self._get_client()
+                    merged_headers = {**self._default_headers, **(headers or {})}
+                    total_rate_limit_wait_ms += await self._acquire_request_slot()
 
-                if form_data is not None:
-                    response = await client.post(
-                        url,
-                        content=form_data.encode(),
-                        headers=merged_headers,
-                    )
-                else:
-                    response = await client.post(
-                        url,
-                        json=json_body,
-                        headers=merged_headers,
-                    )
+                    attempts_made += 1
+                    network_started_at = time.perf_counter()
+                    try:
+                        if form_data is not None:
+                            response = await client.post(
+                                url,
+                                content=form_data.encode(),
+                                headers=merged_headers,
+                            )
+                        else:
+                            response = await client.post(
+                                url,
+                                json=json_body,
+                                headers=merged_headers,
+                            )
+                    finally:
+                        total_network_ms += _elapsed_ms(network_started_at)
+                    status_codes.append(response.status_code)
 
-                if response.status_code in _RETRYABLE_STATUS_CODES:
+                    if response.status_code in _RETRYABLE_STATUS_CODES:
+                        logger.warning(
+                            "Retryable status %d from %s (attempt %d/%d)",
+                            response.status_code, url, attempt + 1, self._max_retries + 1,
+                        )
+                        if attempt < self._max_retries:
+                            self._rotate_proxy()
+                            await asyncio.sleep(self._backoff_base * (2 ** attempt))
+                            continue
+                        response.raise_for_status()
+
+                    response.raise_for_status()
+                    payload = response.json()
+                    success = True
+                    return payload
+
+                except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError) as exc:
+                    last_error = exc
                     logger.warning(
-                        "Retryable status %d from %s (attempt %d/%d)",
-                        response.status_code, url, attempt + 1, self._max_retries + 1,
+                        "Network error from %s: %s (attempt %d/%d)",
+                        url, exc, attempt + 1, self._max_retries + 1,
                     )
                     if attempt < self._max_retries:
                         self._rotate_proxy()
                         await asyncio.sleep(self._backoff_base * (2 ** attempt))
                         continue
-                    response.raise_for_status()
 
-                response.raise_for_status()
-                return response.json()
-
-            except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError) as exc:
-                last_error = exc
-                logger.warning(
-                    "Network error from %s: %s (attempt %d/%d)",
-                    url, exc, attempt + 1, self._max_retries + 1,
-                )
-                if attempt < self._max_retries:
-                    self._rotate_proxy()
-                    await asyncio.sleep(self._backoff_base * (2 ** attempt))
-                    continue
-
-        raise last_error or RuntimeError(f"Failed after {self._max_retries + 1} attempts")
+            raise last_error or RuntimeError(f"Failed after {self._max_retries + 1} attempts")
+        finally:
+            benchmark_recorder.record_http_request(
+                method="POST",
+                elapsed_ms=_elapsed_ms(benchmark_started_at),
+                attempts=attempts_made,
+                rate_limit_wait_ms=total_rate_limit_wait_ms,
+                network_ms=total_network_ms,
+                status_codes=status_codes,
+                error=not success,
+            )
 
     async def get_json(
         self,
@@ -153,45 +186,70 @@ class HttpClient:
     ) -> dict:
         """GET JSON with retry, rate limiting, and proxy rotation."""
         last_error: Exception | None = None
+        benchmark_started_at = time.perf_counter()
+        attempts_made = 0
+        total_rate_limit_wait_ms = 0
+        total_network_ms = 0
+        status_codes: list[int] = []
+        success = False
 
-        for attempt in range(self._max_retries + 1):
-            try:
-                client = await self._get_client()
-                merged_headers = {**self._default_headers, **(headers or {})}
-                await self._acquire_request_slot()
+        try:
+            for attempt in range(self._max_retries + 1):
+                try:
+                    client = await self._get_client()
+                    merged_headers = {**self._default_headers, **(headers or {})}
+                    total_rate_limit_wait_ms += await self._acquire_request_slot()
 
-                response = await client.get(
-                    url,
-                    params=params,
-                    headers=merged_headers,
-                )
+                    attempts_made += 1
+                    network_started_at = time.perf_counter()
+                    try:
+                        response = await client.get(
+                            url,
+                            params=params,
+                            headers=merged_headers,
+                        )
+                    finally:
+                        total_network_ms += _elapsed_ms(network_started_at)
+                    status_codes.append(response.status_code)
 
-                if response.status_code in _RETRYABLE_STATUS_CODES:
+                    if response.status_code in _RETRYABLE_STATUS_CODES:
+                        logger.warning(
+                            "Retryable status %d from %s (attempt %d/%d)",
+                            response.status_code, url, attempt + 1, self._max_retries + 1,
+                        )
+                        if attempt < self._max_retries:
+                            self._rotate_proxy()
+                            await asyncio.sleep(self._backoff_base * (2 ** attempt))
+                            continue
+                        response.raise_for_status()
+
+                    response.raise_for_status()
+                    payload = response.json()
+                    success = True
+                    return payload
+
+                except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError) as exc:
+                    last_error = exc
                     logger.warning(
-                        "Retryable status %d from %s (attempt %d/%d)",
-                        response.status_code, url, attempt + 1, self._max_retries + 1,
+                        "Network error from %s: %s (attempt %d/%d)",
+                        url, exc, attempt + 1, self._max_retries + 1,
                     )
                     if attempt < self._max_retries:
                         self._rotate_proxy()
                         await asyncio.sleep(self._backoff_base * (2 ** attempt))
                         continue
-                    response.raise_for_status()
 
-                response.raise_for_status()
-                return response.json()
-
-            except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError) as exc:
-                last_error = exc
-                logger.warning(
-                    "Network error from %s: %s (attempt %d/%d)",
-                    url, exc, attempt + 1, self._max_retries + 1,
-                )
-                if attempt < self._max_retries:
-                    self._rotate_proxy()
-                    await asyncio.sleep(self._backoff_base * (2 ** attempt))
-                    continue
-
-        raise last_error or RuntimeError(f"Failed after {self._max_retries + 1} attempts")
+            raise last_error or RuntimeError(f"Failed after {self._max_retries + 1} attempts")
+        finally:
+            benchmark_recorder.record_http_request(
+                method="GET",
+                elapsed_ms=_elapsed_ms(benchmark_started_at),
+                attempts=attempts_made,
+                rate_limit_wait_ms=total_rate_limit_wait_ms,
+                network_ms=total_network_ms,
+                status_codes=status_codes,
+                error=not success,
+            )
 
     async def put_json(
         self,
@@ -206,47 +264,70 @@ class HttpClient:
         JSON-compatible value depending on the endpoint.
         """
         last_error: Exception | None = None
+        benchmark_started_at = time.perf_counter()
+        attempts_made = 0
+        total_rate_limit_wait_ms = 0
+        total_network_ms = 0
+        status_codes: list[int] = []
+        success = False
 
-        for attempt in range(self._max_retries + 1):
-            retry_delay: float | None = None
-            should_rotate_proxy = False
-            try:
-                client = await self._get_client()
-                merged_headers = {**self._default_headers, **(headers or {})}
-                await self._acquire_request_slot()
+        try:
+            for attempt in range(self._max_retries + 1):
+                try:
+                    client = await self._get_client()
+                    merged_headers = {**self._default_headers, **(headers or {})}
+                    total_rate_limit_wait_ms += await self._acquire_request_slot()
 
-                response = await client.put(
-                    url,
-                    json=json_body,
-                    headers=merged_headers,
-                )
+                    attempts_made += 1
+                    network_started_at = time.perf_counter()
+                    try:
+                        response = await client.put(
+                            url,
+                            json=json_body,
+                            headers=merged_headers,
+                        )
+                    finally:
+                        total_network_ms += _elapsed_ms(network_started_at)
+                    status_codes.append(response.status_code)
 
-                if response.status_code in _RETRYABLE_STATUS_CODES:
+                    if response.status_code in _RETRYABLE_STATUS_CODES:
+                        logger.warning(
+                            "Retryable status %d from %s (attempt %d/%d)",
+                            response.status_code, url, attempt + 1, self._max_retries + 1,
+                        )
+                        if attempt < self._max_retries:
+                            self._rotate_proxy()
+                            await asyncio.sleep(self._backoff_base * (2 ** attempt))
+                            continue
+                        response.raise_for_status()
+
+                    response.raise_for_status()
+                    payload = response.json()
+                    success = True
+                    return payload
+
+                except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError) as exc:
+                    last_error = exc
                     logger.warning(
-                        "Retryable status %d from %s (attempt %d/%d)",
-                        response.status_code, url, attempt + 1, self._max_retries + 1,
+                        "Network error from %s: %s (attempt %d/%d)",
+                        url, exc, attempt + 1, self._max_retries + 1,
                     )
                     if attempt < self._max_retries:
                         self._rotate_proxy()
                         await asyncio.sleep(self._backoff_base * (2 ** attempt))
                         continue
-                    response.raise_for_status()
 
-                response.raise_for_status()
-                return response.json()
-
-            except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError) as exc:
-                last_error = exc
-                logger.warning(
-                    "Network error from %s: %s (attempt %d/%d)",
-                    url, exc, attempt + 1, self._max_retries + 1,
-                )
-                if attempt < self._max_retries:
-                    self._rotate_proxy()
-                    await asyncio.sleep(self._backoff_base * (2 ** attempt))
-                    continue
-
-        raise last_error or RuntimeError(f"Failed after {self._max_retries + 1} attempts")
+            raise last_error or RuntimeError(f"Failed after {self._max_retries + 1} attempts")
+        finally:
+            benchmark_recorder.record_http_request(
+                method="PUT",
+                elapsed_ms=_elapsed_ms(benchmark_started_at),
+                attempts=attempts_made,
+                rate_limit_wait_ms=total_rate_limit_wait_ms,
+                network_ms=total_network_ms,
+                status_codes=status_codes,
+                error=not success,
+            )
 
     async def get_sse_json(
         self,
@@ -258,96 +339,120 @@ class HttpClient:
         read_timeout: float | None = None,
     ) -> list[Any]:
         """GET JSON messages from an SSE endpoint with retry and rate limiting."""
-        if max_messages <= 0:
-            raise ValueError("max_messages must be positive")
-
         last_error: Exception | None = None
+        benchmark_started_at = time.perf_counter()
+        attempts_made = 0
+        total_rate_limit_wait_ms = 0
+        total_network_ms = 0
+        status_codes: list[int] = []
+        success = False
 
-        for attempt in range(self._max_retries + 1):
-            retry_delay: float | None = None
-            should_rotate_proxy = False
-            try:
-                client = await self._get_client()
-                merged_headers = {**self._default_headers, **(headers or {})}
-                await self._acquire_request_slot()
+        try:
+            if max_messages <= 0:
+                raise ValueError("max_messages must be positive")
+            for attempt in range(self._max_retries + 1):
+                retry_delay: float | None = None
+                should_rotate_proxy = False
+                try:
+                    client = await self._get_client()
+                    merged_headers = {**self._default_headers, **(headers or {})}
+                    total_rate_limit_wait_ms += await self._acquire_request_slot()
 
-                timeout = httpx.Timeout(
-                    connect=self._timeout,
-                    read=read_timeout if read_timeout is not None else self._timeout,
-                    write=self._timeout,
-                    pool=self._timeout,
-                )
+                    timeout = httpx.Timeout(
+                        connect=self._timeout,
+                        read=read_timeout if read_timeout is not None else self._timeout,
+                        write=self._timeout,
+                        pool=self._timeout,
+                    )
 
-                async with client.stream(
-                    "GET",
-                    url,
-                    params=params,
-                    headers=merged_headers,
-                    timeout=timeout,
-                ) as response:
-                    if response.status_code in _RETRYABLE_STATUS_CODES:
-                        logger.warning(
-                            "Retryable status %d from %s (attempt %d/%d)",
-                            response.status_code, url, attempt + 1, self._max_retries + 1,
-                        )
-                        if attempt < self._max_retries:
-                            should_rotate_proxy = True
-                            retry_delay = self._backoff_base * (2 ** attempt)
-                        else:
-                            response.raise_for_status()
-                    else:
-                        response.raise_for_status()
+                    attempts_made += 1
+                    network_started_at = time.perf_counter()
+                    try:
+                        async with client.stream(
+                            "GET",
+                            url,
+                            params=params,
+                            headers=merged_headers,
+                            timeout=timeout,
+                        ) as response:
+                            status_codes.append(response.status_code)
+                            if response.status_code in _RETRYABLE_STATUS_CODES:
+                                logger.warning(
+                                    "Retryable status %d from %s (attempt %d/%d)",
+                                    response.status_code, url, attempt + 1, self._max_retries + 1,
+                                )
+                                if attempt < self._max_retries:
+                                    should_rotate_proxy = True
+                                    retry_delay = self._backoff_base * (2 ** attempt)
+                                else:
+                                    response.raise_for_status()
+                            else:
+                                response.raise_for_status()
 
-                    if retry_delay is None:
-                        messages: list[Any] = []
-                        data_lines: list[str] = []
+                            if retry_delay is None:
+                                messages: list[Any] = []
+                                data_lines: list[str] = []
 
-                        async for line in response.aiter_lines():
-                            if not line:
+                                async for line in response.aiter_lines():
+                                    if not line:
+                                        if data_lines:
+                                            messages.append(json.loads("\n".join(data_lines)))
+                                            data_lines = []
+                                            if len(messages) >= max_messages:
+                                                success = True
+                                                return messages
+                                        continue
+
+                                    if line.startswith(":"):
+                                        continue
+                                    if line.startswith("data:"):
+                                        data_lines.append(line[5:].lstrip())
+
                                 if data_lines:
                                     messages.append(json.loads("\n".join(data_lines)))
-                                    data_lines = []
-                                    if len(messages) >= max_messages:
-                                        return messages
-                                continue
 
-                            if line.startswith(":"):
-                                continue
-                            if line.startswith("data:"):
-                                data_lines.append(line[5:].lstrip())
+                                if messages:
+                                    success = True
+                                    return messages[:max_messages]
 
-                        if data_lines:
-                            messages.append(json.loads("\n".join(data_lines)))
+                                raise RuntimeError(f"No SSE data received from {url}")
+                    finally:
+                        total_network_ms += _elapsed_ms(network_started_at)
 
-                        if messages:
-                            return messages[:max_messages]
+                    if retry_delay is not None:
+                        if should_rotate_proxy:
+                            self._rotate_proxy()
+                        await asyncio.sleep(retry_delay)
+                        continue
 
-                        raise RuntimeError(f"No SSE data received from {url}")
-
-                if retry_delay is not None:
-                    if should_rotate_proxy:
+                except (
+                    httpx.TimeoutException,
+                    httpx.ConnectError,
+                    httpx.ReadError,
+                    json.JSONDecodeError,
+                    RuntimeError,
+                ) as exc:
+                    last_error = exc
+                    logger.warning(
+                        "SSE read error from %s: %s (attempt %d/%d)",
+                        url, exc, attempt + 1, self._max_retries + 1,
+                    )
+                    if attempt < self._max_retries:
                         self._rotate_proxy()
-                    await asyncio.sleep(retry_delay)
-                    continue
+                        await asyncio.sleep(self._backoff_base * (2 ** attempt))
+                        continue
 
-            except (
-                httpx.TimeoutException,
-                httpx.ConnectError,
-                httpx.ReadError,
-                json.JSONDecodeError,
-                RuntimeError,
-            ) as exc:
-                last_error = exc
-                logger.warning(
-                    "SSE read error from %s: %s (attempt %d/%d)",
-                    url, exc, attempt + 1, self._max_retries + 1,
-                )
-                if attempt < self._max_retries:
-                    self._rotate_proxy()
-                    await asyncio.sleep(self._backoff_base * (2 ** attempt))
-                    continue
-
-        raise last_error or RuntimeError(f"Failed after {self._max_retries + 1} attempts")
+            raise last_error or RuntimeError(f"Failed after {self._max_retries + 1} attempts")
+        finally:
+            benchmark_recorder.record_http_request(
+                method="GET",
+                elapsed_ms=_elapsed_ms(benchmark_started_at),
+                attempts=attempts_made,
+                rate_limit_wait_ms=total_rate_limit_wait_ms,
+                network_ms=total_network_ms,
+                status_codes=status_codes,
+                error=not success,
+            )
 
     async def close(self) -> None:
         if self._client and not self._client.is_closed:

--- a/backend/app/services/event_resolver.py
+++ b/backend/app/services/event_resolver.py
@@ -5,10 +5,12 @@ from dataclasses import dataclass
 import hashlib
 import logging
 import re
+import time
 
 from rapidfuzz import fuzz
 
 from ..models.schemas import (
+    EventResolverBenchmarkOut,
     EventReviewCaseIn,
     NormalizedOdds,
     NormalizedOutcomeOffer,
@@ -68,6 +70,10 @@ _LOW_SIGNAL_TEAM_TOKENS = {
     "club",
     "team",
 }
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return int((time.perf_counter() - started_at) * 1000)
 
 
 @dataclass(frozen=True)
@@ -500,12 +506,26 @@ class EventResolutionGroup:
     evidence: tuple[str, ...]
 
 
+@dataclass
+class _EventCandidateExtractionStats:
+    football_raw_resolution_candidates_ms: int = 0
+
+
+@dataclass
+class _EventGroupBuildStats:
+    exact_group_count: int = 0
+    pair_check_count: int = 0
+    accepted_fuzzy_pair_count: int = 0
+    review_case_count: int = 0
+
+
 @dataclass(frozen=True)
 class EventResolverResult:
     candidates: int
     resolved_events: int
     resolved_event_members: int
     review_cases: int
+    benchmark: EventResolverBenchmarkOut | None = None
 
 
 def _league_source(raw_league_id: str, bookmaker_id: str) -> tuple[str, str]:
@@ -910,6 +930,7 @@ def extract_event_candidates(
     raw_outcome_offers: list[RawOutcomeOffer],
     normalized_odds: list[NormalizedOdds],
     normalized_outcome_offers: list[NormalizedOutcomeOffer],
+    stats: _EventCandidateExtractionStats | None = None,
 ) -> list[EventCandidate]:
     """Build one source-event candidate per bookmaker/match from the current scrape."""
 
@@ -963,10 +984,16 @@ def extract_event_candidates(
     stored_outcome_match_bookmakers = {
         (offer.match_id, offer.bookmaker_id) for offer in normalized_outcome_offers
     }
-    for candidate in _football_raw_resolution_candidates(
+    football_candidates_started_at = time.perf_counter()
+    football_candidates = _football_raw_resolution_candidates(
         raw_outcome_offers,
         stored_outcome_match_bookmakers,
-    ):
+    )
+    if stats is not None:
+        stats.football_raw_resolution_candidates_ms = _elapsed_ms(
+            football_candidates_started_at
+        )
+    for candidate in football_candidates:
         _merge_candidate(candidates, candidate)
 
     return sorted(
@@ -1350,8 +1377,12 @@ def _build_exact_groups(candidates: list[EventCandidate]) -> list[_CandidateGrou
 
 def build_event_resolution_groups(
     candidates: list[EventCandidate],
+    *,
+    stats: _EventGroupBuildStats | None = None,
 ) -> tuple[list[EventResolutionGroup], list[EventReviewCaseIn]]:
     exact_groups = _build_exact_groups(candidates)
+    if stats is not None:
+        stats.exact_group_count = len(exact_groups)
     dsu = _DisjointSet(exact_groups)
     accepted_pairs: list[tuple[int, int, _PairResolution]] = []
     review_cases: dict[str, EventReviewCaseIn] = {}
@@ -1378,6 +1409,8 @@ def build_event_resolution_groups(
                 # an already-merged component).
                 if dsu.find(left.index) == dsu.find(right.index):
                     continue
+                if stats is not None:
+                    stats.pair_check_count += 1
                 pair = _group_pair_resolution(left, right)
                 if pair is None:
                     continue
@@ -1385,6 +1418,8 @@ def build_event_resolution_groups(
                     if dsu.can_union(left.index, right.index):
                         dsu.union(left.index, right.index)
                         accepted_pairs.append((left.index, right.index, pair))
+                        if stats is not None:
+                            stats.accepted_fuzzy_pair_count += 1
                     elif _quorum_resolution_passes(left, right, pair):
                         dsu.union(left.index, right.index)
                         quorum_pair = _PairResolution(
@@ -1403,6 +1438,8 @@ def build_event_resolution_groups(
                             ),
                         )
                         accepted_pairs.append((left.index, right.index, quorum_pair))
+                        if stats is not None:
+                            stats.accepted_fuzzy_pair_count += 1
                         # Log the override for operator visibility instead of
                         # emitting an audit review case. The override is
                         # explicitly intended to clear pairs from the manual
@@ -1513,6 +1550,9 @@ def build_event_resolution_groups(
             )
         )
 
+    if stats is not None:
+        stats.review_case_count = len(review_cases)
+
     return (
         sorted(
             resolutions,
@@ -1613,17 +1653,47 @@ async def resolve_and_persist_events(
     normalized_odds: list[NormalizedOdds],
     normalized_outcome_offers: list[NormalizedOutcomeOffer],
 ) -> EventResolverResult:
+    extraction_stats = _EventCandidateExtractionStats()
+    extraction_started_at = time.perf_counter()
     candidates = extract_event_candidates(
         raw_odds=raw_odds,
         raw_outcome_offers=raw_outcome_offers,
         normalized_odds=normalized_odds,
         normalized_outcome_offers=normalized_outcome_offers,
+        stats=extraction_stats,
     )
-    resolutions, review_cases = build_event_resolution_groups(candidates)
+    extract_event_candidates_ms = _elapsed_ms(extraction_started_at)
+
+    group_stats = _EventGroupBuildStats()
+    grouping_started_at = time.perf_counter()
+    resolutions, review_cases = build_event_resolution_groups(
+        candidates,
+        stats=group_stats,
+    )
+    build_event_resolution_groups_ms = _elapsed_ms(grouping_started_at)
+
+    persistence_started_at = time.perf_counter()
     result = await persist_event_resolution_groups(
         resolutions,
         review_cases,
         snapshot_id=snapshot_id,
+    )
+    persist_event_resolution_groups_ms = _elapsed_ms(persistence_started_at)
+    benchmark = EventResolverBenchmarkOut(
+        extract_event_candidates_ms=extract_event_candidates_ms,
+        football_raw_resolution_candidates_ms=(
+            extraction_stats.football_raw_resolution_candidates_ms
+        ),
+        build_event_resolution_groups_ms=build_event_resolution_groups_ms,
+        persist_event_resolution_groups_ms=persist_event_resolution_groups_ms,
+        candidate_count=len(candidates),
+        exact_group_count=group_stats.exact_group_count,
+        pair_check_count=group_stats.pair_check_count,
+        accepted_fuzzy_pair_count=group_stats.accepted_fuzzy_pair_count,
+        review_case_count=group_stats.review_case_count,
+        persisted_resolved_event_count=result.resolved_events,
+        persisted_member_count=result.resolved_event_members,
+        persisted_review_case_count=result.review_cases,
     )
     logger.info(
         "Resolved %d source-event candidates into %d events (%d members, %d review cases)",
@@ -1637,4 +1707,5 @@ async def resolve_and_persist_events(
         resolved_events=result.resolved_events,
         resolved_event_members=result.resolved_event_members,
         review_cases=result.review_cases,
+        benchmark=benchmark,
     )

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -4,11 +4,13 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 import logging
 import re
+import time
 
 from rapidfuzz import fuzz
 
 from ..models.schemas import (
     NormalizedOutcomeOffer,
+    OutcomeNormalizationBenchmarkOut,
     RawOddsData,
     RawOutcomeOffer,
     TeamReviewDiagnostic,
@@ -56,6 +58,10 @@ _EXPLICIT_Z_WOMEN_MARKER_RE = re.compile(
 )
 _SAME_ORIENTATION = "same"
 _REVERSED_ORIENTATION = "reversed"
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return int((time.perf_counter() - started_at) * 1000)
 
 
 @dataclass(frozen=True)
@@ -110,6 +116,14 @@ class _OutcomeEventPair:
     @property
     def weak_side_score(self) -> float:
         return min(self.home_score, self.away_score)
+
+
+@dataclass
+class _FootballEventResolutionStats:
+    football_unique_event_count: int = 0
+    football_event_pair_ranking_ms: int = 0
+    football_event_slot_lookup_ms: int = 0
+    football_event_slot_mutation_ms: int = 0
 
 
 def _significant_tokens(name: str, *, sport: str | None = None) -> set[str]:
@@ -238,7 +252,7 @@ def _display_name_for_event(*names: str) -> str:
     )
 
 
-def _autocreate_cross_book_football_teams(raw_list: list[RawOutcomeOffer]) -> None:
+def _autocreate_cross_book_football_teams(raw_list: list[RawOutcomeOffer]) -> int:
     matchup_counts: dict[tuple[str, str, tuple[str, str]], set[str]] = defaultdict(set)
     display_names: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
 
@@ -254,6 +268,7 @@ def _autocreate_cross_book_football_teams(raw_list: list[RawOutcomeOffer]) -> No
         display_names[(raw.sport, home_key)][raw.home_team.strip()] += 1
         display_names[(raw.sport, away_key)][raw.away_team.strip()] += 1
 
+    created_count = 0
     for (sport, _start_time, team_keys), bookmaker_ids in matchup_counts.items():
         if len(bookmaker_ids) < 2:
             continue
@@ -264,6 +279,8 @@ def _autocreate_cross_book_football_teams(raw_list: list[RawOutcomeOffer]) -> No
             display_name = max(counter.items(), key=lambda item: (item[1], len(item[0]), item[0]))[0]
             if resolve_team_name(display_name, sport=sport).team_id is None:
                 create_canonical_team(display_name=display_name, sport=sport)
+                created_count += 1
+    return created_count
 
 
 def _unique_events(raw_list: list[RawOutcomeOffer]) -> list[_OutcomeEvent]:
@@ -662,16 +679,28 @@ def _rank_event_pairs(
 
 def _build_football_event_resolutions(
     raw_list: list[RawOutcomeOffer],
+    *,
+    stats: _FootballEventResolutionStats | None = None,
 ) -> dict[tuple[str, str, str, str, str], _OutcomeEventResolution]:
     events = _unique_events(raw_list)
+    if stats is not None:
+        stats.football_unique_event_count = len(events)
     resolutions: dict[tuple[str, str, str, str, str], _OutcomeEventResolution] = {}
+    lookup_started_at = time.perf_counter()
     for event in events:
         slot = _resolve_event_slot(event)
         if slot is None:
             continue
         resolutions[_event_key(event)] = _OutcomeEventResolution(slot=slot)
+    if stats is not None:
+        stats.football_event_slot_lookup_ms += _elapsed_ms(lookup_started_at)
 
-    for pair in _rank_event_pairs(events, resolutions=resolutions):
+    ranking_started_at = time.perf_counter()
+    ranked_pairs = _rank_event_pairs(events, resolutions=resolutions)
+    if stats is not None:
+        stats.football_event_pair_ranking_ms += _elapsed_ms(ranking_started_at)
+
+    for pair in ranked_pairs:
         left_key = _event_key(pair.left)
         right_key = _event_key(pair.right)
         left_resolution = resolutions.get(left_key)
@@ -683,6 +712,7 @@ def _build_football_event_resolutions(
             if pair.orientation == _REVERSED_ORIENTATION and _reversed_slots(
                 left_resolution, right_resolution
             ):
+                mutation_started_at = time.perf_counter()
                 _move_resolution_component(
                     resolutions,
                     source_resolution=right_resolution,
@@ -692,6 +722,10 @@ def _build_football_event_resolutions(
                         pair.orientation,
                     ),
                 )
+                if stats is not None:
+                    stats.football_event_slot_mutation_ms += _elapsed_ms(
+                        mutation_started_at
+                    )
                 continue
             if _pair_has_compatible_women_context(
                 pair,
@@ -701,6 +735,7 @@ def _build_football_event_resolutions(
                     right_resolution,
                 ),
             ):
+                mutation_started_at = time.perf_counter()
                 _move_resolution_component(
                     resolutions,
                     source_resolution=right_resolution,
@@ -710,6 +745,10 @@ def _build_football_event_resolutions(
                         pair.orientation,
                     ),
                 )
+                if stats is not None:
+                    stats.football_event_slot_mutation_ms += _elapsed_ms(
+                        mutation_started_at
+                    )
             continue
 
         if left_resolution is not None:
@@ -726,7 +765,10 @@ def _build_football_event_resolutions(
             )
             continue
 
+        mutation_started_at = time.perf_counter()
         slot = _create_event_slot(pair)
+        if stats is not None:
+            stats.football_event_slot_mutation_ms += _elapsed_ms(mutation_started_at)
         if slot is None:
             continue
         resolutions[left_key] = _OutcomeEventResolution(slot=slot)
@@ -868,15 +910,27 @@ def _normalized_offer_from_resolution(
     )
 
 
-def normalize_outcome_offers_with_diagnostics(
+def normalize_outcome_offers_with_benchmark(
     raw_list: list[RawOutcomeOffer],
 ) -> tuple[
     list[NormalizedOutcomeOffer],
     list[UnresolvedOddsDiagnostic],
     list[TeamReviewDiagnostic],
+    OutcomeNormalizationBenchmarkOut,
 ]:
-    _autocreate_cross_book_football_teams(raw_list)
-    event_resolutions = _build_football_event_resolutions(raw_list)
+    autocreate_started_at = time.perf_counter()
+    auto_created_team_count = _autocreate_cross_book_football_teams(raw_list)
+    auto_create_football_teams_ms = _elapsed_ms(autocreate_started_at)
+
+    football_resolution_stats = _FootballEventResolutionStats()
+    event_resolution_started_at = time.perf_counter()
+    event_resolutions = _build_football_event_resolutions(
+        raw_list,
+        stats=football_resolution_stats,
+    )
+    football_event_resolution_ms = _elapsed_ms(event_resolution_started_at)
+
+    row_normalization_started_at = time.perf_counter()
     unresolved_event_rows = [
         raw
         for raw in raw_list
@@ -973,4 +1027,40 @@ def normalize_outcome_offers_with_diagnostics(
             )
         )
 
+    benchmark = OutcomeNormalizationBenchmarkOut(
+        runs=1,
+        raw_outcome_offer_count=len(raw_list),
+        normalized_outcome_offer_count=len(normalized),
+        unresolved_outcome_offer_count=len(unresolved),
+        football_unique_event_count=(
+            football_resolution_stats.football_unique_event_count
+        ),
+        auto_created_football_team_count=auto_created_team_count,
+        auto_create_football_teams_ms=auto_create_football_teams_ms,
+        football_event_resolution_ms=football_event_resolution_ms,
+        football_event_pair_ranking_ms=(
+            football_resolution_stats.football_event_pair_ranking_ms
+        ),
+        football_event_slot_lookup_ms=(
+            football_resolution_stats.football_event_slot_lookup_ms
+        ),
+        football_event_slot_mutation_ms=(
+            football_resolution_stats.football_event_slot_mutation_ms
+        ),
+        row_normalization_ms=_elapsed_ms(row_normalization_started_at),
+    )
+
+    return normalized, unresolved, team_review_cases, benchmark
+
+
+def normalize_outcome_offers_with_diagnostics(
+    raw_list: list[RawOutcomeOffer],
+) -> tuple[
+    list[NormalizedOutcomeOffer],
+    list[UnresolvedOddsDiagnostic],
+    list[TeamReviewDiagnostic],
+]:
+    normalized, unresolved, team_review_cases, _benchmark = (
+        normalize_outcome_offers_with_benchmark(raw_list)
+    )
     return normalized, unresolved, team_review_cases

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -46,7 +46,7 @@ from ..services.event_resolver import (
     _same_time_slot_orientation,
     resolve_and_persist_events,
 )
-from ..services.outcome_normalizer import normalize_outcome_offers_with_diagnostics
+from ..services.outcome_normalizer import normalize_outcome_offers_with_benchmark
 from ..services.notifications import NotificationService, InAppNotificationProvider
 from ..services.scrape_window import (
     configured_lookahead_hours,
@@ -228,15 +228,27 @@ def _normalize_pipeline_batch(
     *,
     log_unresolved_shared_platform: bool = True,
 ) -> _NormalizedPipelineBatch:
+    threshold_started_at = time.perf_counter()
     normalized_odds, unresolved_odds, team_review_cases = normalize_odds_with_diagnostics(
         raw_odds,
         log_unresolved_shared_platform=log_unresolved_shared_platform,
     )
+    benchmark_recorder.record_phase_duration(
+        "normalize_threshold_odds",
+        int((time.perf_counter() - threshold_started_at) * 1000),
+    )
+    outcome_started_at = time.perf_counter()
     (
         normalized_outcome_offers,
         unresolved_outcome_offers,
         outcome_team_review_cases,
-    ) = normalize_outcome_offers_with_diagnostics(raw_outcome_offers)
+        outcome_benchmark,
+    ) = normalize_outcome_offers_with_benchmark(raw_outcome_offers)
+    benchmark_recorder.record_phase_duration(
+        "normalize_outcome_offers",
+        int((time.perf_counter() - outcome_started_at) * 1000),
+    )
+    benchmark_recorder.record_outcome_normalization(outcome_benchmark)
     return _NormalizedPipelineBatch(
         odds=normalized_odds,
         outcome_offers=normalized_outcome_offers,
@@ -1113,30 +1125,36 @@ class Scheduler:
         capability: ScraperCapability,
         runtime_settings: ScrapeRuntimeSettings,
     ) -> _ScrapeBatch:
-        if capability.lane == "threshold_odds":
-            if capability.league_id is None:
-                raise ValueError("threshold_odds capability is missing league_id")
-            return _ScrapeBatch(
-                capability=capability,
-                raw_odds=tuple(
-                    await self._scrape_one(
-                        scraper,
-                        capability.league_id,
-                        lookahead_hours=runtime_settings.scrape_lookahead_hours,
-                    )
-                ),
-            )
-        if capability.lane == "outcome_offer":
-            return _ScrapeBatch(
-                capability=capability,
-                raw_outcome_offers=tuple(
-                    await self._scrape_outcome_one(
-                        scraper,
-                        capability.sport,
-                        lookahead_hours=runtime_settings.scrape_lookahead_hours,
-                    )
-                ),
-            )
+        with benchmark_recorder.scrape_request_context(
+            bookmaker_id=scraper.get_bookmaker_id(),
+            lane=capability.lane,
+            sport=capability.sport,
+            league_id=capability.league_id,
+        ):
+            if capability.lane == "threshold_odds":
+                if capability.league_id is None:
+                    raise ValueError("threshold_odds capability is missing league_id")
+                return _ScrapeBatch(
+                    capability=capability,
+                    raw_odds=tuple(
+                        await self._scrape_one(
+                            scraper,
+                            capability.league_id,
+                            lookahead_hours=runtime_settings.scrape_lookahead_hours,
+                        )
+                    ),
+                )
+            if capability.lane == "outcome_offer":
+                return _ScrapeBatch(
+                    capability=capability,
+                    raw_outcome_offers=tuple(
+                        await self._scrape_outcome_one(
+                            scraper,
+                            capability.sport,
+                            lookahead_hours=runtime_settings.scrape_lookahead_hours,
+                        )
+                    ),
+                )
         raise ValueError(f"Unsupported scraper capability lane: {capability.lane}")
 
     def _apply_runtime_scraper_settings(
@@ -1194,7 +1212,10 @@ class Scheduler:
             self._scan_completed_tasks = 0
             self._scan_failed_tasks = 0
             self._scan_active_tasks = 0
-            benchmark_recorder.begin_cycle(cycle_started_at_iso)
+            benchmark_recorder.begin_cycle(
+                cycle_started_at_iso,
+                runtime_settings=runtime_settings,
+            )
             logger.info("Starting scrape cycle at %s", cycle_started_at_iso)
 
             enabled_bookmakers = set(runtime_settings.enabled_bookmakers)
@@ -1233,6 +1254,7 @@ class Scheduler:
                 item for batch in scrape_batches for item in batch.raw_outcome_offers
             ]
             scrape_duration_ms = int((time.perf_counter() - scrape_started_at) * 1000)
+            benchmark_recorder.record_phase_duration("scrape", scrape_duration_ms)
             logger.info(
                 "Scrape phase complete: %d tasks, %d raw odds items, %d raw outcome offers in %d ms",
                 len(scrape_tasks),
@@ -1242,11 +1264,16 @@ class Scheduler:
             )
 
             self._scan_phase = "registering"
+            registering_started_at = time.perf_counter()
             for scraper in scrapers:
                 await odds_store.upsert_bookmaker(
                     id=scraper.get_bookmaker_id(),
                     name=scraper.get_bookmaker_name(),
                 )
+            benchmark_recorder.record_phase_duration(
+                "register_bookmakers",
+                int((time.perf_counter() - registering_started_at) * 1000),
+            )
 
             self._scan_phase = "normalizing"
             normalized = []
@@ -1279,6 +1306,7 @@ class Scheduler:
             applied_auto_merges: list[tuple[int, int]] = []
             auto_approved_team_review_case_ids: list[int] = []
             try:
+                team_auto_resolution_started_at = time.perf_counter()
                 (
                     same_time_auto_reviews,
                     same_time_auto_merges,
@@ -1303,6 +1331,10 @@ class Scheduler:
                     applied_auto_merges = await self._apply_canonical_merges(
                         pending_auto_merges
                     )
+                benchmark_recorder.record_phase_duration(
+                    "team_auto_resolution",
+                    int((time.perf_counter() - team_auto_resolution_started_at) * 1000),
+                )
                 if auto_approved_team_reviews or applied_auto_merges:
                     full_normalized_batch = _normalize_pipeline_batch(
                         all_raw,
@@ -1326,6 +1358,7 @@ class Scheduler:
 
                 self._scan_phase = "storing"
                 cycle_scraped_at = datetime.utcnow().isoformat()
+                persist_snapshot_started_at = time.perf_counter()
                 persisted_snapshot = await odds_store.persist_scrape_snapshot_batch(
                     snapshot_at=cycle_scraped_at,
                     odds=normalized,
@@ -1342,18 +1375,33 @@ class Scheduler:
                         "auto_approved_team_review_case_ids"
                     ]
                 )
-                await resolve_and_persist_events(
+                benchmark_recorder.record_phase_duration(
+                    "persist_snapshot",
+                    int((time.perf_counter() - persist_snapshot_started_at) * 1000),
+                )
+
+                resolve_events_started_at = time.perf_counter()
+                event_resolver_result = await resolve_and_persist_events(
                     snapshot_id=snapshot_id,
                     raw_odds=all_raw,
                     raw_outcome_offers=all_raw_outcome_offers,
                     normalized_odds=event_resolution_batch.odds,
                     normalized_outcome_offers=event_resolution_batch.outcome_offers,
                 )
+                benchmark_recorder.record_phase_duration(
+                    "resolve_events",
+                    int((time.perf_counter() - resolve_events_started_at) * 1000),
+                )
+                if event_resolver_result.benchmark is not None:
+                    benchmark_recorder.record_event_resolver(
+                        event_resolver_result.benchmark
+                    )
 
                 self._scan_phase = "analyzing"
                 canonical_analysis = _CanonicalAnalysisResult()
                 canonical_analysis_failed = False
                 canonical_analysis_error: str | None = None
+                analyze_started_at = time.perf_counter()
                 try:
                     canonical_analysis = await _load_current_canonical_analysis(
                         match_ids=seen_matches,
@@ -1366,8 +1414,13 @@ class Scheduler:
                     canonical_analysis_failed = True
                     canonical_analysis_error = f"{type(exc).__name__}: {exc}"
                     logger.exception("Canonical opportunity analysis failed")
+                benchmark_recorder.record_phase_duration(
+                    "analyze_opportunities",
+                    int((time.perf_counter() - analyze_started_at) * 1000),
+                )
                 opportunities = list(canonical_analysis.opportunities)
 
+                publish_opportunities_started_at = time.perf_counter()
                 if not canonical_analysis_failed:
                     await odds_store.publish_opportunities(
                         snapshot_id=snapshot_id,
@@ -1381,6 +1434,10 @@ class Scheduler:
                         snapshot_at=cycle_scraped_at,
                         error=canonical_analysis_error,
                     )
+                benchmark_recorder.record_phase_duration(
+                    "publish_opportunities",
+                    int((time.perf_counter() - publish_opportunities_started_at) * 1000),
+                )
 
                 if canonical_analysis_failed:
                     canonical_shadow = _CanonicalShadowResult(
@@ -1401,7 +1458,12 @@ class Scheduler:
                 self._configure_notification_service_for_runtime_settings(
                     runtime_settings
                 )
+                notify_started_at = time.perf_counter()
                 notified = await self._notification_service.notify_opportunities(opportunities)
+                benchmark_recorder.record_phase_duration(
+                    "notify_opportunities",
+                    int((time.perf_counter() - notify_started_at) * 1000),
+                )
             except Exception:
                 await odds_store.rollback_pending_transaction()
                 rollback_failed = False

--- a/backend/app/services/scraper_benchmarks.py
+++ b/backend/app/services/scraper_benchmarks.py
@@ -13,14 +13,26 @@ from __future__ import annotations
 
 import json
 import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from threading import Lock
-from typing import Optional
+from typing import Iterator, Optional
 
 from ..config import settings
-from ..models.schemas import CycleBenchmarkOut, ScraperBenchmarkOut
+from ..models.schemas import (
+    BenchmarkRuntimeMetadataOut,
+    CycleBenchmarkOut,
+    EventResolverBenchmarkOut,
+    HttpTimingBenchmarkOut,
+    OutcomeNormalizationBenchmarkOut,
+    ScrapeRuntimeSettings,
+    ScraperBenchmarkOut,
+    ScraperRequestBenchmarkOut,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +52,154 @@ class _BookmakerAcc:
         self.leagues_failed: int = 0
 
 
+@dataclass(frozen=True)
+class _HttpRequestContext:
+    bookmaker_id: str
+    lane: str | None
+    sport: str | None
+    league_id: str | None
+
+
+class _HttpTimingAcc:
+    __slots__ = (
+        "logical_requests",
+        "attempts",
+        "retries",
+        "errors",
+        "total_elapsed_ms",
+        "total_rate_limit_wait_ms",
+        "total_network_ms",
+        "min_latency_ms",
+        "max_latency_ms",
+        "status_classes",
+    )
+
+    def __init__(self) -> None:
+        self.logical_requests = 0
+        self.attempts = 0
+        self.retries = 0
+        self.errors = 0
+        self.total_elapsed_ms = 0
+        self.total_rate_limit_wait_ms = 0
+        self.total_network_ms = 0
+        self.min_latency_ms: int | None = None
+        self.max_latency_ms: int | None = None
+        self.status_classes: dict[str, int] = defaultdict(int)
+
+    def record(
+        self,
+        *,
+        elapsed_ms: int,
+        attempts: int,
+        rate_limit_wait_ms: int,
+        network_ms: int,
+        status_codes: list[int],
+        error: bool,
+    ) -> None:
+        self.logical_requests += 1
+        self.attempts += int(attempts)
+        self.retries += max(0, int(attempts) - 1)
+        self.errors += 1 if error else 0
+        self.total_elapsed_ms += int(elapsed_ms)
+        self.total_rate_limit_wait_ms += int(rate_limit_wait_ms)
+        self.total_network_ms += int(network_ms)
+        if self.min_latency_ms is None or elapsed_ms < self.min_latency_ms:
+            self.min_latency_ms = int(elapsed_ms)
+        if self.max_latency_ms is None or elapsed_ms > self.max_latency_ms:
+            self.max_latency_ms = int(elapsed_ms)
+        for status_code in status_codes:
+            status_class = f"{int(status_code) // 100}xx"
+            self.status_classes[status_class] += 1
+
+    def to_model(self) -> HttpTimingBenchmarkOut:
+        avg_latency = (
+            self.total_elapsed_ms / self.logical_requests
+            if self.logical_requests
+            else 0.0
+        )
+        return HttpTimingBenchmarkOut(
+            logical_requests=self.logical_requests,
+            attempts=self.attempts,
+            retries=self.retries,
+            errors=self.errors,
+            total_elapsed_ms=self.total_elapsed_ms,
+            total_rate_limit_wait_ms=self.total_rate_limit_wait_ms,
+            total_network_ms=self.total_network_ms,
+            min_latency_ms=self.min_latency_ms,
+            avg_latency_ms=round(avg_latency, 2),
+            max_latency_ms=self.max_latency_ms,
+            status_classes=dict(sorted(self.status_classes.items())),
+        )
+
+
+_HTTP_REQUEST_CONTEXT: ContextVar[_HttpRequestContext | None] = ContextVar(
+    "scraper_benchmark_http_request_context", default=None
+)
+
+
+def _runtime_metadata(
+    runtime_settings: ScrapeRuntimeSettings,
+) -> BenchmarkRuntimeMetadataOut:
+    proxy_count = len(settings.proxy_url_list)
+    return BenchmarkRuntimeMetadataOut(
+        scraper_mode=settings.scraper_mode,
+        enabled_bookmakers=list(runtime_settings.enabled_bookmakers),
+        enabled_sports=list(runtime_settings.enabled_sports),
+        scrape_market_scope=runtime_settings.scrape_market_scope,
+        analysis_markets=list(runtime_settings.analysis_markets),
+        scrape_lookahead_hours=runtime_settings.scrape_lookahead_hours,
+        rate_limit_per_second=runtime_settings.rate_limit_per_second,
+        meridian_rate_limit_per_second=runtime_settings.meridian_rate_limit_per_second,
+        detail_modes={
+            "soccerbet": runtime_settings.soccerbet_detail_mode,
+            "merkurxtip": runtime_settings.merkurxtip_detail_mode,
+            "pinnbet": runtime_settings.pinnbet_detail_mode,
+        },
+        proxies_configured=proxy_count > 0,
+        proxy_count=proxy_count,
+    )
+
+
+def _merge_outcome_metrics(
+    current: OutcomeNormalizationBenchmarkOut,
+    update: OutcomeNormalizationBenchmarkOut,
+) -> OutcomeNormalizationBenchmarkOut:
+    return OutcomeNormalizationBenchmarkOut(
+        runs=current.runs + update.runs,
+        raw_outcome_offer_count=update.raw_outcome_offer_count,
+        normalized_outcome_offer_count=update.normalized_outcome_offer_count,
+        unresolved_outcome_offer_count=update.unresolved_outcome_offer_count,
+        football_unique_event_count=update.football_unique_event_count,
+        auto_created_football_team_count=(
+            current.auto_created_football_team_count
+            + update.auto_created_football_team_count
+        ),
+        auto_create_football_teams_ms=(
+            current.auto_create_football_teams_ms
+            + update.auto_create_football_teams_ms
+        ),
+        football_event_resolution_ms=(
+            current.football_event_resolution_ms
+            + update.football_event_resolution_ms
+        ),
+        football_event_pair_ranking_ms=(
+            current.football_event_pair_ranking_ms
+            + update.football_event_pair_ranking_ms
+        ),
+        football_event_slot_lookup_ms=(
+            current.football_event_slot_lookup_ms
+            + update.football_event_slot_lookup_ms
+        ),
+        football_event_slot_mutation_ms=(
+            current.football_event_slot_mutation_ms
+            + update.football_event_slot_mutation_ms
+        ),
+        row_normalization_ms=(
+            current.row_normalization_ms + update.row_normalization_ms
+        ),
+    )
+
+
 class CycleBenchmarkRecorder:
     """Accumulates per-scraper stats for one in-flight cycle, then publishes."""
 
@@ -50,15 +210,34 @@ class CycleBenchmarkRecorder:
 
     def _reset(self) -> None:
         self._cycle_started_at: Optional[str] = None
+        self._metadata: BenchmarkRuntimeMetadataOut | None = None
         self._scrape_duration_ms: int = 0
         self._cycle_duration_ms: int = 0
         self._buckets: dict[str, _BookmakerAcc] = defaultdict(_BookmakerAcc)
+        self._http_by_bookmaker: dict[str, _HttpTimingAcc] = defaultdict(_HttpTimingAcc)
+        self._http_by_request: dict[
+            tuple[str, str | None, str | None, str | None, str],
+            _HttpTimingAcc,
+        ] = defaultdict(_HttpTimingAcc)
+        self._phase_durations_ms: dict[str, int] = {}
+        self._outcome_normalization = OutcomeNormalizationBenchmarkOut()
+        self._event_resolver = EventResolverBenchmarkOut()
 
     # ---- accumulation ---------------------------------------------------
-    def begin_cycle(self, cycle_started_at: str) -> None:
+    def begin_cycle(
+        self,
+        cycle_started_at: str,
+        *,
+        runtime_settings: ScrapeRuntimeSettings | None = None,
+    ) -> None:
         with self._lock:
             self._reset()
             self._cycle_started_at = cycle_started_at
+            self._metadata = (
+                _runtime_metadata(runtime_settings)
+                if runtime_settings is not None
+                else None
+            )
 
     def record_scrape_task(
         self,
@@ -83,6 +262,87 @@ class CycleBenchmarkRecorder:
             self._scrape_duration_ms = int(scrape_duration_ms)
             self._cycle_duration_ms = int(cycle_duration_ms)
 
+    def record_phase_duration(self, phase_name: str, duration_ms: int) -> None:
+        with self._lock:
+            self._phase_durations_ms[phase_name] = (
+                self._phase_durations_ms.get(phase_name, 0) + int(duration_ms)
+            )
+
+    def record_outcome_normalization(
+        self, metrics: OutcomeNormalizationBenchmarkOut
+    ) -> None:
+        with self._lock:
+            self._outcome_normalization = _merge_outcome_metrics(
+                self._outcome_normalization,
+                metrics,
+            )
+
+    def record_event_resolver(self, metrics: EventResolverBenchmarkOut) -> None:
+        with self._lock:
+            self._event_resolver = metrics
+
+    @contextmanager
+    def scrape_request_context(
+        self,
+        *,
+        bookmaker_id: str,
+        lane: str | None,
+        sport: str | None,
+        league_id: str | None,
+    ) -> Iterator[None]:
+        token = _HTTP_REQUEST_CONTEXT.set(
+            _HttpRequestContext(
+                bookmaker_id=bookmaker_id,
+                lane=lane,
+                sport=sport,
+                league_id=league_id,
+            )
+        )
+        try:
+            yield
+        finally:
+            _HTTP_REQUEST_CONTEXT.reset(token)
+
+    def record_http_request(
+        self,
+        *,
+        method: str,
+        elapsed_ms: int,
+        attempts: int,
+        rate_limit_wait_ms: int,
+        network_ms: int,
+        status_codes: list[int],
+        error: bool,
+    ) -> None:
+        context = _HTTP_REQUEST_CONTEXT.get()
+        if context is None:
+            return
+        normalized_method = method.upper()
+        with self._lock:
+            self._http_by_bookmaker[context.bookmaker_id].record(
+                elapsed_ms=elapsed_ms,
+                attempts=attempts,
+                rate_limit_wait_ms=rate_limit_wait_ms,
+                network_ms=network_ms,
+                status_codes=status_codes,
+                error=error,
+            )
+            request_key = (
+                context.bookmaker_id,
+                context.lane,
+                context.sport,
+                context.league_id,
+                normalized_method,
+            )
+            self._http_by_request[request_key].record(
+                elapsed_ms=elapsed_ms,
+                attempts=attempts,
+                rate_limit_wait_ms=rate_limit_wait_ms,
+                network_ms=network_ms,
+                status_codes=status_codes,
+                error=error,
+            )
+
     # ---- publish --------------------------------------------------------
     def publish(
         self,
@@ -101,9 +361,41 @@ class CycleBenchmarkRecorder:
         with self._lock:
             cycle_finished_at = datetime.utcnow().isoformat()
             scrapers: list[ScraperBenchmarkOut] = []
-            all_keys = set(self._buckets) | set(matches_per_bookmaker) | set(odds_per_bookmaker)
+            all_keys = (
+                set(self._buckets)
+                | set(matches_per_bookmaker)
+                | set(odds_per_bookmaker)
+                | set(self._http_by_bookmaker)
+            )
             for bm in sorted(all_keys):
                 acc = self._buckets.get(bm) or _BookmakerAcc()
+                request_rows = [
+                    ScraperRequestBenchmarkOut(
+                        lane=lane,
+                        sport=sport,
+                        league_id=league_id,
+                        method=method,
+                        **http_acc.to_model().model_dump(),
+                    )
+                    for (
+                        request_bookmaker_id,
+                        lane,
+                        sport,
+                        league_id,
+                        method,
+                    ),
+                    http_acc in sorted(
+                        self._http_by_request.items(),
+                        key=lambda item: (
+                            item[0][0],
+                            item[0][1] or "",
+                            item[0][2] or "",
+                            item[0][3] or "",
+                            item[0][4],
+                        ),
+                    )
+                    if request_bookmaker_id == bm
+                ]
                 attempted = acc.leagues_attempted
                 failure_rate = (
                     (acc.leagues_failed / attempted) if attempted > 0 else 0.0
@@ -120,6 +412,8 @@ class CycleBenchmarkRecorder:
                         leagues_attempted=attempted,
                         leagues_failed=acc.leagues_failed,
                         failure_rate=round(failure_rate, 4),
+                        http=self._http_by_bookmaker[bm].to_model(),
+                        requests=request_rows,
                     )
                 )
 
@@ -131,6 +425,10 @@ class CycleBenchmarkRecorder:
                 total_raw_items=sum(s.raw_items for s in scrapers),
                 total_matches=int(total_unique_matches),
                 total_odds=sum(s.odds_count for s in scrapers),
+                metadata=self._metadata,
+                phase_durations_ms=dict(sorted(self._phase_durations_ms.items())),
+                outcome_normalization=self._outcome_normalization,
+                event_resolver=self._event_resolver,
                 scrapers=scrapers,
             )
             self._latest = snapshot

--- a/backend/tests/test_http_client.py
+++ b/backend/tests/test_http_client.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from app.scrapers.http_client import HttpClient
+from app.services import scraper_benchmarks
 
 
 class MockTransport(httpx.AsyncBaseTransport):
@@ -50,6 +51,53 @@ async def test_get_json_success():
     client._client = httpx.AsyncClient(transport=MockTransport())
     result = await client.get_json("https://example.com/api", params={"key": "value"})
     assert result == {"ok": True}
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_json_records_benchmark_http_timing_when_context_is_set():
+    transport = MockTransport(
+        responses=[
+            httpx.Response(429, json={"error": "rate limited"}),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    client = HttpClient(max_retries=1, backoff_base=0.01, rate_limit_per_second=0)
+    client._client = httpx.AsyncClient(transport=transport)
+    scraper_benchmarks.recorder.begin_cycle("2026-05-06T12:00:00")
+    scraper_benchmarks.recorder.record_scrape_task(
+        bookmaker_id="365",
+        duration_ms=20,
+        raw_items=1,
+        failed=False,
+    )
+
+    with scraper_benchmarks.recorder.scrape_request_context(
+        bookmaker_id="365",
+        lane="outcome_offer",
+        sport="football",
+        league_id=None,
+    ):
+        result = await client.get_json("https://example.com/api")
+
+    scraper_benchmarks.recorder.record_phase_durations(
+        scrape_duration_ms=20,
+        cycle_duration_ms=25,
+    )
+    snapshot = scraper_benchmarks.recorder.publish(
+        matches_per_bookmaker={"365": 1},
+        odds_per_bookmaker={"365": 1},
+        total_unique_matches=1,
+    )
+
+    assert result == {"ok": True}
+    scraper_row = snapshot.scrapers[0]
+    assert scraper_row.http.logical_requests == 1
+    assert scraper_row.http.attempts == 2
+    assert scraper_row.http.retries == 1
+    assert scraper_row.http.errors == 0
+    assert scraper_row.http.status_classes == {"2xx": 1, "4xx": 1}
+    assert scraper_row.requests[0].total_network_ms >= 0
     await client.close()
 
 
@@ -272,6 +320,42 @@ async def test_get_sse_json_reads_first_json_message():
     result = await client.get_sse_json("https://example.test/stream")
 
     assert result == [[{"event_id": 1}]]
+
+
+@pytest.mark.asyncio
+async def test_get_sse_json_records_invalid_argument_benchmark_error():
+    client = HttpClient(max_retries=0)
+    scraper_benchmarks.recorder.begin_cycle("2026-05-06T12:00:00")
+    scraper_benchmarks.recorder.record_scrape_task(
+        bookmaker_id="superbet",
+        duration_ms=1,
+        raw_items=0,
+        failed=True,
+    )
+
+    with scraper_benchmarks.recorder.scrape_request_context(
+        bookmaker_id="superbet",
+        lane="outcome_offer",
+        sport="football",
+        league_id=None,
+    ):
+        with pytest.raises(ValueError, match="max_messages must be positive"):
+            await client.get_sse_json("https://example.test/stream", max_messages=0)
+
+    scraper_benchmarks.recorder.record_phase_durations(
+        scrape_duration_ms=1,
+        cycle_duration_ms=1,
+    )
+    snapshot = scraper_benchmarks.recorder.publish(
+        matches_per_bookmaker={"superbet": 0},
+        odds_per_bookmaker={"superbet": 0},
+        total_unique_matches=0,
+    )
+
+    scraper_row = snapshot.scrapers[0]
+    assert scraper_row.http.logical_requests == 1
+    assert scraper_row.http.attempts == 0
+    assert scraper_row.http.errors == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scraper_benchmarks.py
+++ b/backend/tests/test_scraper_benchmarks.py
@@ -9,6 +9,7 @@ from httpx import ASGITransport, AsyncClient
 from app.config import settings
 from app.database import close_db, init_db
 from app.main import app
+from app.models.schemas import ScrapeRuntimeSettings
 from app.scrapers.mock_scraper import MockScraper
 from app.scrapers.registry import registry
 from app.services import scraper_benchmarks
@@ -55,6 +56,23 @@ async def test_benchmarks_published_after_cycle(client: AsyncClient, tmp_path):
     assert body["cycle_finished_at"] is not None
     assert body["scrape_duration_ms"] >= 0
     assert body["cycle_duration_ms"] >= 0
+    assert body["metadata"]["scraper_mode"] == settings.scraper_mode
+    assert set(body["metadata"]["enabled_bookmakers"]) == {"mozzart", "meridian"}
+    assert body["metadata"]["proxy_count"] == 0
+    assert body["metadata"]["proxies_configured"] is False
+    assert body["metadata"]["detail_modes"] == {
+        "merkurxtip": settings.merkurxtip_detail_mode,
+        "pinnbet": settings.pinnbet_detail_mode,
+        "soccerbet": settings.soccerbet_detail_mode,
+    }
+    assert "scrape" in body["phase_durations_ms"]
+    assert "normalize_threshold_odds" in body["phase_durations_ms"]
+    assert "normalize_outcome_offers" in body["phase_durations_ms"]
+    assert "persist_snapshot" in body["phase_durations_ms"]
+    assert "resolve_events" in body["phase_durations_ms"]
+    assert body["outcome_normalization"]["runs"] >= 1
+    assert body["outcome_normalization"]["raw_outcome_offer_count"] >= 0
+    assert body["event_resolver"]["candidate_count"] >= 0
 
     bm_ids = {s["bookmaker_id"] for s in body["scrapers"]}
     assert {"mozzart", "meridian"}.issubset(bm_ids)
@@ -64,6 +82,8 @@ async def test_benchmarks_published_after_cycle(client: AsyncClient, tmp_path):
         assert entry["matches_after_normalization"] >= 0
         assert entry["odds_count"] >= 0
         assert 0.0 <= entry["failure_rate"] <= 1.0
+        assert entry["http"]["logical_requests"] >= 0
+        assert isinstance(entry["requests"], list)
 
     # Files written
     out_dir = Path(settings.benchmark_dir)
@@ -76,6 +96,10 @@ async def test_benchmarks_published_after_cycle(client: AsyncClient, tmp_path):
     assert len(ndjson) == 1
     parsed = json.loads(ndjson[0])
     assert parsed["scrapers"]
+    assert parsed["metadata"]["enabled_bookmakers"]
+    assert parsed["phase_durations_ms"]
+    assert "outcome_normalization" in parsed
+    assert "event_resolver" in parsed
 
 
 @pytest.mark.asyncio
@@ -113,3 +137,85 @@ async def test_failed_scraper_increments_failure_rate(monkeypatch, client: Async
     assert by_bm["mozzart"]["failure_rate"] == 0.5
     assert by_bm["meridian"]["raw_items"] == 0
     assert by_bm["mozzart"]["raw_items"] > 0
+
+
+def test_http_request_aggregates_and_metadata_are_persisted_without_secrets(
+    monkeypatch,
+    tmp_path,
+):
+    secret_proxy = "http://user:secret-password@example.test:8080"
+    monkeypatch.setattr(settings, "proxy_list", secret_proxy)
+    runtime_settings = ScrapeRuntimeSettings(
+        enabled_bookmakers=["betole"],
+        enabled_sports=["football"],
+        scrape_market_scope="all",
+        analysis_markets=["football:football_result"],
+        scrape_lookahead_hours=36,
+        scrape_interval_minutes=10,
+        max_middle_opportunities_per_market=10,
+        rate_limit_per_second=1.0,
+        meridian_rate_limit_per_second=2.0,
+        soccerbet_detail_mode="partial",
+        merkurxtip_detail_mode="full",
+        pinnbet_detail_mode="partial",
+        notification_gap_threshold=1.5,
+        persist_inapp_notifications=False,
+    )
+
+    scraper_benchmarks.recorder.begin_cycle(
+        "2026-05-06T12:00:00",
+        runtime_settings=runtime_settings,
+    )
+    scraper_benchmarks.recorder.record_scrape_task(
+        bookmaker_id="betole",
+        duration_ms=50,
+        raw_items=12,
+        failed=False,
+    )
+    with scraper_benchmarks.recorder.scrape_request_context(
+        bookmaker_id="betole",
+        lane="outcome_offer",
+        sport="football",
+        league_id=None,
+    ):
+        scraper_benchmarks.recorder.record_http_request(
+            method="GET",
+            elapsed_ms=120,
+            attempts=2,
+            rate_limit_wait_ms=35,
+            network_ms=70,
+            status_codes=[429, 200],
+            error=False,
+        )
+    scraper_benchmarks.recorder.record_phase_durations(
+        scrape_duration_ms=50,
+        cycle_duration_ms=80,
+    )
+
+    snapshot = scraper_benchmarks.recorder.publish(
+        matches_per_bookmaker={"betole": 3},
+        odds_per_bookmaker={"betole": 12},
+        total_unique_matches=3,
+    )
+
+    assert snapshot.metadata is not None
+    assert snapshot.metadata.proxies_configured is True
+    assert snapshot.metadata.proxy_count == 1
+    assert snapshot.metadata.analysis_markets == ["football:football_result"]
+    scraper_row = snapshot.scrapers[0]
+    assert scraper_row.http.logical_requests == 1
+    assert scraper_row.http.attempts == 2
+    assert scraper_row.http.retries == 1
+    assert scraper_row.http.total_rate_limit_wait_ms == 35
+    assert scraper_row.http.total_network_ms == 70
+    assert scraper_row.http.status_classes == {"2xx": 1, "4xx": 1}
+    assert len(scraper_row.requests) == 1
+    request_row = scraper_row.requests[0]
+    assert request_row.lane == "outcome_offer"
+    assert request_row.sport == "football"
+    assert request_row.method == "GET"
+
+    out_dir = Path(settings.benchmark_dir)
+    persisted = "\n".join(path.read_text() for path in out_dir.glob("*"))
+    assert "secret-password" not in persisted
+    assert secret_proxy not in persisted


### PR DESCRIPTION
Closes #94.\n\n## Summary\n- add benchmark runtime metadata with secret-safe proxy presence/count\n- add HTTP timing aggregates split into rate-limit wait vs network time\n- add outcome-normalization and event-resolver subphase metrics\n- persist the new fields through the existing benchmark API, JSON snapshots, and NDJSON history\n\n## Verification\n- cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q\n- git --no-pager diff --check