### PR TITLE
Batch football team auto-creation

### DIFF
--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -18,7 +18,7 @@ from ..models.schemas import (
 )
 from .league_registry import resolve_league
 from .normalizer import generate_match_id, normalize_odds_with_diagnostics, resolve_team_name
-from .team_registry import create_canonical_team
+from .team_registry import create_canonical_team, create_canonical_teams_batch
 from .text_normalizer import normalize_identity_text
 
 logger = logging.getLogger(__name__)
@@ -268,7 +268,7 @@ def _autocreate_cross_book_football_teams(raw_list: list[RawOutcomeOffer]) -> in
         display_names[(raw.sport, home_key)][raw.home_team.strip()] += 1
         display_names[(raw.sport, away_key)][raw.away_team.strip()] += 1
 
-    created_count = 0
+    missing_display_names: dict[tuple[str, str], str] = {}
     for (sport, _start_time, team_keys), bookmaker_ids in matchup_counts.items():
         if len(bookmaker_ids) < 2:
             continue
@@ -278,8 +278,18 @@ def _autocreate_cross_book_football_teams(raw_list: list[RawOutcomeOffer]) -> in
                 continue
             display_name = max(counter.items(), key=lambda item: (item[1], len(item[0]), item[0]))[0]
             if resolve_team_name(display_name, sport=sport).team_id is None:
-                create_canonical_team(display_name=display_name, sport=sport)
-                created_count += 1
+                missing_display_names[(sport, team_key)] = display_name
+
+    created_count = 0
+    by_sport: dict[str, list[str]] = defaultdict(list)
+    for (sport, _team_key), display_name in missing_display_names.items():
+        by_sport[sport].append(display_name)
+    for sport, sport_display_names in by_sport.items():
+        resolutions = create_canonical_teams_batch(
+            display_names=sport_display_names,
+            sport=sport,
+        )
+        created_count += sum(1 for resolution in resolutions if resolution.source == "batch_create")
     return created_count
 
 

--- a/backend/app/services/team_registry.py
+++ b/backend/app/services/team_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 import json
 import sqlite3
 from dataclasses import dataclass
@@ -676,6 +677,37 @@ def create_canonical_team(
         conn.commit()
     clear_team_registry_cache(reset_bootstrap=False)
     return resolution
+
+
+def create_canonical_teams_batch(
+    *,
+    display_names: Iterable[str],
+    sport: str = DEFAULT_SPORT,
+) -> list[TeamAliasResolution]:
+    unique_names: dict[str, str] = {}
+    for display_name in display_names:
+        normalized_display_name = normalize_identity_text(display_name)
+        stripped_name = display_name.strip()
+        if normalized_display_name and stripped_name and normalized_display_name not in unique_names:
+            unique_names[normalized_display_name] = stripped_name
+    if not unique_names:
+        return []
+
+    _ensure_bootstrapped()
+    with _connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        resolutions = [
+            _create_canonical_team(
+                conn,
+                sport=sport,
+                display_name=display_name,
+                source="batch_create",
+            )
+            for display_name in unique_names.values()
+        ]
+        conn.commit()
+    clear_team_registry_cache(reset_bootstrap=False)
+    return resolutions
 
 
 @lru_cache(maxsize=16)

--- a/backend/tests/test_outcome_normalizer.py
+++ b/backend/tests/test_outcome_normalizer.py
@@ -9,6 +9,7 @@ from app.services.outcome_normalizer import (
     _same_team_context,
     _team_similarity,
     _team_qualifiers,
+    normalize_outcome_offers_with_benchmark,
     normalize_outcome_offers_with_diagnostics,
 )
 from app.services.team_registry import create_canonical_team, remember_team_alias
@@ -80,6 +81,21 @@ def test_exact_cross_book_football_event_normalizes_without_auto_aliases(team_re
     assert unresolved == []
     assert review_cases == []
     assert _auto_review_alias_count() == 0
+
+
+def test_cross_book_football_autocreate_reports_multiple_batch_created_teams(team_registry_file):
+    raw = [
+        _offer("maxbet", "Batch Home FC", "Batch Away FC", outcome_code="over"),
+        _offer("balkanbet", "Batch Home FC", "Batch Away FC", outcome_code="under"),
+    ]
+
+    normalized, unresolved, review_cases, benchmark = normalize_outcome_offers_with_benchmark(raw)
+
+    assert len(normalized) == 2
+    assert unresolved == []
+    assert review_cases == []
+    assert benchmark.auto_created_football_team_count == 2
+    assert {"Batch Home FC", "Batch Away FC"} <= _canonical_team_names()
 
 
 def test_one_strong_football_team_matches_event_without_alias_write(team_registry_file):

--- a/backend/tests/test_team_registry.py
+++ b/backend/tests/test_team_registry.py
@@ -6,6 +6,7 @@ import sqlite3
 import pytest
 
 from app.config import settings
+from app.services import team_registry
 from app.services.team_registry import (
     clear_team_registry_cache,
     create_canonical_team,
@@ -193,3 +194,54 @@ def test_unmerge_canonical_team_rejects_legacy_history_without_snapshot(team_reg
 
     with pytest.raises(ValueError, match="before alias rollback metadata existed"):
         unmerge_canonical_team(source_team_id=source.team_id)
+
+
+def test_create_canonical_teams_batch_creates_multiple_teams_and_clears_once(
+    monkeypatch,
+    team_registry_file,
+):
+    clear_calls: list[bool] = []
+    original_clear = team_registry.clear_team_registry_cache
+
+    def spy_clear(*, reset_bootstrap: bool = True) -> None:
+        clear_calls.append(reset_bootstrap)
+        original_clear(reset_bootstrap=reset_bootstrap)
+
+    monkeypatch.setattr(team_registry, "clear_team_registry_cache", spy_clear)
+
+    resolutions = team_registry.create_canonical_teams_batch(
+        display_names=["Batch Alpha FC", "Batch Beta FC", "Batch Alpha FC"],
+        sport="football",
+    )
+
+    assert [resolution.team_name for resolution in resolutions] == [
+        "Batch Alpha FC",
+        "Batch Beta FC",
+    ]
+    assert {resolution.source for resolution in resolutions} == {"batch_create"}
+    assert clear_calls == [False]
+    assert (
+        team_registry.resolve_team_alias("Batch Alpha FC", sport="football").team_id
+        == resolutions[0].team_id
+    )
+    assert (
+        team_registry.resolve_team_alias("Batch Beta FC", sport="football").team_id
+        == resolutions[1].team_id
+    )
+
+
+def test_create_canonical_teams_batch_returns_existing_active_team(team_registry_file):
+    first = team_registry.create_canonical_team(
+        display_name="Existing Batch FC",
+        sport="football",
+    )
+
+    resolutions = team_registry.create_canonical_teams_batch(
+        display_names=["Existing Batch FC", "Fresh Batch FC"],
+        sport="football",
+    )
+
+    assert resolutions[0].team_id == first.team_id
+    assert resolutions[0].source == "canonical"
+    assert resolutions[1].team_name == "Fresh Batch FC"
+    assert resolutions[1].source == "batch_create"


### PR DESCRIPTION
## Summary
- add batch canonical-team creation in the team registry using one transaction/cache invalidation
- switch football outcome auto-create to collect missing teams and batch by sport
- add regression coverage for batch creation, existing team reuse, and benchmark auto-created counts

Closes #99

## Tests
- cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q tests/test_team_registry.py tests/test_outcome_normalizer.py tests/test_event_resolver.py tests/test_scheduler.py -k 'football or outcome or team'\n- cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q