### PR TITLE
Reuse football outcome event resolutions

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -589,6 +589,7 @@ class EventResolverBenchmarkOut(BaseModel):
 
     extract_event_candidates_ms: int = 0
     football_raw_resolution_candidates_ms: int = 0
+    reused_football_event_resolution_count: int = 0
     build_event_resolution_groups_ms: int = 0
     persist_event_resolution_groups_ms: int = 0
     candidate_count: int = 0

--- a/backend/app/services/event_resolver.py
+++ b/backend/app/services/event_resolver.py
@@ -30,6 +30,7 @@ from .outcome_normalizer import (
     _same_team_context,
     _team_similarity,
     _team_qualifiers,
+    FootballEventResolutionMap,
 )
 from .text_normalizer import normalize_identity_text
 
@@ -509,6 +510,7 @@ class EventResolutionGroup:
 @dataclass
 class _EventCandidateExtractionStats:
     football_raw_resolution_candidates_ms: int = 0
+    reused_football_event_resolution_count: int = 0
 
 
 @dataclass
@@ -880,10 +882,16 @@ def _merge_candidate(
 def _football_raw_resolution_candidates(
     raw_offers: list[RawOutcomeOffer],
     stored_match_bookmakers: set[tuple[str, str]],
+    *,
+    football_event_resolutions: FootballEventResolutionMap | None = None,
 ) -> list[EventCandidate]:
     if not raw_offers:
         return []
-    event_resolutions = _build_football_event_resolutions(raw_offers)
+    event_resolutions = (
+        football_event_resolutions
+        if football_event_resolutions is not None
+        else _build_football_event_resolutions(raw_offers)
+    )
     seen_raw_events: set[tuple[str, str, str, str, str]] = set()
     candidates: list[EventCandidate] = []
     for raw in raw_offers:
@@ -930,6 +938,7 @@ def extract_event_candidates(
     raw_outcome_offers: list[RawOutcomeOffer],
     normalized_odds: list[NormalizedOdds],
     normalized_outcome_offers: list[NormalizedOutcomeOffer],
+    football_event_resolutions: FootballEventResolutionMap | None = None,
     stats: _EventCandidateExtractionStats | None = None,
 ) -> list[EventCandidate]:
     """Build one source-event candidate per bookmaker/match from the current scrape."""
@@ -988,7 +997,10 @@ def extract_event_candidates(
     football_candidates = _football_raw_resolution_candidates(
         raw_outcome_offers,
         stored_outcome_match_bookmakers,
+        football_event_resolutions=football_event_resolutions,
     )
+    if stats is not None and football_event_resolutions is not None:
+        stats.reused_football_event_resolution_count = len(football_candidates)
     if stats is not None:
         stats.football_raw_resolution_candidates_ms = _elapsed_ms(
             football_candidates_started_at
@@ -1652,6 +1664,7 @@ async def resolve_and_persist_events(
     raw_outcome_offers: list[RawOutcomeOffer],
     normalized_odds: list[NormalizedOdds],
     normalized_outcome_offers: list[NormalizedOutcomeOffer],
+    football_event_resolutions: FootballEventResolutionMap | None = None,
 ) -> EventResolverResult:
     extraction_stats = _EventCandidateExtractionStats()
     extraction_started_at = time.perf_counter()
@@ -1660,6 +1673,7 @@ async def resolve_and_persist_events(
         raw_outcome_offers=raw_outcome_offers,
         normalized_odds=normalized_odds,
         normalized_outcome_offers=normalized_outcome_offers,
+        football_event_resolutions=football_event_resolutions,
         stats=extraction_stats,
     )
     extract_event_candidates_ms = _elapsed_ms(extraction_started_at)
@@ -1683,6 +1697,9 @@ async def resolve_and_persist_events(
         extract_event_candidates_ms=extract_event_candidates_ms,
         football_raw_resolution_candidates_ms=(
             extraction_stats.football_raw_resolution_candidates_ms
+        ),
+        reused_football_event_resolution_count=(
+            extraction_stats.reused_football_event_resolution_count
         ),
         build_event_resolution_groups_ms=build_event_resolution_groups_ms,
         persist_event_resolution_groups_ms=persist_event_resolution_groups_ms,

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -97,6 +97,19 @@ class _OutcomeEventResolution:
     orientation: str = _SAME_ORIENTATION
 
 
+FootballEventResolutionKey = tuple[str, str, str, str, str]
+FootballEventResolutionMap = dict[FootballEventResolutionKey, _OutcomeEventResolution]
+
+
+@dataclass(frozen=True)
+class OutcomeNormalizationResult:
+    normalized: list[NormalizedOutcomeOffer]
+    unresolved: list[UnresolvedOddsDiagnostic]
+    team_review_cases: list[TeamReviewDiagnostic]
+    benchmark: OutcomeNormalizationBenchmarkOut
+    football_event_resolutions: FootballEventResolutionMap
+
+
 @dataclass(frozen=True)
 class _OutcomeEventPair:
     left: _OutcomeEvent
@@ -691,11 +704,11 @@ def _build_football_event_resolutions(
     raw_list: list[RawOutcomeOffer],
     *,
     stats: _FootballEventResolutionStats | None = None,
-) -> dict[tuple[str, str, str, str, str], _OutcomeEventResolution]:
+) -> FootballEventResolutionMap:
     events = _unique_events(raw_list)
     if stats is not None:
         stats.football_unique_event_count = len(events)
-    resolutions: dict[tuple[str, str, str, str, str], _OutcomeEventResolution] = {}
+    resolutions: FootballEventResolutionMap = {}
     lookup_started_at = time.perf_counter()
     for event in events:
         slot = _resolve_event_slot(event)
@@ -920,14 +933,9 @@ def _normalized_offer_from_resolution(
     )
 
 
-def normalize_outcome_offers_with_benchmark(
+def normalize_outcome_offers_with_context(
     raw_list: list[RawOutcomeOffer],
-) -> tuple[
-    list[NormalizedOutcomeOffer],
-    list[UnresolvedOddsDiagnostic],
-    list[TeamReviewDiagnostic],
-    OutcomeNormalizationBenchmarkOut,
-]:
+) -> OutcomeNormalizationResult:
     autocreate_started_at = time.perf_counter()
     auto_created_team_count = _autocreate_cross_book_football_teams(raw_list)
     auto_create_football_teams_ms = _elapsed_ms(autocreate_started_at)
@@ -1060,7 +1068,30 @@ def normalize_outcome_offers_with_benchmark(
         row_normalization_ms=_elapsed_ms(row_normalization_started_at),
     )
 
-    return normalized, unresolved, team_review_cases, benchmark
+    return OutcomeNormalizationResult(
+        normalized=normalized,
+        unresolved=unresolved,
+        team_review_cases=team_review_cases,
+        benchmark=benchmark,
+        football_event_resolutions=event_resolutions,
+    )
+
+
+def normalize_outcome_offers_with_benchmark(
+    raw_list: list[RawOutcomeOffer],
+) -> tuple[
+    list[NormalizedOutcomeOffer],
+    list[UnresolvedOddsDiagnostic],
+    list[TeamReviewDiagnostic],
+    OutcomeNormalizationBenchmarkOut,
+]:
+    result = normalize_outcome_offers_with_context(raw_list)
+    return (
+        result.normalized,
+        result.unresolved,
+        result.team_review_cases,
+        result.benchmark,
+    )
 
 
 def normalize_outcome_offers_with_diagnostics(

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -47,7 +47,10 @@ from ..services.event_resolver import (
     _same_time_slot_orientation,
     resolve_and_persist_events,
 )
-from ..services.outcome_normalizer import normalize_outcome_offers_with_benchmark
+from ..services.outcome_normalizer import (
+    FootballEventResolutionMap,
+    normalize_outcome_offers_with_context,
+)
 from ..services.notifications import NotificationService, InAppNotificationProvider
 from ..services.scrape_window import (
     configured_lookahead_hours,
@@ -104,6 +107,7 @@ class _NormalizedPipelineBatch:
     outcome_offers: list[NormalizedOutcomeOffer] = field(default_factory=list)
     unresolved_odds: list[UnresolvedOddsDiagnostic] = field(default_factory=list)
     team_review_cases: list[TeamReviewDiagnostic] = field(default_factory=list)
+    football_event_resolutions: FootballEventResolutionMap = field(default_factory=dict)
 
 
 def _is_auto_alias_candidate(case) -> bool:
@@ -194,6 +198,7 @@ def _filter_normalized_pipeline_batch_by_market_allowlist(
             )
         ],
         team_review_cases=batch.team_review_cases,
+        football_event_resolutions=batch.football_event_resolutions,
     )
 
 
@@ -235,6 +240,7 @@ def _event_resolution_batch_for_market_allowlist(
         ],
         unresolved_odds=full_batch.unresolved_odds,
         team_review_cases=full_batch.team_review_cases,
+        football_event_resolutions=full_batch.football_event_resolutions,
     )
 
 
@@ -254,12 +260,11 @@ def _normalize_pipeline_batch(
         int((time.perf_counter() - threshold_started_at) * 1000),
     )
     outcome_started_at = time.perf_counter()
-    (
-        normalized_outcome_offers,
-        unresolved_outcome_offers,
-        outcome_team_review_cases,
-        outcome_benchmark,
-    ) = normalize_outcome_offers_with_benchmark(raw_outcome_offers)
+    outcome_result = normalize_outcome_offers_with_context(raw_outcome_offers)
+    normalized_outcome_offers = outcome_result.normalized
+    unresolved_outcome_offers = outcome_result.unresolved
+    outcome_team_review_cases = outcome_result.team_review_cases
+    outcome_benchmark = outcome_result.benchmark
     benchmark_recorder.record_phase_duration(
         "normalize_outcome_offers",
         int((time.perf_counter() - outcome_started_at) * 1000),
@@ -270,6 +275,7 @@ def _normalize_pipeline_batch(
         outcome_offers=normalized_outcome_offers,
         unresolved_odds=[*unresolved_odds, *unresolved_outcome_offers],
         team_review_cases=[*team_review_cases, *outcome_team_review_cases],
+        football_event_resolutions=outcome_result.football_event_resolutions,
     )
 
 
@@ -1427,6 +1433,9 @@ class Scheduler:
                     raw_outcome_offers=all_raw_outcome_offers,
                     normalized_odds=event_resolution_batch.odds,
                     normalized_outcome_offers=event_resolution_batch.outcome_offers,
+                    football_event_resolutions=(
+                        event_resolution_batch.football_event_resolutions
+                    ),
                 )
                 benchmark_recorder.record_phase_duration(
                     "resolve_events",

--- a/backend/tests/test_event_resolver.py
+++ b/backend/tests/test_event_resolver.py
@@ -13,6 +13,7 @@ from app.models.schemas import (
     TeamReviewCandidate,
     TeamReviewDiagnostic,
 )
+from app.services import event_resolver as event_resolver_module
 from app.services.event_resolver import (
     EventCandidate,
     _CandidateGroup,
@@ -26,7 +27,11 @@ from app.services.event_resolver import (
     resolve_and_persist_events,
 )
 from app.services.normalizer import generate_match_id
-from app.services.outcome_normalizer import _same_team_context, _team_qualifiers
+from app.services.outcome_normalizer import (
+    _same_team_context,
+    _team_qualifiers,
+    normalize_outcome_offers_with_context,
+)
 from app.services.team_registry import create_canonical_team
 from app.store import odds_store
 
@@ -339,6 +344,99 @@ async def test_event_resolver_persists_football_outcome_candidates(team_registry
     assert event.sport == "football"
     assert {member.source_home_team for member in event.members} == {"Arsenal"}
     assert {member.source_away_team for member in event.members} == {"Chelsea"}
+
+
+@pytest.mark.asyncio
+async def test_event_resolver_reuses_precomputed_football_outcome_resolutions(
+    monkeypatch,
+    team_registry_file,
+):
+    await _seed_bookmakers("maxbet", "balkanbet", "unusedbet")
+    await _seed_league("premier_league", "football")
+    raw = [
+        RawOutcomeOffer(
+            bookmaker_id="maxbet",
+            league_id="premier_league",
+            sport="football",
+            home_team="Arsenal",
+            away_team="Chelsea",
+            source_url="https://maxbet.example/football-event",
+            market_type="football_total_goals",
+            outcome_code="over",
+            odds=1.9,
+            line=2.5,
+            raw_label="Over 2.5",
+            start_time=START_TIME,
+        ),
+        RawOutcomeOffer(
+            bookmaker_id="balkanbet",
+            league_id="premier_league",
+            sport="football",
+            home_team="Arsenal",
+            away_team="Chelsea",
+            source_url="https://balkanbet.example/football-event",
+            market_type="football_total_goals",
+            outcome_code="under",
+            odds=1.95,
+            line=2.5,
+            raw_label="Under 2.5",
+            start_time=START_TIME,
+        ),
+        RawOutcomeOffer(
+            bookmaker_id="unusedbet",
+            league_id="premier_league",
+            sport="football",
+            home_team="Arsenal",
+            away_team="Chelsea",
+            source_url="https://unusedbet.example/football-event",
+            market_type="football_total_goals",
+            outcome_code="over",
+            odds=1.91,
+            line=2.5,
+            raw_label="Over 2.5",
+            start_time=START_TIME,
+        ),
+    ]
+    outcome_result = normalize_outcome_offers_with_context(raw)
+    assert len(outcome_result.football_event_resolutions) == 3
+    persisted_normalized = [
+        row
+        for row in outcome_result.normalized
+        if row.bookmaker_id in {"maxbet", "balkanbet"}
+    ]
+    for row in persisted_normalized:
+        await _store_match(row)
+
+    def fail_rebuild(*args, **kwargs):
+        raise AssertionError("football resolutions should be reused")
+
+    monkeypatch.setattr(
+        event_resolver_module,
+        "_build_football_event_resolutions",
+        fail_rebuild,
+    )
+
+    result = await resolve_and_persist_events(
+        raw_odds=[],
+        raw_outcome_offers=raw,
+        normalized_odds=[],
+        normalized_outcome_offers=persisted_normalized,
+        football_event_resolutions=outcome_result.football_event_resolutions,
+    )
+
+    assert result.resolved_events == 1
+    assert result.benchmark is not None
+    assert result.benchmark.reused_football_event_resolution_count == 2
+    event = await odds_store.get_resolved_event(
+        f"evt_{persisted_normalized[0].match_id}"
+    )
+    assert event is not None
+    assert {member.source_home_team for member in event.members} == {"Arsenal"}
+    assert {member.source_away_team for member in event.members} == {"Chelsea"}
+    assert {member.source_url for member in event.members} == {
+        "https://maxbet.example/football-event",
+        "https://balkanbet.example/football-event",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- carry football outcome event resolutions from outcome normalization into event resolution
- skip rebuilding football resolutions for the same raw outcome offers during the scheduler cycle
- add benchmark metadata for reused football resolution candidates and regression coverage for filtered maps/source metadata

Closes #100

## Tests
- cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q tests/test_event_resolver.py tests/test_outcome_normalizer.py tests/test_scheduler.py -k 'event or outcome or football'\n- cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q tests/test_scraper_benchmarks.py tests/test_api.py -k 'benchmark or scraper_benchmarks'\n- cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q