### PR TITLE
Cache event matching hot-loop inputs

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -575,6 +575,8 @@ class OutcomeNormalizationBenchmarkOut(BaseModel):
     normalized_outcome_offer_count: int = 0
     unresolved_outcome_offer_count: int = 0
     football_unique_event_count: int = 0
+    football_event_pair_candidate_count: int = 0
+    football_event_fuzzy_score_count: int = 0
     auto_created_football_team_count: int = 0
     auto_create_football_teams_ms: int = 0
     football_event_resolution_ms: int = 0
@@ -595,6 +597,7 @@ class EventResolverBenchmarkOut(BaseModel):
     candidate_count: int = 0
     exact_group_count: int = 0
     pair_check_count: int = 0
+    fuzzy_score_count: int = 0
     accepted_fuzzy_pair_count: int = 0
     review_case_count: int = 0
     persisted_resolved_event_count: int = 0

--- a/backend/app/services/event_resolver.py
+++ b/backend/app/services/event_resolver.py
@@ -517,8 +517,135 @@ class _EventCandidateExtractionStats:
 class _EventGroupBuildStats:
     exact_group_count: int = 0
     pair_check_count: int = 0
+    fuzzy_score_count: int = 0
     accepted_fuzzy_pair_count: int = 0
     review_case_count: int = 0
+
+
+class _ResolverTextCache:
+    def __init__(self, stats: _EventGroupBuildStats | None = None) -> None:
+        self._stats = stats
+        self._qualifiers: dict[tuple[str, str | None], set[str]] = {}
+        self._comparison_text: dict[tuple[str, str | None], str] = {}
+        self._significant_tokens: dict[tuple[str, str | None], set[str]] = {}
+        self._expanded_tokens: dict[tuple[str, str, str | None], str] = {}
+        self._team_similarity: dict[tuple[str, str, str | None], float] = {}
+        self._orientation_scores: dict[
+            tuple[str, str, str, str, str | None],
+            tuple[_OrientationScore, ...],
+        ] = {}
+
+    def qualifiers(self, name: str, *, sport: str | None = None) -> set[str]:
+        key = (name, sport)
+        cached = self._qualifiers.get(key)
+        if cached is None:
+            cached = _team_qualifiers(name, sport=sport)
+            self._qualifiers[key] = cached
+        return cached
+
+    def comparison_text(self, name: str, *, sport: str | None = None) -> str:
+        key = (name, sport)
+        cached = self._comparison_text.get(key)
+        if cached is None:
+            cached = _comparison_team_text(name, sport=sport)
+            self._comparison_text[key] = cached
+        return cached
+
+    def significant_tokens(self, name: str, *, sport: str | None = None) -> set[str]:
+        key = (name, sport)
+        cached = self._significant_tokens.get(key)
+        if cached is None:
+            cached = {
+                token
+                for token in self.comparison_text(name, sport=sport).split()
+                if token not in _LOW_SIGNAL_TEAM_TOKENS
+            }
+            self._significant_tokens[key] = cached
+        return cached
+
+    def same_context(self, left: str, right: str, *, sport: str | None = None) -> bool:
+        return self.qualifiers(left, sport=sport) == self.qualifiers(right, sport=sport)
+
+    def expanded_token(
+        self,
+        name: str,
+        counterpart: str,
+        *,
+        sport: str | None = None,
+    ) -> str:
+        key = (name, counterpart, sport)
+        cached = self._expanded_tokens.get(key)
+        if cached is None:
+            cached = (
+                _expand_dotted_token(name, counterpart)
+                if sport in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE
+                else name
+            )
+            self._expanded_tokens[key] = cached
+        return cached
+
+    def team_similarity(self, left: str, right: str, *, sport: str | None = None) -> float:
+        expanded_left = self.expanded_token(left, right, sport=sport)
+        expanded_right = self.expanded_token(right, left, sport=sport)
+        key = (expanded_left, expanded_right, sport)
+        reverse_key = (expanded_right, expanded_left, sport)
+        cached = self._team_similarity.get(key)
+        if cached is None:
+            cached = self._team_similarity.get(reverse_key)
+        if cached is not None:
+            return cached
+
+        left_key = self.comparison_text(expanded_left, sport=sport)
+        right_key = self.comparison_text(expanded_right, sport=sport)
+        if not left_key or not right_key:
+            score = 0.0
+        elif left_key == right_key:
+            score = 100.0
+        else:
+            left_tokens = self.significant_tokens(expanded_left, sport=sport)
+            right_tokens = self.significant_tokens(expanded_right, sport=sport)
+            if left_tokens and left_tokens == right_tokens:
+                score = 100.0
+            else:
+                if self._stats is not None:
+                    self._stats.fuzzy_score_count += 1
+                score = float(fuzz.token_sort_ratio(left_key, right_key))
+        self._team_similarity[key] = score
+        return score
+
+    def orientation_scores(
+        self,
+        left_home: str,
+        left_away: str,
+        right_home: str,
+        right_away: str,
+        *,
+        sport: str | None = None,
+    ) -> list[_OrientationScore]:
+        key = (left_home, left_away, right_home, right_away, sport)
+        cached = self._orientation_scores.get(key)
+        if cached is not None:
+            return list(cached)
+        scores: list[_OrientationScore] = []
+        if self.same_context(left_home, right_home, sport=sport) and self.same_context(left_away, right_away, sport=sport):
+            scores.append(
+                _OrientationScore(
+                    orientation="as_listed",
+                    home_score=self.team_similarity(left_home, right_home, sport=sport),
+                    away_score=self.team_similarity(left_away, right_away, sport=sport),
+                )
+            )
+        if self.same_context(left_home, right_away, sport=sport) and self.same_context(left_away, right_home, sport=sport):
+            scores.append(
+                _OrientationScore(
+                    orientation="reversed",
+                    home_score=self.team_similarity(left_home, right_away, sport=sport),
+                    away_score=self.team_similarity(left_away, right_home, sport=sport),
+                )
+            )
+        scores = sorted(scores, key=lambda score: score.avg_score, reverse=True)
+        self._orientation_scores[key] = tuple(scores)
+        return scores
 
 
 @dataclass(frozen=True)
@@ -733,6 +860,7 @@ def _is_subset_or_equal_token_pair(
     right_name: str,
     *,
     sport: str | None = None,
+    text_cache: _ResolverTextCache | None = None,
 ) -> bool:
     """True iff one team's significant tokens are a subset/equal of the other's.
 
@@ -742,8 +870,12 @@ def _is_subset_or_equal_token_pair(
     ``Hermine Nantes Basket``) are typically the same team with an extra
     qualifier and are safe to auto-merge at lowered score thresholds.
     """
-    left_tokens = _significant_team_tokens(left_name, sport=sport)
-    right_tokens = _significant_team_tokens(right_name, sport=sport)
+    if text_cache is not None:
+        left_tokens = text_cache.significant_tokens(left_name, sport=sport)
+        right_tokens = text_cache.significant_tokens(right_name, sport=sport)
+    else:
+        left_tokens = _significant_team_tokens(left_name, sport=sport)
+        right_tokens = _significant_team_tokens(right_name, sport=sport)
     if not left_tokens or not right_tokens:
         return False
     return left_tokens <= right_tokens or right_tokens <= left_tokens
@@ -757,6 +889,7 @@ def _weak_side_pair_is_subset_or_equal(
     score: _OrientationScore,
     *,
     sport: str | None = None,
+    text_cache: _ResolverTextCache | None = None,
 ) -> bool:
     if score.orientation == "as_listed":
         home_pair = (left_home, right_home)
@@ -765,7 +898,7 @@ def _weak_side_pair_is_subset_or_equal(
         home_pair = (left_home, right_away)
         away_pair = (left_away, right_home)
     weak_pair = home_pair if score.home_score <= score.away_score else away_pair
-    return _is_subset_or_equal_token_pair(*weak_pair, sport=sport)
+    return _is_subset_or_equal_token_pair(*weak_pair, sport=sport, text_cache=text_cache)
 
 
 def _source_match_score(source: _RawEventSource, candidate: EventCandidate) -> float:
@@ -1024,7 +1157,12 @@ def _shared_significant_tokens(
     right_name: str,
     *,
     sport: str | None = None,
+    text_cache: _ResolverTextCache | None = None,
 ) -> set[str]:
+    if text_cache is not None:
+        return text_cache.significant_tokens(
+            left_name, sport=sport
+        ) & text_cache.significant_tokens(right_name, sport=sport)
     return _significant_team_tokens(left_name, sport=sport) & _significant_team_tokens(
         right_name,
         sport=sport,
@@ -1037,6 +1175,7 @@ def _passes_anchored_low_conf(
     right_candidate: EventCandidate,
     top: _OrientationScore,
     combined_bookmaker_count: int,
+    text_cache: _ResolverTextCache | None = None,
 ) -> bool:
     """Lower-threshold corroborated merge for same-slot pairs.
 
@@ -1077,7 +1216,11 @@ def _passes_anchored_low_conf(
         away_pair = (left_candidate.away_team, right_candidate.home_team)
     weak_pair = home_pair if top.home_score <= top.away_score else away_pair
 
-    if _is_subset_or_equal_token_pair(*weak_pair, sport=left_candidate.sport):
+    if _is_subset_or_equal_token_pair(
+        *weak_pair,
+        sport=left_candidate.sport,
+        text_cache=text_cache,
+    ):
         return True
 
     if left_candidate.sport not in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
@@ -1085,7 +1228,11 @@ def _passes_anchored_low_conf(
     if right_candidate.sport not in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
         return False
 
-    if not _shared_significant_tokens(*weak_pair, sport=left_candidate.sport):
+    if not _shared_significant_tokens(
+        *weak_pair,
+        sport=left_candidate.sport,
+        text_cache=text_cache,
+    ):
         return False
 
     left_league = left_candidate.source_league_id
@@ -1144,12 +1291,15 @@ def _quorum_resolution_passes(
 def _group_pair_resolution(
     left: _CandidateGroup,
     right: _CandidateGroup,
+    *,
+    text_cache: _ResolverTextCache | None = None,
 ) -> _PairResolution | None:
+    text_cache = text_cache or _ResolverTextCache()
     best: _PairResolution | None = None
     combined_bookmaker_count = len(left.bookmakers | right.bookmakers)
     for left_candidate in left.candidates:
         for right_candidate in right.candidates:
-            scores = _orientation_scores(
+            scores = text_cache.orientation_scores(
                 left_candidate.home_team,
                 left_candidate.away_team,
                 right_candidate.home_team,
@@ -1182,6 +1332,7 @@ def _group_pair_resolution(
                     right_candidate.away_team,
                     top,
                     sport=left_candidate.sport,
+                    text_cache=text_cache,
                 )
                 and top.avg_score >= _HIGH_FUZZY_AVG_SCORE
                 and top.weak_side_score >= _HIGH_FUZZY_SIDE_SCORE
@@ -1210,6 +1361,7 @@ def _group_pair_resolution(
                 right_candidate=right_candidate,
                 top=top,
                 combined_bookmaker_count=combined_bookmaker_count,
+                text_cache=text_cache,
             ):
                 resolution = _PairResolution(
                     confidence=top.avg_score / 100,
@@ -1396,6 +1548,7 @@ def build_event_resolution_groups(
     if stats is not None:
         stats.exact_group_count = len(exact_groups)
     dsu = _DisjointSet(exact_groups)
+    text_cache = _ResolverTextCache(stats)
     accepted_pairs: list[tuple[int, int, _PairResolution]] = []
     review_cases: dict[str, EventReviewCaseIn] = {}
 
@@ -1423,7 +1576,7 @@ def build_event_resolution_groups(
                     continue
                 if stats is not None:
                     stats.pair_check_count += 1
-                pair = _group_pair_resolution(left, right)
+                pair = _group_pair_resolution(left, right, text_cache=text_cache)
                 if pair is None:
                     continue
                 if pair.reason_code == "high_confidence_fuzzy_event_match":
@@ -1706,6 +1859,7 @@ async def resolve_and_persist_events(
         candidate_count=len(candidates),
         exact_group_count=group_stats.exact_group_count,
         pair_check_count=group_stats.pair_check_count,
+        fuzzy_score_count=group_stats.fuzzy_score_count,
         accepted_fuzzy_pair_count=group_stats.accepted_fuzzy_pair_count,
         review_case_count=group_stats.review_case_count,
         persisted_resolved_event_count=result.resolved_events,

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -134,9 +134,118 @@ class _OutcomeEventPair:
 @dataclass
 class _FootballEventResolutionStats:
     football_unique_event_count: int = 0
+    football_event_pair_candidate_count: int = 0
+    football_event_fuzzy_score_count: int = 0
     football_event_pair_ranking_ms: int = 0
     football_event_slot_lookup_ms: int = 0
     football_event_slot_mutation_ms: int = 0
+
+
+class _OutcomeTextCache:
+    def __init__(self, stats: _FootballEventResolutionStats | None = None) -> None:
+        self._stats = stats
+        self._qualifiers: dict[tuple[str, str | None], set[str]] = {}
+        self._comparison_text: dict[tuple[str, str | None], str] = {}
+        self._significant_tokens: dict[tuple[str, str | None], set[str]] = {}
+        self._women_marker_forms: dict[str, frozenset[str]] = {}
+
+    def qualifiers(self, name: str, *, sport: str | None = None) -> set[str]:
+        key = (name, sport)
+        cached = self._qualifiers.get(key)
+        if cached is None:
+            cached = _team_qualifiers(name, sport=sport)
+            self._qualifiers[key] = cached
+        return cached
+
+    def comparison_text(self, name: str, *, sport: str | None = None) -> str:
+        key = (name, sport)
+        cached = self._comparison_text.get(key)
+        if cached is None:
+            qualifiers = self.qualifiers(name, sport=sport)
+            comparison_name = (
+                _strip_explicit_z_women_markers(name)
+                if "women" in qualifiers
+                else name
+            )
+            tokens = normalize_identity_text(comparison_name).split()
+            if "women" in qualifiers:
+                tokens = [
+                    token for token in tokens if token not in _WOMEN_MARKER_TOKENS
+                ]
+            cached = " ".join(tokens)
+            self._comparison_text[key] = cached
+        return cached
+
+    def significant_tokens(self, name: str, *, sport: str | None = None) -> set[str]:
+        key = (name, sport)
+        cached = self._significant_tokens.get(key)
+        if cached is None:
+            cached = {
+                token
+                for token in self.comparison_text(name, sport=sport).split()
+                if token not in _LOW_SIGNAL_TEAM_TOKENS
+            }
+            self._significant_tokens[key] = cached
+        return cached
+
+    def same_context(
+        self,
+        left: str,
+        right: str,
+        *,
+        sport: str | None = None,
+    ) -> bool:
+        return self.qualifiers(left, sport=sport) == self.qualifiers(
+            right, sport=sport
+        )
+
+    def team_similarity(
+        self,
+        left: str,
+        right: str,
+        *,
+        sport: str | None = None,
+    ) -> float:
+        left_key = self.comparison_text(left, sport=sport)
+        right_key = self.comparison_text(right, sport=sport)
+        if not left_key or not right_key:
+            return 0.0
+        if left_key == right_key:
+            return 100.0
+        left_tokens = self.significant_tokens(left, sport=sport)
+        right_tokens = self.significant_tokens(right, sport=sport)
+        if left_tokens and left_tokens == right_tokens:
+            return 100.0
+        if self._stats is not None:
+            self._stats.football_event_fuzzy_score_count += 1
+        return float(fuzz.token_sort_ratio(left_key, right_key))
+
+    def comparison_texts_are_compatible(
+        self,
+        left_name: str,
+        right_name: str,
+        *,
+        sport: str | None = None,
+        team_ids: tuple[int, int] | None = None,
+    ) -> bool:
+        if team_ids is not None and team_ids[0] == team_ids[1]:
+            return True
+        left_text = self.comparison_text(left_name, sport=sport)
+        right_text = self.comparison_text(right_name, sport=sport)
+        if left_text == right_text:
+            return True
+        left_tokens = self.significant_tokens(left_name, sport=sport)
+        right_tokens = self.significant_tokens(right_name, sport=sport)
+        if not left_tokens or not right_tokens:
+            return False
+        return left_tokens <= right_tokens or right_tokens <= left_tokens
+
+    def women_marker_forms(self, name: str) -> frozenset[str]:
+        cached = self._women_marker_forms.get(name)
+        if cached is None:
+            cached = _women_marker_forms(name, text_cache=self)
+            self._women_marker_forms[name] = cached
+        return cached
 
 
 def _significant_tokens(name: str, *, sport: str | None = None) -> set[str]:
@@ -334,33 +443,42 @@ def _unique_events(raw_list: list[RawOutcomeOffer]) -> list[_OutcomeEvent]:
     return events
 
 
-def _pair_candidates(left: _OutcomeEvent, right: _OutcomeEvent) -> _OutcomeEventPair | None:
+def _pair_candidates(
+    left: _OutcomeEvent,
+    right: _OutcomeEvent,
+    *,
+    text_cache: _OutcomeTextCache | None = None,
+    stats: _FootballEventResolutionStats | None = None,
+) -> _OutcomeEventPair | None:
     if left.bookmaker_id == right.bookmaker_id or left.sport != right.sport or left.start_time != right.start_time:
         return None
+    if stats is not None:
+        stats.football_event_pair_candidate_count += 1
+    text_cache = text_cache or _OutcomeTextCache(stats)
     candidates: list[_OutcomeEventPair] = []
-    if _same_team_context(left.home_team, right.home_team, sport=left.sport) and _same_team_context(left.away_team, right.away_team, sport=left.sport):
+    if text_cache.same_context(left.home_team, right.home_team, sport=left.sport) and text_cache.same_context(left.away_team, right.away_team, sport=left.sport):
         candidates.append(
             _OutcomeEventPair(
                 left=left,
                 right=right,
-                home_score=_team_similarity(
+                home_score=text_cache.team_similarity(
                     left.home_team, right.home_team, sport=left.sport
                 ),
-                away_score=_team_similarity(
+                away_score=text_cache.team_similarity(
                     left.away_team, right.away_team, sport=left.sport
                 ),
                 orientation=_SAME_ORIENTATION,
             )
         )
-    if _same_team_context(left.home_team, right.away_team, sport=left.sport) and _same_team_context(left.away_team, right.home_team, sport=left.sport):
+    if text_cache.same_context(left.home_team, right.away_team, sport=left.sport) and text_cache.same_context(left.away_team, right.home_team, sport=left.sport):
         candidates.append(
             _OutcomeEventPair(
                 left=left,
                 right=right,
-                home_score=_team_similarity(
+                home_score=text_cache.team_similarity(
                     left.home_team, right.away_team, sport=left.sport
                 ),
-                away_score=_team_similarity(
+                away_score=text_cache.team_similarity(
                     left.away_team, right.home_team, sport=left.sport
                 ),
                 orientation=_REVERSED_ORIENTATION,
@@ -545,7 +663,15 @@ def _comparison_team_texts_are_compatible(
     *,
     sport: str | None = None,
     team_ids: tuple[int, int] | None = None,
+    text_cache: _OutcomeTextCache | None = None,
 ) -> bool:
+    if text_cache is not None:
+        return text_cache.comparison_texts_are_compatible(
+            left_name,
+            right_name,
+            sport=sport,
+            team_ids=team_ids,
+        )
     if team_ids is not None and team_ids[0] == team_ids[1]:
         return True
     left_text = _comparison_team_text(left_name, sport=sport)
@@ -563,11 +689,13 @@ def _pair_has_compatible_women_context(
     pair: _OutcomeEventPair,
     *,
     oriented_team_ids: tuple[tuple[int, int], tuple[int, int]] | None = None,
+    text_cache: _OutcomeTextCache | None = None,
 ) -> bool:
+    text_cache = text_cache or _OutcomeTextCache()
     has_women_pair = False
     for index, (left_name, right_name) in enumerate(_oriented_pair_team_names(pair)):
-        left_qualifiers = _team_qualifiers(left_name, sport=pair.left.sport)
-        right_qualifiers = _team_qualifiers(right_name, sport=pair.left.sport)
+        left_qualifiers = text_cache.qualifiers(left_name, sport=pair.left.sport)
+        right_qualifiers = text_cache.qualifiers(right_name, sport=pair.left.sport)
         if left_qualifiers != right_qualifiers:
             return False
         if "women" in left_qualifiers:
@@ -577,12 +705,17 @@ def _pair_has_compatible_women_context(
             right_name,
             sport=pair.left.sport,
             team_ids=oriented_team_ids[index] if oriented_team_ids is not None else None,
+            text_cache=text_cache,
         ):
             return False
     return has_women_pair
 
 
-def _women_marker_forms(name: str) -> frozenset[str]:
+def _women_marker_forms(
+    name: str,
+    *,
+    text_cache: _OutcomeTextCache | None = None,
+) -> frozenset[str]:
     forms: set[str] = set()
     if re.search(r"\(\s*[žz]\s*\)", name, flags=re.IGNORECASE):
         forms.add("z:parenthesized")
@@ -629,13 +762,21 @@ def _women_marker_forms(name: str) -> frozenset[str]:
 
 
 def _pair_has_women_marker_variation(pair: _OutcomeEventPair) -> bool:
+    return _pair_has_women_marker_variation_cached(pair, text_cache=_OutcomeTextCache())
+
+
+def _pair_has_women_marker_variation_cached(
+    pair: _OutcomeEventPair,
+    *,
+    text_cache: _OutcomeTextCache,
+) -> bool:
     for left_name, right_name in _oriented_pair_team_names(pair):
-        left_qualifiers = _team_qualifiers(left_name, sport=pair.left.sport)
-        right_qualifiers = _team_qualifiers(right_name, sport=pair.left.sport)
+        left_qualifiers = text_cache.qualifiers(left_name, sport=pair.left.sport)
+        right_qualifiers = text_cache.qualifiers(right_name, sport=pair.left.sport)
         if (
             left_qualifiers == right_qualifiers
             and "women" in left_qualifiers
-            and _women_marker_forms(left_name) != _women_marker_forms(right_name)
+            and text_cache.women_marker_forms(left_name) != text_cache.women_marker_forms(right_name)
         ):
             return True
     return False
@@ -645,6 +786,7 @@ def _rank_event_pairs(
     events: list[_OutcomeEvent],
     *,
     resolutions: dict[tuple[str, str, str, str, str], _OutcomeEventResolution] | None = None,
+    stats: _FootballEventResolutionStats | None = None,
 ) -> list[_OutcomeEventPair]:
     events_by_slot: dict[tuple[str, str], list[_OutcomeEvent]] = defaultdict(list)
     for event in events:
@@ -652,11 +794,12 @@ def _rank_event_pairs(
 
     accepted: list[_OutcomeEventPair] = []
     for events in events_by_slot.values():
+        text_cache = _OutcomeTextCache(stats)
         all_pairs: list[_OutcomeEventPair] = []
         candidates_by_event: dict[_OutcomeEvent, list[_OutcomeEventPair]] = defaultdict(list)
         for idx, left in enumerate(events):
             for right in events[idx + 1 :]:
-                pair = _pair_candidates(left, right)
+                pair = _pair_candidates(left, right, text_cache=text_cache, stats=stats)
                 if pair is None:
                     continue
                 all_pairs.append(pair)
@@ -691,8 +834,9 @@ def _rank_event_pairs(
                 _pair_has_compatible_women_context(
                     pair,
                     oriented_team_ids=oriented_team_ids,
+                    text_cache=text_cache,
                 )
-                and _pair_has_women_marker_variation(pair)
+                and _pair_has_women_marker_variation_cached(pair, text_cache=text_cache)
                 and pair not in accepted
             ):
                 accepted.append(pair)
@@ -719,7 +863,7 @@ def _build_football_event_resolutions(
         stats.football_event_slot_lookup_ms += _elapsed_ms(lookup_started_at)
 
     ranking_started_at = time.perf_counter()
-    ranked_pairs = _rank_event_pairs(events, resolutions=resolutions)
+    ranked_pairs = _rank_event_pairs(events, resolutions=resolutions, stats=stats)
     if stats is not None:
         stats.football_event_pair_ranking_ms += _elapsed_ms(ranking_started_at)
 
@@ -1052,6 +1196,12 @@ def normalize_outcome_offers_with_context(
         unresolved_outcome_offer_count=len(unresolved),
         football_unique_event_count=(
             football_resolution_stats.football_unique_event_count
+        ),
+        football_event_pair_candidate_count=(
+            football_resolution_stats.football_event_pair_candidate_count
+        ),
+        football_event_fuzzy_score_count=(
+            football_resolution_stats.football_event_fuzzy_score_count
         ),
         auto_created_football_team_count=auto_created_team_count,
         auto_create_football_teams_ms=auto_create_football_teams_ms,

--- a/backend/tests/test_event_resolver.py
+++ b/backend/tests/test_event_resolver.py
@@ -17,6 +17,7 @@ from app.services import event_resolver as event_resolver_module
 from app.services.event_resolver import (
     EventCandidate,
     _CandidateGroup,
+    _EventGroupBuildStats,
     _PairResolution,
     _comparison_team_text,
     _contextual_merge_source_ids,
@@ -151,6 +152,37 @@ def test_event_resolution_groups_keep_sports_separate_for_same_teams_and_time():
         ("basketball", "basketball-match"),
         ("football", "football-match"),
     }
+
+
+def test_event_resolution_benchmark_counts_pair_and_fuzzy_work():
+    candidates = [
+        EventCandidate(
+            match_id="basketball-a",
+            bookmaker_id="book-a",
+            sport="basketball",
+            start_time=START_TIME,
+            home_team_id=1,
+            away_team_id=2,
+            home_team="Basket Sibirsk",
+            away_team="CSKA Moscow",
+        ),
+        EventCandidate(
+            match_id="basketball-b",
+            bookmaker_id="book-b",
+            sport="basketball",
+            start_time=START_TIME,
+            home_team_id=3,
+            away_team_id=2,
+            home_team="Blec Sybirsk",
+            away_team="CSKA Moscow",
+        ),
+    ]
+    stats = _EventGroupBuildStats()
+
+    build_event_resolution_groups(candidates, stats=stats)
+
+    assert stats.pair_check_count == 1
+    assert stats.fuzzy_score_count >= 1
 
 
 async def _seed_bookmakers(*bookmaker_ids: str) -> None:

--- a/backend/tests/test_outcome_normalizer.py
+++ b/backend/tests/test_outcome_normalizer.py
@@ -6,6 +6,8 @@ from app.config import settings
 from app.models.schemas import RawOutcomeOffer
 from app.services.normalizer import generate_match_id
 from app.services.outcome_normalizer import (
+    _FootballEventResolutionStats,
+    _build_football_event_resolutions,
     _same_team_context,
     _team_similarity,
     _team_qualifiers,
@@ -96,6 +98,19 @@ def test_cross_book_football_autocreate_reports_multiple_batch_created_teams(tea
     assert review_cases == []
     assert benchmark.auto_created_football_team_count == 2
     assert {"Batch Home FC", "Batch Away FC"} <= _canonical_team_names()
+
+
+def test_football_event_resolution_benchmark_counts_pair_and_fuzzy_work(team_registry_file):
+    raw = [
+        _offer("maxbet", "Basket Sibirsk", "CSKA Moscow", outcome_code="over"),
+        _offer("balkanbet", "Blec Sybirsk", "CSKA Moscow", outcome_code="under"),
+    ]
+    stats = _FootballEventResolutionStats()
+
+    _build_football_event_resolutions(raw, stats=stats)
+
+    assert stats.football_event_pair_candidate_count == 1
+    assert stats.football_event_fuzzy_score_count >= 1
 
 
 def test_one_strong_football_team_matches_event_without_alias_write(team_registry_file):


### PR DESCRIPTION
## Summary
- add short-lived text/scoring caches in football outcome event pairing and resolved-event grouping
- expose pair candidate and fuzzy scoring counters in benchmark metadata
- add regression coverage for the new hot-loop counters while preserving existing false-positive guardrails

Closes #101

## Tests
- cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q tests/test_event_resolver.py tests/test_outcome_normalizer.py tests/test_normalizer.py
- cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q tests/test_scraper_benchmarks.py tests/test_api.py -k 'benchmark or scraper_benchmarks'\n- cd backend && /Users/filiptanic/code/kvotolovac/backend/venv/bin/python -m pytest -q