### PR TITLE
Add scraper rate-limit policies

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,12 +33,19 @@ SCRAPER_MODE=mock
 # HTTP controls for real scraper mode. PROXY_LIST is comma-separated.
 RATE_LIMIT_PER_SECOND=1.0
 MERIDIAN_RATE_LIMIT_PER_SECOND=2.0
+# Optional rate caps. Examples:
+# BOOKMAKER_RATE_LIMITS=betole:0.5,365:1
+# SCRAPE_TYPE_RATE_LIMITS=betole:outcome_offer:full:0.5
+BOOKMAKER_RATE_LIMITS=
+SCRAPE_TYPE_RATE_LIMITS=
 PROXY_LIST=
 
 # Detail modes:
 # partial = broad/list feeds only; full = extra per-match detail calls when supported.
 SOCCERBET_DETAIL_MODE=partial
 MERKURXTIP_DETAIL_MODE=partial
+PINNBET_DETAIL_MODE=partial
+BETOLE_DETAIL_MODE=partial
 
 # Notification and retention settings.
 NOTIFICATION_GAP_THRESHOLD=1.5

--- a/backend/README.md
+++ b/backend/README.md
@@ -84,8 +84,12 @@ Settings are loaded from environment variables and `backend/.env`. Copy `backend
 | `PROXY_LIST` | empty | Comma-separated proxy URLs distributed to real scraper HTTP clients. |
 | `RATE_LIMIT_PER_SECOND` | `1.0` | Default per-scraper HTTP rate limit in real mode. |
 | `MERIDIAN_RATE_LIMIT_PER_SECOND` | `2.0` | Meridian-specific HTTP rate limit override. |
+| `BOOKMAKER_RATE_LIMITS` | empty | Optional comma/semicolon-separated caps in `<bookmaker>:<rate>` form, e.g. `betole:0.5,365:1`. Caps never raise a scraper above its default global/Meridian rate. |
+| `SCRAPE_TYPE_RATE_LIMITS` | empty | Optional comma/semicolon-separated caps in `<bookmaker>:<lane>:<rate>` or `<bookmaker>:<lane>:<detail_mode>:<rate>` form, e.g. `betole:outcome_offer:full:0.5`. |
 | `SOCCERBET_DETAIL_MODE` | `partial` | `partial` uses broad preview feeds; `full` adds match-by-code enrichment. |
 | `MERKURXTIP_DETAIL_MODE` | `partial` | `partial` uses list feeds; `full` adds match detail for alternate totals. |
+| `PINNBET_DETAIL_MODE` | `partial` | `partial` uses football list data; `full` adds per-event football detail. |
+| `BETOLE_DETAIL_MODE` | `partial` | `partial` uses football list data; `full` adds per-event football detail for double chance. |
 | `NOTIFICATION_GAP_THRESHOLD` | `1.5` | Minimum opportunity gap/margin threshold used by notification logic. |
 | `PERSIST_INAPP_NOTIFICATIONS` | `false` | Persist generated in-app notifications when enabled. |
 | `NOTIFICATION_RETENTION_DAYS` | `3` | Retention window for persisted notifications. |
@@ -124,6 +128,7 @@ Use this only when you intend to call live bookmaker endpoints. Each bookmaker h
 - The scheduler runs scraper tasks concurrently at the top level, so slow bookmakers do not stall the whole scrape phase.
 - In `real` mode, each scraper gets its own `HttpClient`, so HTTP rate limiting is isolated per bookmaker instead of shared globally.
 - Meridian is temporarily excluded from the default `BOOKMAKERS` list because its market-detail endpoint is often blocked by upstream Cloudflare protection. It can still be explicitly enabled with `BOOKMAKERS=...meridian...`; use `MERIDIAN_RATE_LIMIT_PER_SECOND` if Meridian needs a higher cap without changing other bookmakers.
+- `BOOKMAKER_RATE_LIMITS` and `SCRAPE_TYPE_RATE_LIMITS` are backend-only caps for isolating expensive paths without raising defaults. Scrape-type caps take precedence over bookmaker caps; detail-specific caps such as `betole:outcome_offer:full:0.5` apply only when that scraper is in the matching detail mode.
 - The API starts immediately and the initial scrape runs in the scheduler background loop instead of blocking app startup.
 - `GET /api/v1/status` includes live scan progress metadata while a cycle is running, so the frontend can show warmup/progress state instead of timing out on first load.
 - `POST /api/v1/scrape/trigger` rejects with `409` while a scan is already running, so callers do not queue duplicate full cycles behind the background scheduler.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,11 @@ class Settings(BaseSettings):
     proxy_list: str = ""
     rate_limit_per_second: float = 1.0
     meridian_rate_limit_per_second: float = 2.0
+    # Comma/semicolon-separated '<bookmaker>:<rate>' caps.
+    bookmaker_rate_limits: str = ""
+    # Comma/semicolon-separated '<bookmaker>:<lane>:<rate>' or
+    # '<bookmaker>:<lane>:<detail_mode>:<rate>' caps.
+    scrape_type_rate_limits: str = ""
     # partial = preview feeds only; full = preview feeds plus match-by-code enrichment.
     soccerbet_detail_mode: Literal["partial", "full"] = "partial"
     # partial = list feeds only; full = list feeds plus match detail for alternate totals.

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -535,6 +535,8 @@ class BenchmarkRuntimeMetadataOut(BaseModel):
     scrape_lookahead_hours: int = 0
     rate_limit_per_second: float = 0
     meridian_rate_limit_per_second: float = 0
+    bookmaker_rate_limits: dict[str, float] = Field(default_factory=dict)
+    scrape_type_rate_limits: dict[str, float] = Field(default_factory=dict)
     detail_modes: dict[str, ScraperDetailMode] = Field(default_factory=dict)
     proxies_configured: bool = False
     proxy_count: int = 0

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from typing import Literal
 
@@ -82,6 +83,12 @@ class BaseScraper(abc.ABC):
         http_client = getattr(self, "_http", None)
         if http_client is not None and hasattr(http_client, "rate_limit_per_second"):
             http_client.rate_limit_per_second = rate_limit_per_second
+
+    def runtime_rate_limit(self, rate_limit_per_second: float) -> AbstractContextManager[None]:
+        http_client = getattr(self, "_http", None)
+        if http_client is not None and hasattr(http_client, "use_rate_limit"):
+            return http_client.use_rate_limit(rate_limit_per_second)
+        return nullcontext()
 
     def set_runtime_detail_mode(self, detail_mode: Literal["partial", "full"]) -> None:
         if hasattr(self, "_detail_mode"):

--- a/backend/app/scrapers/http_client.py
+++ b/backend/app/scrapers/http_client.py
@@ -4,6 +4,9 @@ import asyncio
 import json
 import logging
 import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from collections.abc import Iterator
 from typing import Any
 
 import httpx
@@ -44,17 +47,36 @@ class HttpClient:
         self._default_headers = default_headers or {}
         self._last_request_time: float = 0.0
         self._rate_limit_lock: asyncio.Lock | None = None
+        self._rate_limit_override: ContextVar[float | None] = ContextVar(
+            f"http_client_rate_limit_override_{id(self)}",
+            default=None,
+        )
         self._client: httpx.AsyncClient | None = None
 
     @property
     def rate_limit_per_second(self) -> float:
-        if self._min_interval <= 0:
+        min_interval = self._effective_min_interval()
+        if min_interval <= 0:
             return 0.0
-        return 1.0 / self._min_interval
+        return 1.0 / min_interval
 
     @rate_limit_per_second.setter
     def rate_limit_per_second(self, value: float) -> None:
         self._min_interval = 1.0 / value if value > 0 else 0
+
+    @contextmanager
+    def use_rate_limit(self, rate_limit_per_second: float) -> Iterator[None]:
+        token = self._rate_limit_override.set(rate_limit_per_second)
+        try:
+            yield
+        finally:
+            self._rate_limit_override.reset(token)
+
+    def _effective_min_interval(self) -> float:
+        override = self._rate_limit_override.get()
+        if override is not None:
+            return 1.0 / override if override > 0 else 0
+        return self._min_interval
 
     async def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
@@ -80,14 +102,15 @@ class HttpClient:
 
     async def _acquire_request_slot(self) -> int:
         started_at = time.perf_counter()
-        if self._min_interval <= 0:
+        min_interval = self._effective_min_interval()
+        if min_interval <= 0:
             return 0
         if self._rate_limit_lock is None:
             self._rate_limit_lock = asyncio.Lock()
         async with self._rate_limit_lock:
             elapsed = time.monotonic() - self._last_request_time
-            if elapsed < self._min_interval:
-                await asyncio.sleep(self._min_interval - elapsed)
+            if elapsed < min_interval:
+                await asyncio.sleep(min_interval - elapsed)
             self._last_request_time = time.monotonic()
         return _elapsed_ms(started_at)
 

--- a/backend/app/services/rate_limit_policy.py
+++ b/backend/app/services/rate_limit_policy.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Literal
+
+from ..config import settings
+
+ScrapeLane = Literal["threshold_odds", "outcome_offer"]
+DetailMode = Literal["partial", "full"]
+
+_RATE_LIMIT_PER_SECOND_MAX = 20.0
+_ENTRY_SPLIT_RE = re.compile(r"[,;]")
+_VALID_LANES = {"threshold_odds", "outcome_offer"}
+_VALID_DETAIL_MODES = {"partial", "full", "*"}
+
+
+class RateLimitPolicyError(ValueError):
+    """Raised when configured rate-limit policy strings cannot be parsed."""
+
+
+@dataclass(frozen=True)
+class ScrapeTypeRateLimit:
+    bookmaker_id: str
+    lane: ScrapeLane
+    detail_mode: DetailMode | None
+    rate_limit_per_second: float
+
+    @property
+    def key(self) -> str:
+        detail = self.detail_mode if self.detail_mode is not None else "*"
+        return f"{self.bookmaker_id}:{self.lane}:{detail}"
+
+
+@dataclass(frozen=True)
+class RateLimitPolicy:
+    bookmaker_rate_limits: dict[str, float]
+    scrape_type_rate_limits: tuple[ScrapeTypeRateLimit, ...]
+
+    @classmethod
+    def from_settings(cls) -> "RateLimitPolicy":
+        return cls(
+            bookmaker_rate_limits=parse_bookmaker_rate_limits(settings.bookmaker_rate_limits),
+            scrape_type_rate_limits=parse_scrape_type_rate_limits(settings.scrape_type_rate_limits),
+        )
+
+    def effective_rate_limit(
+        self,
+        *,
+        bookmaker_id: str,
+        lane: ScrapeLane,
+        detail_mode: DetailMode | None,
+        global_rate_limit_per_second: float,
+        meridian_rate_limit_per_second: float,
+    ) -> float:
+        normalized_bookmaker_id = _normalize_bookmaker_id(bookmaker_id)
+        baseline = (
+            meridian_rate_limit_per_second
+            if normalized_bookmaker_id == "meridian"
+            else global_rate_limit_per_second
+        )
+
+        scrape_type_cap = self._scrape_type_cap(
+            bookmaker_id=normalized_bookmaker_id,
+            lane=lane,
+            detail_mode=detail_mode,
+        )
+        if scrape_type_cap is not None:
+            return min(scrape_type_cap, baseline)
+
+        bookmaker_cap = self.bookmaker_rate_limits.get(normalized_bookmaker_id)
+        if bookmaker_cap is not None:
+            return min(bookmaker_cap, baseline)
+
+        return baseline
+
+    def metadata_bookmaker_rate_limits(self) -> dict[str, float]:
+        return dict(sorted(self.bookmaker_rate_limits.items()))
+
+    def metadata_scrape_type_rate_limits(self) -> dict[str, float]:
+        return {
+            policy.key: policy.rate_limit_per_second
+            for policy in sorted(
+                self.scrape_type_rate_limits,
+                key=lambda item: item.key,
+            )
+        }
+
+    def _scrape_type_cap(
+        self,
+        *,
+        bookmaker_id: str,
+        lane: ScrapeLane,
+        detail_mode: DetailMode | None,
+    ) -> float | None:
+        wildcard_match: float | None = None
+        for policy in self.scrape_type_rate_limits:
+            if policy.bookmaker_id != bookmaker_id or policy.lane != lane:
+                continue
+            if policy.detail_mode is None:
+                wildcard_match = policy.rate_limit_per_second
+                continue
+            if policy.detail_mode == detail_mode:
+                return policy.rate_limit_per_second
+        return wildcard_match
+
+
+def parse_bookmaker_rate_limits(raw: str) -> dict[str, float]:
+    result: dict[str, float] = {}
+    for entry in _split_entries(raw):
+        parts = _split_policy_parts(entry)
+        if len(parts) != 2:
+            raise RateLimitPolicyError(
+                "Bookmaker rate limits must use '<bookmaker>:<rate>' entries"
+            )
+        bookmaker_id, raw_rate = parts
+        normalized_bookmaker_id = _normalize_bookmaker_id(bookmaker_id)
+        if normalized_bookmaker_id in result:
+            raise RateLimitPolicyError(f"Duplicate bookmaker rate policy: {entry}")
+        result[normalized_bookmaker_id] = _parse_rate(raw_rate, entry)
+    return result
+
+
+def parse_scrape_type_rate_limits(raw: str) -> tuple[ScrapeTypeRateLimit, ...]:
+    result: list[ScrapeTypeRateLimit] = []
+    seen: set[tuple[str, ScrapeLane, DetailMode | None]] = set()
+    for entry in _split_entries(raw):
+        parts = _split_policy_parts(entry)
+        if len(parts) == 3:
+            bookmaker_id, raw_lane, raw_rate = parts
+            raw_detail_mode = "*"
+        elif len(parts) == 4:
+            bookmaker_id, raw_lane, raw_detail_mode, raw_rate = parts
+        else:
+            raise RateLimitPolicyError(
+                (
+                    "Scrape-type rate limits must use '<bookmaker>:<lane>:<rate>' "
+                    "or '<bookmaker>:<lane>:<detail_mode>:<rate>' entries"
+                )
+            )
+
+        lane = _parse_lane(raw_lane, entry)
+        detail_mode = _parse_detail_mode(raw_detail_mode, entry)
+        key = (_normalize_bookmaker_id(bookmaker_id), lane, detail_mode)
+        if key in seen:
+            raise RateLimitPolicyError(f"Duplicate scrape-type rate policy: {entry}")
+        seen.add(key)
+        result.append(
+            ScrapeTypeRateLimit(
+                bookmaker_id=key[0],
+                lane=lane,
+                detail_mode=detail_mode,
+                rate_limit_per_second=_parse_rate(raw_rate, entry),
+            )
+        )
+    return tuple(result)
+
+
+def _split_entries(raw: str) -> list[str]:
+    return [entry.strip() for entry in _ENTRY_SPLIT_RE.split(raw or "") if entry.strip()]
+
+
+def _split_policy_parts(entry: str) -> list[str]:
+    return [part.strip() for part in entry.split(":")]
+
+
+def _normalize_bookmaker_id(bookmaker_id: str) -> str:
+    normalized = bookmaker_id.strip().lower()
+    if not normalized:
+        raise RateLimitPolicyError("Rate-limit policy bookmaker id cannot be empty")
+    return normalized
+
+
+def _parse_lane(raw_lane: str, entry: str) -> ScrapeLane:
+    lane = raw_lane.strip().lower()
+    if lane not in _VALID_LANES:
+        raise RateLimitPolicyError(f"Invalid scrape lane in rate policy '{entry}'")
+    return lane  # type: ignore[return-value]
+
+
+def _parse_detail_mode(raw_detail_mode: str, entry: str) -> DetailMode | None:
+    detail_mode = raw_detail_mode.strip().lower()
+    if detail_mode not in _VALID_DETAIL_MODES:
+        raise RateLimitPolicyError(f"Invalid detail mode in rate policy '{entry}'")
+    if detail_mode == "*":
+        return None
+    return detail_mode  # type: ignore[return-value]
+
+
+def _parse_rate(raw_rate: str, entry: str) -> float:
+    try:
+        rate = float(raw_rate)
+    except ValueError as exc:
+        raise RateLimitPolicyError(f"Invalid rate value in rate policy '{entry}'") from exc
+    if rate < 0 or rate > _RATE_LIMIT_PER_SECOND_MAX:
+        raise RateLimitPolicyError(
+            (
+                "Rate-limit policy values must be between "
+                f"0 and {_RATE_LIMIT_PER_SECOND_MAX}: '{entry}'"
+            )
+        )
+    return rate

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -28,6 +28,7 @@ from ..services.market_allowlist import (
     MarketAllowlist,
     analysis_market_allowlist,
 )
+from ..services.rate_limit_policy import DetailMode, RateLimitPolicy
 from ..services.normalizer import (
     ANCHORED_AUTO_APPLY_THRESHOLD,
     log_unresolved_shared_platform_diagnostics,
@@ -147,6 +148,21 @@ def _is_enabled_scraper_capability(
     ):
         return False
     return True
+
+
+def _runtime_detail_mode_for_scraper(
+    bookmaker_id: str,
+    runtime_settings: ScrapeRuntimeSettings,
+) -> DetailMode | None:
+    if bookmaker_id == "soccerbet":
+        return runtime_settings.soccerbet_detail_mode
+    if bookmaker_id == "merkurxtip":
+        return runtime_settings.merkurxtip_detail_mode
+    if bookmaker_id == "pinnbet":
+        return runtime_settings.pinnbet_detail_mode
+    if bookmaker_id == "betole":
+        return runtime_settings.betole_detail_mode
+    return None
 
 
 def _filter_normalized_pipeline_batch_by_market_allowlist(
@@ -1124,37 +1140,49 @@ class Scheduler:
         scraper: BaseScraper,
         capability: ScraperCapability,
         runtime_settings: ScrapeRuntimeSettings,
+        rate_limit_policy: RateLimitPolicy,
     ) -> _ScrapeBatch:
-        with benchmark_recorder.scrape_request_context(
+        effective_rate_limit = rate_limit_policy.effective_rate_limit(
             bookmaker_id=scraper.get_bookmaker_id(),
             lane=capability.lane,
-            sport=capability.sport,
-            league_id=capability.league_id,
-        ):
-            if capability.lane == "threshold_odds":
-                if capability.league_id is None:
-                    raise ValueError("threshold_odds capability is missing league_id")
-                return _ScrapeBatch(
-                    capability=capability,
-                    raw_odds=tuple(
-                        await self._scrape_one(
-                            scraper,
-                            capability.league_id,
-                            lookahead_hours=runtime_settings.scrape_lookahead_hours,
-                        )
-                    ),
-                )
-            if capability.lane == "outcome_offer":
-                return _ScrapeBatch(
-                    capability=capability,
-                    raw_outcome_offers=tuple(
-                        await self._scrape_outcome_one(
-                            scraper,
-                            capability.sport,
-                            lookahead_hours=runtime_settings.scrape_lookahead_hours,
-                        )
-                    ),
-                )
+            detail_mode=_runtime_detail_mode_for_scraper(
+                scraper.get_bookmaker_id(),
+                runtime_settings,
+            ),
+            global_rate_limit_per_second=runtime_settings.rate_limit_per_second,
+            meridian_rate_limit_per_second=runtime_settings.meridian_rate_limit_per_second,
+        )
+        with scraper.runtime_rate_limit(effective_rate_limit):
+            with benchmark_recorder.scrape_request_context(
+                bookmaker_id=scraper.get_bookmaker_id(),
+                lane=capability.lane,
+                sport=capability.sport,
+                league_id=capability.league_id,
+            ):
+                if capability.lane == "threshold_odds":
+                    if capability.league_id is None:
+                        raise ValueError("threshold_odds capability is missing league_id")
+                    return _ScrapeBatch(
+                        capability=capability,
+                        raw_odds=tuple(
+                            await self._scrape_one(
+                                scraper,
+                                capability.league_id,
+                                lookahead_hours=runtime_settings.scrape_lookahead_hours,
+                            )
+                        ),
+                    )
+                if capability.lane == "outcome_offer":
+                    return _ScrapeBatch(
+                        capability=capability,
+                        raw_outcome_offers=tuple(
+                            await self._scrape_outcome_one(
+                                scraper,
+                                capability.sport,
+                                lookahead_hours=runtime_settings.scrape_lookahead_hours,
+                            )
+                        ),
+                    )
         raise ValueError(f"Unsupported scraper capability lane: {capability.lane}")
 
     def _apply_runtime_scraper_settings(
@@ -1225,6 +1253,7 @@ class Scheduler:
             logger.info("Starting scrape cycle at %s", cycle_started_at_iso)
 
             enabled_bookmakers = set(runtime_settings.enabled_bookmakers)
+            rate_limit_policy = RateLimitPolicy.from_settings()
             market_allowlist = analysis_market_allowlist(
                 runtime_settings.analysis_markets,
                 legacy_scrape_market_scope=runtime_settings.scrape_market_scope,
@@ -1248,7 +1277,12 @@ class Scheduler:
                 )
             ]
             scrape_tasks = [
-                self._scrape_capability(scraper, capability, runtime_settings)
+                self._scrape_capability(
+                    scraper,
+                    capability,
+                    runtime_settings,
+                    rate_limit_policy,
+                )
                 for scraper, capability in scrape_capabilities
             ]
             self._scan_phase = "scraping"

--- a/backend/app/services/scraper_benchmarks.py
+++ b/backend/app/services/scraper_benchmarks.py
@@ -33,6 +33,7 @@ from ..models.schemas import (
     ScraperBenchmarkOut,
     ScraperRequestBenchmarkOut,
 )
+from .rate_limit_policy import RateLimitPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -141,6 +142,7 @@ def _runtime_metadata(
     runtime_settings: ScrapeRuntimeSettings,
 ) -> BenchmarkRuntimeMetadataOut:
     proxy_count = len(settings.proxy_url_list)
+    rate_limit_policy = RateLimitPolicy.from_settings()
     return BenchmarkRuntimeMetadataOut(
         scraper_mode=settings.scraper_mode,
         enabled_bookmakers=list(runtime_settings.enabled_bookmakers),
@@ -150,6 +152,8 @@ def _runtime_metadata(
         scrape_lookahead_hours=runtime_settings.scrape_lookahead_hours,
         rate_limit_per_second=runtime_settings.rate_limit_per_second,
         meridian_rate_limit_per_second=runtime_settings.meridian_rate_limit_per_second,
+        bookmaker_rate_limits=rate_limit_policy.metadata_bookmaker_rate_limits(),
+        scrape_type_rate_limits=rate_limit_policy.metadata_scrape_type_rate_limits(),
         detail_modes={
             "betole": runtime_settings.betole_detail_mode,
             "soccerbet": runtime_settings.soccerbet_detail_mode,

--- a/backend/tests/test_http_client.py
+++ b/backend/tests/test_http_client.py
@@ -257,6 +257,15 @@ async def test_rate_limit_is_isolated_per_http_client():
     await client_b.close()
 
 
+def test_rate_limit_property_uses_context_override_for_scraper_concurrency():
+    client = HttpClient(rate_limit_per_second=3)
+
+    assert client.rate_limit_per_second == pytest.approx(3)
+    with client.use_rate_limit(0.5):
+        assert client.rate_limit_per_second == pytest.approx(0.5)
+    assert client.rate_limit_per_second == pytest.approx(3)
+
+
 class _FakeResponse:
     def __init__(self, lines: list[str], status_code: int = 200) -> None:
         self._lines = lines

--- a/backend/tests/test_rate_limit_policy.py
+++ b/backend/tests/test_rate_limit_policy.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.rate_limit_policy import (
+    RateLimitPolicy,
+    RateLimitPolicyError,
+    parse_bookmaker_rate_limits,
+    parse_scrape_type_rate_limits,
+)
+
+
+def test_parse_bookmaker_rate_limits_accepts_comma_and_semicolon_entries():
+    assert parse_bookmaker_rate_limits("365:1; BetOle:0.5, meridian:2") == {
+        "365": 1.0,
+        "betole": 0.5,
+        "meridian": 2.0,
+    }
+
+
+def test_parse_bookmaker_rate_limits_rejects_duplicates():
+    with pytest.raises(RateLimitPolicyError):
+        parse_bookmaker_rate_limits("betole:1,BetOle:0.5")
+
+
+def test_parse_scrape_type_rate_limits_accepts_lane_and_detail_entries():
+    policies = parse_scrape_type_rate_limits(
+        "betole:outcome_offer:full:0.5,365:threshold_odds:1"
+    )
+
+    assert [policy.key for policy in policies] == [
+        "betole:outcome_offer:full",
+        "365:threshold_odds:*",
+    ]
+    assert [policy.rate_limit_per_second for policy in policies] == [0.5, 1.0]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "betole",
+        "betole:not_a_lane:1",
+        "betole:outcome_offer:turbo:1",
+        "betole:outcome_offer:full:not-a-number",
+        "betole:outcome_offer:full:99",
+    ],
+)
+def test_parse_scrape_type_rate_limits_rejects_invalid_entries(raw: str):
+    with pytest.raises(RateLimitPolicyError):
+        parse_scrape_type_rate_limits(raw)
+
+
+def test_effective_rate_limit_preserves_meridian_default_without_policy():
+    policy = RateLimitPolicy(bookmaker_rate_limits={}, scrape_type_rate_limits=())
+
+    assert policy.effective_rate_limit(
+        bookmaker_id="meridian",
+        lane="threshold_odds",
+        detail_mode=None,
+        global_rate_limit_per_second=1.0,
+        meridian_rate_limit_per_second=2.0,
+    ) == 2.0
+
+
+def test_effective_rate_limit_uses_specific_policy_before_bookmaker_policy():
+    policy = RateLimitPolicy(
+        bookmaker_rate_limits={"betole": 1.0},
+        scrape_type_rate_limits=parse_scrape_type_rate_limits(
+            "betole:outcome_offer:full:0.25"
+        ),
+    )
+
+    assert policy.effective_rate_limit(
+        bookmaker_id="betole",
+        lane="outcome_offer",
+        detail_mode="full",
+        global_rate_limit_per_second=3.0,
+        meridian_rate_limit_per_second=2.0,
+    ) == 0.25
+    assert policy.effective_rate_limit(
+        bookmaker_id="betole",
+        lane="outcome_offer",
+        detail_mode="partial",
+        global_rate_limit_per_second=3.0,
+        meridian_rate_limit_per_second=2.0,
+    ) == 1.0
+
+
+def test_effective_rate_limit_policy_cannot_raise_existing_default():
+    policy = RateLimitPolicy(
+        bookmaker_rate_limits={"365": 5.0},
+        scrape_type_rate_limits=parse_scrape_type_rate_limits(
+            "betole:outcome_offer:full:4"
+        ),
+    )
+
+    assert policy.effective_rate_limit(
+        bookmaker_id="365",
+        lane="outcome_offer",
+        detail_mode=None,
+        global_rate_limit_per_second=1.0,
+        meridian_rate_limit_per_second=2.0,
+    ) == 1.0
+    assert policy.effective_rate_limit(
+        bookmaker_id="betole",
+        lane="outcome_offer",
+        detail_mode="full",
+        global_rate_limit_per_second=1.0,
+        meridian_rate_limit_per_second=2.0,
+    ) == 1.0

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -15,6 +16,7 @@ from app.models.schemas import (
     OpportunityLeg,
     RawOddsData,
     RawOutcomeOffer,
+    ScrapeRuntimeSettings,
     ScrapeRuntimeSettingsUpdate,
     TeamReviewDiagnostic,
 )
@@ -24,6 +26,7 @@ from app.services.scheduler import Scheduler, _normalize_merge_pairings
 from app.services.normalizer import normalize_team_name
 from app.services.notifications import InAppNotificationProvider
 from app.services.runtime_settings import update_scrape_settings
+from app.services.rate_limit_policy import RateLimitPolicy, ScrapeTypeRateLimit
 from app.services.team_registry import (
     create_canonical_team,
     get_canonical_team,
@@ -193,6 +196,37 @@ class StubScraper(BaseScraper):
         return list(self._outcome_payload_by_sport.get(sport, []))
 
 
+class RecordingRateLimitClient:
+    def __init__(self) -> None:
+        self.rate_limit_per_second = 0.0
+        self.active_rate_limit: float | None = None
+        self.seen_rate_limits: list[float] = []
+
+    @contextmanager
+    def use_rate_limit(self, rate_limit_per_second: float):
+        self.active_rate_limit = rate_limit_per_second
+        self.seen_rate_limits.append(rate_limit_per_second)
+        try:
+            yield
+        finally:
+            self.active_rate_limit = None
+
+
+class RateRecordingScraper(StubScraper):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._http = RecordingRateLimitClient()
+        self.observed_rate_limits: list[float | None] = []
+
+    async def scrape_odds(self, league_id: str) -> list[RawOddsData]:
+        self.observed_rate_limits.append(self._http.active_rate_limit)
+        return await super().scrape_odds(league_id)
+
+    async def scrape_outcome_offers(self, sport: str) -> list[RawOutcomeOffer]:
+        self.observed_rate_limits.append(self._http.active_rate_limit)
+        return await super().scrape_outcome_offers(sport)
+
+
 def test_normalize_merge_pairings_flattens_valid_chains():
     normalized, conflicts = _normalize_merge_pairings([(3, 2), (2, 1)])
 
@@ -246,6 +280,120 @@ def test_scraper_capabilities_unify_threshold_and_outcome_lanes():
         ScraperCapability.threshold_odds(sport="football", league_id="football_league"),
         ScraperCapability.outcome_offer(sport="tennis"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_scrape_capability_applies_bookmaker_rate_policy_cap():
+    scraper = RateRecordingScraper(
+        "betole",
+        outcome_sports=("football",),
+        outcome_payload_by_sport={"football": [_raw_outcome_offer("betole", "home")]},
+    )
+    runtime_settings = ScrapeRuntimeSettings(
+        enabled_bookmakers=["betole"],
+        enabled_sports=["football"],
+        scrape_market_scope="all",
+        analysis_markets=["all"],
+        scrape_lookahead_hours=24,
+        scrape_interval_minutes=10,
+        max_middle_opportunities_per_market=10,
+        rate_limit_per_second=3.0,
+        meridian_rate_limit_per_second=2.0,
+        soccerbet_detail_mode="partial",
+        merkurxtip_detail_mode="partial",
+        pinnbet_detail_mode="partial",
+        betole_detail_mode="partial",
+        notification_gap_threshold=1.5,
+        persist_inapp_notifications=False,
+    )
+    policy = RateLimitPolicy(bookmaker_rate_limits={"betole": 1.0}, scrape_type_rate_limits=())
+
+    await Scheduler(interval_minutes=1)._scrape_capability(
+        scraper,
+        ScraperCapability.outcome_offer(sport="football"),
+        runtime_settings,
+        policy,
+    )
+
+    assert scraper.observed_rate_limits == [1.0]
+    assert scraper._http.seen_rate_limits == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_scrape_capability_applies_detail_specific_policy_before_bookmaker_cap():
+    scraper = RateRecordingScraper(
+        "betole",
+        outcome_sports=("football",),
+        outcome_payload_by_sport={"football": [_raw_outcome_offer("betole", "home")]},
+    )
+    runtime_settings = ScrapeRuntimeSettings(
+        enabled_bookmakers=["betole"],
+        enabled_sports=["football"],
+        scrape_market_scope="all",
+        analysis_markets=["all"],
+        scrape_lookahead_hours=24,
+        scrape_interval_minutes=10,
+        max_middle_opportunities_per_market=10,
+        rate_limit_per_second=3.0,
+        meridian_rate_limit_per_second=2.0,
+        soccerbet_detail_mode="partial",
+        merkurxtip_detail_mode="partial",
+        pinnbet_detail_mode="partial",
+        betole_detail_mode="full",
+        notification_gap_threshold=1.5,
+        persist_inapp_notifications=False,
+    )
+    policy = RateLimitPolicy(
+        bookmaker_rate_limits={"betole": 1.0},
+        scrape_type_rate_limits=(
+            ScrapeTypeRateLimit("betole", "outcome_offer", "full", 0.25),
+        ),
+    )
+
+    await Scheduler(interval_minutes=1)._scrape_capability(
+        scraper,
+        ScraperCapability.outcome_offer(sport="football"),
+        runtime_settings,
+        policy,
+    )
+
+    assert scraper.observed_rate_limits == [0.25]
+
+
+@pytest.mark.asyncio
+async def test_scrape_capability_policy_never_raises_above_default_rate():
+    scraper = RateRecordingScraper(
+        "365",
+        outcome_sports=("football",),
+        outcome_payload_by_sport={"football": [_raw_outcome_offer("365", "home")]},
+    )
+    runtime_settings = ScrapeRuntimeSettings(
+        enabled_bookmakers=["365"],
+        enabled_sports=["football"],
+        scrape_market_scope="all",
+        analysis_markets=["all"],
+        scrape_lookahead_hours=24,
+        scrape_interval_minutes=10,
+        max_middle_opportunities_per_market=10,
+        rate_limit_per_second=1.0,
+        meridian_rate_limit_per_second=2.0,
+        soccerbet_detail_mode="partial",
+        merkurxtip_detail_mode="partial",
+        pinnbet_detail_mode="partial",
+        betole_detail_mode="partial",
+        notification_gap_threshold=1.5,
+        persist_inapp_notifications=False,
+    )
+    policy = RateLimitPolicy(bookmaker_rate_limits={"365": 5.0}, scrape_type_rate_limits=())
+
+    await Scheduler(interval_minutes=1)._scrape_capability(
+        scraper,
+        ScraperCapability.outcome_offer(sport="football"),
+        runtime_settings,
+        policy,
+    )
+
+    assert scraper.observed_rate_limits == [1.0]
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_scraper_benchmarks.py
+++ b/backend/tests/test_scraper_benchmarks.py
@@ -60,6 +60,8 @@ async def test_benchmarks_published_after_cycle(client: AsyncClient, tmp_path):
     assert set(body["metadata"]["enabled_bookmakers"]) == {"mozzart", "meridian"}
     assert body["metadata"]["proxy_count"] == 0
     assert body["metadata"]["proxies_configured"] is False
+    assert body["metadata"]["bookmaker_rate_limits"] == {}
+    assert body["metadata"]["scrape_type_rate_limits"] == {}
     assert body["metadata"]["detail_modes"] == {
         "betole": settings.betole_detail_mode,
         "merkurxtip": settings.merkurxtip_detail_mode,
@@ -146,6 +148,12 @@ def test_http_request_aggregates_and_metadata_are_persisted_without_secrets(
 ):
     secret_proxy = "http://user:secret-password@example.test:8080"
     monkeypatch.setattr(settings, "proxy_list", secret_proxy)
+    monkeypatch.setattr(settings, "bookmaker_rate_limits", "betole:0.5")
+    monkeypatch.setattr(
+        settings,
+        "scrape_type_rate_limits",
+        "betole:outcome_offer:partial:0.25",
+    )
     runtime_settings = ScrapeRuntimeSettings(
         enabled_bookmakers=["betole"],
         enabled_sports=["football"],
@@ -204,6 +212,10 @@ def test_http_request_aggregates_and_metadata_are_persisted_without_secrets(
     assert snapshot.metadata.proxies_configured is True
     assert snapshot.metadata.proxy_count == 1
     assert snapshot.metadata.analysis_markets == ["football:football_result"]
+    assert snapshot.metadata.bookmaker_rate_limits == {"betole": 0.5}
+    assert snapshot.metadata.scrape_type_rate_limits == {
+        "betole:outcome_offer:partial": 0.25
+    }
     scraper_row = snapshot.scrapers[0]
     assert scraper_row.http.logical_requests == 1
     assert scraper_row.http.attempts == 2


### PR DESCRIPTION
## Summary
- add backend-only bookmaker and scrape-type rate-limit policy caps via `BOOKMAKER_RATE_LIMITS` and `SCRAPE_TYPE_RATE_LIMITS`
- keep policies as caps only, so they cannot raise existing global/Meridian effective defaults
- apply effective caps per scrape capability with a task-local HTTP client override, including detail-mode-specific paths
- include parsed policy maps in benchmark metadata
- document the grammar in backend README and .env.example

## Verification
- `cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q tests/test_rate_limit_policy.py tests/test_scheduler.py tests/test_api.py -k 'rate_limit or settings or runtime' tests/test_scraper_benchmarks.py tests/test_http_client.py` — 28 passed, 132 deselected
- `cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q` — 1111 passed
- focused code review finding fixed: `HttpClient.rate_limit_per_second` now reports the active per-capability override so detail concurrency uses capped rates

Closes #98