### PR TITLE
Centralize team identity policy

### DIFF
--- a/backend/app/api/matches.py
+++ b/backend/app/api/matches.py
@@ -15,7 +15,10 @@ from ..models.schemas import (
     OutcomeOfferOut,
 )
 from ..services.scheduler import scheduler
-from ..services.team_registry import merge_canonical_teams
+from ..services.team_registry import (
+    merge_canonical_teams,
+    validate_canonical_team_merge_identity,
+)
 from ..store import odds_store
 
 router = APIRouter(prefix="/matches", tags=["matches"])
@@ -126,26 +129,100 @@ async def merge_matches(payload: MatchMergeIn) -> MatchMergeOut:
             )
         source_matches.append(match)
 
-    # Validate team pairings: every distinct (source_team_id -> target_team_id) requested
-    # must reference real teams. The frontend computes pairings from match home/away
-    # team IDs; we honor whatever it sends but reject self-pairings of different teams
-    # going to the same target inconsistently.
-    pairing_map: dict[int, int] = {}
-    for pairing in payload.team_pairings:
-        if pairing.source_team_id <= 0 or pairing.target_team_id <= 0:
-            continue
-        if pairing.source_team_id == pairing.target_team_id:
-            continue
-        existing = pairing_map.get(pairing.source_team_id)
-        if existing is not None and existing != pairing.target_team_id:
+    # Validate team pairings: every distinct source->target team relationship must
+    # reference real teams and pass identity guardrails before match rows mutate.
+    # Submitted pairings are the only ones persisted after a successful match merge,
+    # but derived home/away pairings are also prevalidated so clients cannot bypass
+    # qualifier checks by omitting pairings.
+    requested_pairing_map: dict[int, int] = {}
+    validation_pairing_map: dict[int, int] = {}
+    explicit_pairing_source_team_ids: set[int] = set()
+    target_team_ids = {
+        team_id
+        for team_id in (target_match.home_team_id, target_match.away_team_id)
+        if team_id and team_id > 0
+    }
+    source_team_ids = {
+        team_id
+        for source_match in source_matches
+        for team_id in (source_match.home_team_id, source_match.away_team_id)
+        if team_id and team_id > 0
+    }
+
+    def add_pairing(
+        pairing_map: dict[int, int],
+        *,
+        source_team_id: int | None,
+        target_team_id: int | None,
+    ) -> None:
+        if not source_team_id or not target_team_id:
+            return
+        if source_team_id <= 0 or target_team_id <= 0:
+            return
+        if source_team_id == target_team_id:
+            return
+        existing = pairing_map.get(source_team_id)
+        if existing is not None and existing != target_team_id:
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"Conflicting pairings for source team {pairing.source_team_id}: "
-                    f"both {existing} and {pairing.target_team_id}"
+                    f"Conflicting pairings for source team {source_team_id}: "
+                    f"both {existing} and {target_team_id}"
                 ),
             )
-        pairing_map[pairing.source_team_id] = pairing.target_team_id
+        pairing_map[source_team_id] = target_team_id
+
+    def add_derived_pairing(
+        *,
+        source_team_id: int | None,
+        target_team_id: int | None,
+    ) -> None:
+        if source_team_id in explicit_pairing_source_team_ids:
+            return
+        add_pairing(
+            validation_pairing_map,
+            source_team_id=source_team_id,
+            target_team_id=target_team_id,
+        )
+
+    for pairing in payload.team_pairings:
+        if pairing.source_team_id > 0 and pairing.target_team_id > 0:
+            if pairing.source_team_id not in source_team_ids:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Source canonical team {pairing.source_team_id} "
+                        "is not part of the source matches"
+                    ),
+                )
+            if pairing.target_team_id not in target_team_ids:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Target canonical team {pairing.target_team_id} "
+                        "is not part of the target match"
+                    ),
+                )
+            explicit_pairing_source_team_ids.add(pairing.source_team_id)
+        add_pairing(
+            requested_pairing_map,
+            source_team_id=pairing.source_team_id,
+            target_team_id=pairing.target_team_id,
+        )
+        add_pairing(
+            validation_pairing_map,
+            source_team_id=pairing.source_team_id,
+            target_team_id=pairing.target_team_id,
+        )
+    for source_match in source_matches:
+        add_derived_pairing(
+            source_team_id=source_match.home_team_id,
+            target_team_id=target_match.home_team_id,
+        )
+        add_derived_pairing(
+            source_team_id=source_match.away_team_id,
+            target_team_id=target_match.away_team_id,
+        )
 
     # Pre-validate every team pairing before mutating anything: missing teams
     # raise 404, invalid pairings raise 400. We intentionally do NOT call
@@ -155,7 +232,7 @@ async def merge_matches(payload: MatchMergeIn) -> MatchMergeOut:
     from ..services.team_registry import (
         get_canonical_team,
     )  # local import to avoid cycle at module load
-    for source_team_id, target_team_id in pairing_map.items():
+    for source_team_id, target_team_id in validation_pairing_map.items():
         if get_canonical_team(source_team_id) is None:
             raise HTTPException(
                 status_code=404,
@@ -166,6 +243,14 @@ async def merge_matches(payload: MatchMergeIn) -> MatchMergeOut:
                 status_code=404,
                 detail=f"Target canonical team {target_team_id} not found",
             )
+        try:
+            validate_canonical_team_merge_identity(
+                source_team_id=source_team_id,
+                target_team_id=target_team_id,
+                allow_unsafe_subset=True,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     try:
         counts = await odds_store.merge_matches(
@@ -182,12 +267,13 @@ async def merge_matches(payload: MatchMergeIn) -> MatchMergeOut:
     # need to be merged manually via the canonical-teams endpoint.
     merged_pairings: list[MatchMergeTeamPairing] = []
     failed_pairings: list[tuple[int, int, str]] = []
-    for source_team_id, target_team_id in pairing_map.items():
+    for source_team_id, target_team_id in requested_pairing_map.items():
         try:
             await asyncio.to_thread(
                 merge_canonical_teams,
                 source_team_id=source_team_id,
                 target_team_id=target_team_id,
+                allow_unsafe_subset=True,
             )
             merged_pairings.append(
                 MatchMergeTeamPairing(

--- a/backend/app/api/team_review.py
+++ b/backend/app/api/team_review.py
@@ -21,6 +21,7 @@ from ..services.team_registry import (
     merge_canonical_teams,
     remember_team_alias,
     resolve_team_alias,
+    validate_team_name_identity,
 )
 from ..services.text_normalizer import normalize_identity_text
 from ..store import odds_store
@@ -90,6 +91,7 @@ async def _merge_existing_canonical_duplicate_for_review(
         merge_canonical_teams,
         source_team_id=source_team.id,
         target_team_id=target_team_id,
+        allow_unsafe_subset=True,
     )
     resolution = await _remember_team_alias(case, target_team_name=target_team_name)
     return resolution, source_team
@@ -136,6 +138,16 @@ async def approve_team_review_case(
         )
 
     if create_team_name:
+        try:
+            await asyncio.to_thread(
+                validate_team_name_identity,
+                case.raw_team_name,
+                create_team_name,
+                sport=case.sport,
+                allow_unsafe_subset=True,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         target_resolution = await asyncio.to_thread(
             create_canonical_team,
             display_name=create_team_name,
@@ -169,6 +181,16 @@ async def approve_team_review_case(
 
     merged_source_team: CanonicalTeamSummary | None = None
     try:
+        await asyncio.to_thread(
+            validate_team_name_identity,
+            case.raw_team_name,
+            target_team_name,
+            sport=case.sport,
+            allow_unsafe_subset=True,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    try:
         resolution = await _remember_team_alias(case, target_team_name=target_team_name)
     except CircularAliasError as exc:
         try:
@@ -181,6 +203,8 @@ async def approve_team_review_case(
                 if target_team_id > 0
                 else None
             )
+        except ValueError as retry_exc:
+            raise HTTPException(status_code=400, detail=str(retry_exc)) from retry_exc
         except CircularAliasError as retry_exc:
             raise HTTPException(status_code=409, detail=str(retry_exc)) from retry_exc
         if merged_result is None:

--- a/backend/app/services/match_unification/event_matching.py
+++ b/backend/app/services/match_unification/event_matching.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import re
 
 from ..tennis_name_matcher import tennis_competitor_pair_matches
-from ..text_normalizer import normalize_identity_text
-from .team_text import (
+from ..team_identity import (
     AGGRESSIVE_MERGE_SPORTS as _AGGRESSIVE_MERGE_SPORTS,
+    event_team_similarity as _event_team_similarity,
+    expand_dotted_team_token as _expand_dotted_token,
     same_team_context as _same_team_context,
-    team_similarity as _team_similarity,
 )
+from ..text_normalizer import normalize_identity_text
 
 
 @dataclass(frozen=True)
@@ -72,80 +72,6 @@ class _OrientationScore:
 # modules cannot drift; new sports must be enabled in exactly one place.
 _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE: frozenset[str] = _AGGRESSIVE_MERGE_SPORTS
 
-# 2-letter dot-prefixes that overlap heavily with non-team words (street,
-# fort, mount, port, point, doctor, mister, avenue, saint) and would
-# otherwise produce false-positive expansions even within basketball
-# (e.g. ``St.Petersburg`` ↔ ``Stockholm Petersburg``). Keeping these out of
-# the dot-expansion logic preserves the genuine ``Ch.More`` ↔ ``Cherno More``
-# case while blocking the geographic collision class.
-_AMBIGUOUS_DOT_PREFIXES: frozenset[str] = frozenset(
-    {"st", "ft", "mt", "pt", "dr", "mr", "av"}
-)
-
-
-def _expand_dotted_token(name: str, counterpart: str) -> str:
-    """Substitute dot-truncated tokens (``Ch.``, ``Pl.``, ``Ch.More``) by an
-    unambiguous expansion drawn from ``counterpart``.
-
-    Only used inside the Match Unification — keeps shared :func:`_team_similarity`
-    untouched so football pairing is unaffected. Restrictions:
-
-    * Token must end with ``.`` and have at least 2 characters of prefix
-      (1-letter prefixes are too ambiguous, e.g. ``B.`` could be Bayern,
-      Brest, Belgrade, …).
-    * The prefix must not be in ``_AMBIGUOUS_DOT_PREFIXES`` — these short
-      geographic / honorific prefixes (``St``, ``Mt``, ``Ft``, …) collide
-      with real team-name tokens (``Stockholm``, ``Manchester``, ``Fort``,
-      …) and the structural anchor check below cannot disambiguate them.
-    * The counterpart must contain exactly one token starting with that
-      prefix; ambiguous expansions are dropped.
-    * The source name must contain at least one OTHER non-dotted token that
-      already appears in the counterpart — this anchors the expansion in
-      genuine name overlap and blocks coincidences like
-      ``St. Petersburg`` ↔ ``Stockholm Giants`` where ``St`` would
-      otherwise expand to ``Stockholm`` purely on prefix uniqueness.
-
-    Compound tokens with internal dots (``Ch.More`` → ``Ch. More``) are
-    pre-split before expansion so a missing space after the period does not
-    mask the abbreviation.
-    """
-
-    spaced = re.sub(r"\.(?=\S)", ". ", name)
-    counterpart_spaced = re.sub(r"\.(?=\S)", ". ", counterpart)
-    counterpart_tokens = counterpart_spaced.split()
-    counterpart_token_set = {token.lower().rstrip(".") for token in counterpart_tokens}
-    source_tokens = spaced.split()
-    has_anchor = any(
-        not token.endswith(".") and token.lower() in counterpart_token_set
-        for token in source_tokens
-    )
-    if not has_anchor:
-        return name
-    output: list[str] = []
-    for token in source_tokens:
-        if not token.endswith(".") or len(token) < 3:
-            output.append(token)
-            continue
-        prefix = token[:-1].lower()
-        if len(prefix) < 2:
-            output.append(token)
-            continue
-        if prefix in _AMBIGUOUS_DOT_PREFIXES:
-            output.append(token)
-            continue
-        candidates = [
-            candidate
-            for candidate in counterpart_tokens
-            if len(candidate) > len(prefix)
-            and candidate.lower().startswith(prefix)
-        ]
-        if len(candidates) == 1:
-            output.append(candidates[0])
-        else:
-            output.append(token)
-    return " ".join(output)
-
-
 def _resolver_team_similarity(
     left: str, right: str, *, sport: str | None = None
 ) -> float:
@@ -162,12 +88,7 @@ def _resolver_team_similarity(
     incorrectly merge two distinct cities).
     """
 
-    expanded_left = left
-    expanded_right = right
-    if sport in _TARGETED_SPORTS_FOR_AGGRESSIVE_MERGE:
-        expanded_left = _expand_dotted_token(left, right)
-        expanded_right = _expand_dotted_token(right, left)
-    return _team_similarity(expanded_left, expanded_right, sport=sport)
+    return _event_team_similarity(left, right, sport=sport, expand_dotted=True)
 
 
 def _orientation_scores(

--- a/backend/app/services/match_unification/resolution.py
+++ b/backend/app/services/match_unification/resolution.py
@@ -38,10 +38,14 @@ from .event_matching import (
     _expand_dotted_token,
     _orientation_scores,
 )
-from .team_text import (
+from ..team_identity import (
+    canonical_team_auto_merge_analysis as _canonical_team_auto_merge_analysis,
+    canonical_team_similarity_score as _canonical_team_similarity_score,
     comparison_team_text as _comparison_team_text,
-    same_team_context as _same_team_context,
+    event_similarity_score_from_parts as _event_similarity_score_from_parts,
+    match_unification_significant_tokens as _identity_significant_tokens,
     team_qualifiers as _team_qualifiers,
+    unsafe_compound_subset_match as _unsafe_compound_subset_match,
 )
 from ..tennis_name_matcher import (
     TENNIS_BROAD_DRIFT_MINUTES,
@@ -83,17 +87,6 @@ _QUORUM_CANONICAL_SIDE_ANCHOR_AVG_SCORE = 70.0
 _QUORUM_CANONICAL_SIDE_ANCHOR_WEAK_SIDE_SCORE = 45.0
 _QUORUM_MIN_LARGER_BOOKMAKERS = 5
 _QUORUM_MIN_BOOKMAKER_DIFFERENCE = 3
-_LOW_SIGNAL_TEAM_TOKENS = {
-    "bc",
-    "bk",
-    "kk",
-    "fc",
-    "fk",
-    "club",
-    "team",
-}
-
-
 def _elapsed_ms(started_at: float) -> int:
     return int((time.perf_counter() - started_at) * 1000)
 
@@ -128,11 +121,7 @@ class SameTimeCanonicalMergeProposal:
 
 
 def _significant_team_tokens(team_name: str, *, sport: str | None = None) -> set[str]:
-    return {
-        token
-        for token in _comparison_team_text(team_name, sport=sport).split()
-        if token not in _LOW_SIGNAL_TEAM_TOKENS
-    }
+    return _identity_significant_tokens(team_name, sport=sport)
 
 
 def _symmetric_canonical_team_score(
@@ -141,33 +130,7 @@ def _symmetric_canonical_team_score(
     *,
     sport: str | None = None,
 ) -> float:
-    left_key = _comparison_team_text(left_name, sport=sport)
-    right_key = _comparison_team_text(right_name, sport=sport)
-    if not left_key or not right_key:
-        return 0.0
-    if left_key == right_key:
-        return 100.0
-
-    left_tokens = _significant_team_tokens(left_name, sport=sport)
-    right_tokens = _significant_team_tokens(right_name, sport=sport)
-    if not left_tokens or not right_tokens:
-        return 0.0
-    if left_tokens == right_tokens:
-        return 100.0
-    if left_tokens < right_tokens or right_tokens < left_tokens:
-        return float(
-            min(
-                fuzz.ratio(left_key, right_key),
-                fuzz.token_sort_ratio(left_key, right_key),
-            )
-        )
-
-    return float(
-        min(
-            fuzz.ratio(left_key, right_key),
-            fuzz.token_sort_ratio(left_key, right_key),
-        )
-    )
+    return _canonical_team_similarity_score(left_name, right_name, sport=sport)
 
 
 def _is_unsafe_compound_subset_match(
@@ -176,13 +139,7 @@ def _is_unsafe_compound_subset_match(
     *,
     sport: str | None = None,
 ) -> bool:
-    left_tokens = _significant_team_tokens(left_name, sport=sport)
-    right_tokens = _significant_team_tokens(right_name, sport=sport)
-    return bool(
-        left_tokens
-        and right_tokens
-        and (left_tokens < right_tokens or right_tokens < left_tokens)
-    )
+    return _unsafe_compound_subset_match(left_name, right_name, sport=sport)
 
 
 def _canonical_team_auto_merge_score(
@@ -191,22 +148,15 @@ def _canonical_team_auto_merge_score(
     *,
     sport: str | None = None,
 ) -> float | None:
-    if not _same_team_context(source_team_name, target_team_name, sport=sport):
-        return None
-    if _is_unsafe_compound_subset_match(
+    analysis = _canonical_team_auto_merge_analysis(
         source_team_name,
         target_team_name,
         sport=sport,
-    ):
-        return None
-    score = _symmetric_canonical_team_score(
-        source_team_name,
-        target_team_name,
-        sport=sport,
+        threshold=CANONICAL_TEAM_AUTO_MERGE_THRESHOLD,
     )
-    if score < CANONICAL_TEAM_AUTO_MERGE_THRESHOLD:
+    if not analysis.auto_merge_safe:
         return None
-    return score
+    return analysis.score
 
 
 def _same_time_slot_orientation(
@@ -503,11 +453,7 @@ class _ResolverTextCache:
         key = (name, sport)
         cached = self._significant_tokens.get(key)
         if cached is None:
-            cached = {
-                token
-                for token in self.comparison_text(name, sport=sport).split()
-                if token not in _LOW_SIGNAL_TEAM_TOKENS
-            }
+            cached = _significant_team_tokens(name, sport=sport)
             self._significant_tokens[key] = cached
         return cached
 
@@ -543,21 +489,15 @@ class _ResolverTextCache:
         if cached is not None:
             return cached
 
-        left_key = self.comparison_text(expanded_left, sport=sport)
-        right_key = self.comparison_text(expanded_right, sport=sport)
-        if not left_key or not right_key:
-            score = 0.0
-        elif left_key == right_key:
-            score = 100.0
-        else:
-            left_tokens = self.significant_tokens(expanded_left, sport=sport)
-            right_tokens = self.significant_tokens(expanded_right, sport=sport)
-            if left_tokens and left_tokens == right_tokens:
-                score = 100.0
-            else:
-                if self._stats is not None:
-                    self._stats.fuzzy_score_count += 1
-                score = float(fuzz.token_sort_ratio(left_key, right_key))
+        score_result = _event_similarity_score_from_parts(
+            self.comparison_text(expanded_left, sport=sport),
+            self.comparison_text(expanded_right, sport=sport),
+            self.significant_tokens(expanded_left, sport=sport),
+            self.significant_tokens(expanded_right, sport=sport),
+        )
+        if self._stats is not None and score_result.used_fuzzy_score:
+            self._stats.fuzzy_score_count += 1
+        score = score_result.score
         self._team_similarity[key] = score
         return score
 

--- a/backend/app/services/match_unification/team_text.py
+++ b/backend/app/services/match_unification/team_text.py
@@ -1,68 +1,33 @@
 from __future__ import annotations
 
-from rapidfuzz import fuzz
-
-from ..team_qualifiers import (
+from ..team_identity import (
+    AGGRESSIVE_MERGE_SPORTS,
     EXPLICIT_Z_WOMEN_MARKER_RE,
     FOREIGN_WOMEN_TOKENS,
+    LOW_SIGNAL_TEAM_TOKENS,
     TEAM_QUALIFIER_TOKENS,
     WOMEN_MARKER_TOKENS,
     WOMEN_QUALIFIER_ALIASES,
+    comparison_team_text,
+    same_team_context,
+    significant_tokens,
     strip_explicit_z_women_markers,
     team_qualifiers,
+    team_similarity,
 )
-from ..text_normalizer import normalize_identity_text
 
-LOW_SIGNAL_TEAM_TOKENS = {
-    "bc",
-    "bk",
-    "kk",
-    "fc",
-    "fk",
-    "club",
-    "team",
-    "sc",
-    "cf",
-    "cd",
-    "ce",
-}
-AGGRESSIVE_MERGE_SPORTS = frozenset({"basketball"})
-
-
-def comparison_team_text(team_name: str, *, sport: str | None = None) -> str:
-    qualifiers = team_qualifiers(team_name, sport=sport)
-    comparison_name = (
-        strip_explicit_z_women_markers(team_name)
-        if "women" in qualifiers
-        else team_name
-    )
-    tokens = normalize_identity_text(comparison_name).split()
-    if "women" in qualifiers:
-        tokens = [token for token in tokens if token not in WOMEN_MARKER_TOKENS]
-    return " ".join(tokens)
-
-
-def significant_tokens(name: str, *, sport: str | None = None) -> set[str]:
-    return {
-        token
-        for token in comparison_team_text(name, sport=sport).split()
-        if token not in LOW_SIGNAL_TEAM_TOKENS
-    }
-
-
-def team_similarity(left: str, right: str, *, sport: str | None = None) -> float:
-    left_key = comparison_team_text(left, sport=sport)
-    right_key = comparison_team_text(right, sport=sport)
-    if not left_key or not right_key:
-        return 0.0
-    if left_key == right_key:
-        return 100.0
-    left_tokens = significant_tokens(left, sport=sport)
-    right_tokens = significant_tokens(right, sport=sport)
-    if left_tokens and left_tokens == right_tokens:
-        return 100.0
-    return float(fuzz.token_sort_ratio(left_key, right_key))
-
-
-def same_team_context(left: str, right: str, *, sport: str | None = None) -> bool:
-    return team_qualifiers(left, sport=sport) == team_qualifiers(right, sport=sport)
+__all__ = [
+    "AGGRESSIVE_MERGE_SPORTS",
+    "EXPLICIT_Z_WOMEN_MARKER_RE",
+    "FOREIGN_WOMEN_TOKENS",
+    "LOW_SIGNAL_TEAM_TOKENS",
+    "TEAM_QUALIFIER_TOKENS",
+    "WOMEN_MARKER_TOKENS",
+    "WOMEN_QUALIFIER_ALIASES",
+    "comparison_team_text",
+    "same_team_context",
+    "significant_tokens",
+    "strip_explicit_z_women_markers",
+    "team_qualifiers",
+    "team_similarity",
+]

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -7,8 +7,6 @@ import logging
 import re
 import time
 
-from rapidfuzz import fuzz
-
 from ..models.schemas import (
     NormalizedOutcomeOffer,
     OutcomeNormalizationBenchmarkOut,
@@ -34,17 +32,15 @@ from .tennis_name_matcher import (
     match_tennis_player_names,
     tennis_competitor_pair_matches,
 )
-from .match_unification.team_text import (
-    EXPLICIT_Z_WOMEN_MARKER_RE as _EXPLICIT_Z_WOMEN_MARKER_RE,
+from .team_identity import (
     FOREIGN_WOMEN_TOKENS as _FOREIGN_WOMEN_TOKENS,
-    LOW_SIGNAL_TEAM_TOKENS as _LOW_SIGNAL_TEAM_TOKENS,
     TEAM_QUALIFIER_TOKENS as _TEAM_QUALIFIER_TOKENS,
-    WOMEN_MARKER_TOKENS as _WOMEN_MARKER_TOKENS,
     WOMEN_QUALIFIER_ALIASES as _WOMEN_QUALIFIER_ALIASES,
+    comparison_texts_are_compatible_from_parts as _comparison_texts_are_compatible_from_parts,
     comparison_team_text as _comparison_team_text,
+    event_similarity_score_from_parts as _event_similarity_score_from_parts,
     same_team_context as _same_team_context,
     significant_tokens as _significant_tokens,
-    strip_explicit_z_women_markers as _strip_explicit_z_women_markers,
     team_qualifiers as _team_qualifiers,
     team_similarity as _team_similarity,
 )
@@ -193,18 +189,7 @@ class _OutcomeTextCache:
         key = (name, sport)
         cached = self._comparison_text.get(key)
         if cached is None:
-            qualifiers = self.qualifiers(name, sport=sport)
-            comparison_name = (
-                _strip_explicit_z_women_markers(name)
-                if "women" in qualifiers
-                else name
-            )
-            tokens = normalize_identity_text(comparison_name).split()
-            if "women" in qualifiers:
-                tokens = [
-                    token for token in tokens if token not in _WOMEN_MARKER_TOKENS
-                ]
-            cached = " ".join(tokens)
+            cached = _comparison_team_text(name, sport=sport)
             self._comparison_text[key] = cached
         return cached
 
@@ -212,11 +197,7 @@ class _OutcomeTextCache:
         key = (name, sport)
         cached = self._significant_tokens.get(key)
         if cached is None:
-            cached = {
-                token
-                for token in self.comparison_text(name, sport=sport).split()
-                if token not in _LOW_SIGNAL_TEAM_TOKENS
-            }
+            cached = _significant_tokens(name, sport=sport)
             self._significant_tokens[key] = cached
         return cached
 
@@ -238,19 +219,15 @@ class _OutcomeTextCache:
         *,
         sport: str | None = None,
     ) -> float:
-        left_key = self.comparison_text(left, sport=sport)
-        right_key = self.comparison_text(right, sport=sport)
-        if not left_key or not right_key:
-            return 0.0
-        if left_key == right_key:
-            return 100.0
-        left_tokens = self.significant_tokens(left, sport=sport)
-        right_tokens = self.significant_tokens(right, sport=sport)
-        if left_tokens and left_tokens == right_tokens:
-            return 100.0
-        if self._stats is not None:
+        score_result = _event_similarity_score_from_parts(
+            self.comparison_text(left, sport=sport),
+            self.comparison_text(right, sport=sport),
+            self.significant_tokens(left, sport=sport),
+            self.significant_tokens(right, sport=sport),
+        )
+        if self._stats is not None and score_result.used_fuzzy_score:
             self._stats.football_event_fuzzy_score_count += 1
-        return float(fuzz.token_sort_ratio(left_key, right_key))
+        return score_result.score
 
     def comparison_texts_are_compatible(
         self,
@@ -260,17 +237,13 @@ class _OutcomeTextCache:
         sport: str | None = None,
         team_ids: tuple[int, int] | None = None,
     ) -> bool:
-        if team_ids is not None and team_ids[0] == team_ids[1]:
-            return True
-        left_text = self.comparison_text(left_name, sport=sport)
-        right_text = self.comparison_text(right_name, sport=sport)
-        if left_text == right_text:
-            return True
-        left_tokens = self.significant_tokens(left_name, sport=sport)
-        right_tokens = self.significant_tokens(right_name, sport=sport)
-        if not left_tokens or not right_tokens:
-            return False
-        return left_tokens <= right_tokens or right_tokens <= left_tokens
+        return _comparison_texts_are_compatible_from_parts(
+            self.comparison_text(left_name, sport=sport),
+            self.comparison_text(right_name, sport=sport),
+            self.significant_tokens(left_name, sport=sport),
+            self.significant_tokens(right_name, sport=sport),
+            team_ids=team_ids,
+        )
 
     def women_marker_forms(self, name: str) -> frozenset[str]:
         cached = self._women_marker_forms.get(name)
@@ -772,17 +745,13 @@ def _comparison_team_texts_are_compatible(
             sport=sport,
             team_ids=team_ids,
         )
-    if team_ids is not None and team_ids[0] == team_ids[1]:
-        return True
-    left_text = _comparison_team_text(left_name, sport=sport)
-    right_text = _comparison_team_text(right_name, sport=sport)
-    if left_text == right_text:
-        return True
-    left_tokens = _significant_tokens(left_name, sport=sport)
-    right_tokens = _significant_tokens(right_name, sport=sport)
-    if not left_tokens or not right_tokens:
-        return False
-    return left_tokens <= right_tokens or right_tokens <= left_tokens
+    return _comparison_texts_are_compatible_from_parts(
+        _comparison_team_text(left_name, sport=sport),
+        _comparison_team_text(right_name, sport=sport),
+        _significant_tokens(left_name, sport=sport),
+        _significant_tokens(right_name, sport=sport),
+        team_ids=team_ids,
+    )
 
 
 def _pair_has_compatible_women_context(

--- a/backend/app/services/team_identity.py
+++ b/backend/app/services/team_identity.py
@@ -1,0 +1,670 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import AbstractSet
+
+from rapidfuzz import fuzz
+
+from .text_normalizer import normalize_identity_text
+
+
+# Foreign-language women markers seen in real-world team names. Tokens are
+# matched after ``normalize_identity_text`` (NFKD strip + lower + alnum-only).
+FOREIGN_WOMEN_TOKENS: frozenset[str] = frozenset(
+    {
+        "frauen",
+        "damen",
+        "feminino",
+        "feminina",
+        "femminile",
+        "femenino",
+        "femenina",
+        "feminin",
+        "feminines",
+        "kvinnor",
+        "naiset",
+        "vrouwen",
+        "kvinder",
+        "dff",
+    }
+)
+
+TEAM_QUALIFIER_TOKENS: frozenset[str] = frozenset(
+    {
+        "2",
+        "ii",
+        "b",
+        "res",
+        "reserve",
+        "reserves",
+        "u17",
+        "u18",
+        "u19",
+        "u20",
+        "u21",
+        "u23",
+        "w",
+        "women",
+        "youth",
+    }
+) | FOREIGN_WOMEN_TOKENS
+
+# Plain ASCII "z" is not a universal women alias; explicit marker syntax such
+# as "(Z)" or "Z/" is handled by EXPLICIT_Z_WOMEN_MARKER_RE.
+WOMEN_QUALIFIER_ALIASES: frozenset[str] = (
+    frozenset({"w", "wom", "women"}) | FOREIGN_WOMEN_TOKENS
+)
+WOMEN_MARKER_TOKENS: frozenset[str] = (
+    frozenset({"w", "wom", "women"}) | FOREIGN_WOMEN_TOKENS
+)
+
+EXPLICIT_Z_WOMEN_MARKER_RE = re.compile(
+    r"(^|\s)ž(?=$|\s)|\(\s*[žz]\s*\)|^\s*[žz]\s*/",
+    re.IGNORECASE,
+)
+EXPLICIT_W_WOMEN_PREFIX_RE = re.compile(
+    r"^\s*(?:w\s*/|\(\s*w\s*\))",
+    re.IGNORECASE,
+)
+
+YOUTH_AGE_DIGITS: frozenset[str] = frozenset({"17", "18", "19", "20", "21", "23"})
+YOUTH_AGES: frozenset[str] = frozenset({"u17", "u18", "u19", "u20", "u21", "u23"})
+YOUTH_QUALIFIERS: frozenset[str] = YOUTH_AGES | {"youth"}
+RESERVE_QUALIFIERS: frozenset[str] = frozenset(
+    {"b", "ii", "2", "res", "reserve", "reserves"}
+)
+
+LOW_SIGNAL_TEAM_TOKENS: frozenset[str] = frozenset(
+    {
+        "bc",
+        "bk",
+        "kk",
+        "fc",
+        "fk",
+        "club",
+        "team",
+        "sc",
+        "cf",
+        "cd",
+        "ce",
+    }
+)
+MATCH_UNIFICATION_LOW_SIGNAL_TEAM_TOKENS: frozenset[str] = frozenset(
+    {"bc", "bk", "kk", "fc", "fk", "club", "team"}
+)
+
+AGGRESSIVE_MERGE_SPORTS: frozenset[str] = frozenset({"basketball"})
+
+AMBIGUOUS_DOT_PREFIXES: frozenset[str] = frozenset(
+    {"st", "ft", "mt", "pt", "dr", "mr", "av"}
+)
+
+REASON_QUALIFIER_MISMATCH = "qualifier_mismatch"
+REASON_UNSAFE_SUBSET = "unsafe_subset"
+REASON_LOW_FUZZY_SCORE = "low_fuzzy_score"
+REASON_DOTTED_EXPANSION = "dotted_expansion"
+REASON_AUTO_MERGE_SAFE = "auto_merge_safe"
+REASON_REVIEW_ONLY = "review_only"
+REASON_WOMEN_MISMATCH = "women_mismatch"
+REASON_YOUTH_AGE_MISMATCH = "youth_age_mismatch"
+REASON_YOUTH_MARKER_MISMATCH = "youth_marker_mismatch"
+REASON_RESERVE_MARKER_MISMATCH = "reserve_marker_mismatch"
+
+
+@dataclass(frozen=True)
+class TeamSimilarityScore:
+    score: float
+    used_fuzzy_score: bool = False
+
+
+@dataclass(frozen=True)
+class TeamIdentityComparison:
+    left_name: str
+    right_name: str
+    sport: str | None
+    policy: str
+    score: float
+    left_qualifiers: frozenset[str]
+    right_qualifiers: frozenset[str]
+    left_comparison_text: str
+    right_comparison_text: str
+    left_significant_tokens: frozenset[str]
+    right_significant_tokens: frozenset[str]
+    left_expanded_name: str
+    right_expanded_name: str
+    dotted_expanded: bool
+    unsafe_subset: bool
+    reasons: frozenset[str]
+
+    @property
+    def qualifier_match(self) -> bool:
+        return self.left_qualifiers == self.right_qualifiers
+
+    @property
+    def auto_merge_safe(self) -> bool:
+        return REASON_AUTO_MERGE_SAFE in self.reasons
+
+    @property
+    def review_only(self) -> bool:
+        return REASON_REVIEW_ONLY in self.reasons
+
+    @property
+    def low_fuzzy_score(self) -> bool:
+        return REASON_LOW_FUZZY_SCORE in self.reasons
+
+
+@dataclass(frozen=True)
+class QualifierGateDecision:
+    admit: bool
+    youth_marker_mismatch: bool = False
+    reserve_marker_mismatch: bool = False
+    explicit_age_mismatch: bool = False
+    women_mismatch: bool = False
+    reasons: frozenset[str] = frozenset()
+
+
+def team_qualifiers(name: str, *, sport: str | None = None) -> set[str]:
+    """Return normalized women, reserve, and youth qualifiers in ``name``.
+
+    ``sport`` is reserved for future per-sport adjustments and currently
+    ignored. Persistence, score thresholds, and registry consensus status are
+    intentionally outside this module.
+    """
+    del sport
+    tokens = normalize_identity_text(name).split()
+    qualifiers: set[str] = set()
+    active_qualifier_tokens = TEAM_QUALIFIER_TOKENS | {"wom"}
+
+    if EXPLICIT_Z_WOMEN_MARKER_RE.search(name) or EXPLICIT_W_WOMEN_PREFIX_RE.search(
+        name
+    ):
+        qualifiers.add("women")
+
+    def suffix_has_qualifier(start_index: int) -> bool:
+        index = start_index
+        while index < len(tokens):
+            token = tokens[index]
+            next_token = tokens[index + 1] if index + 1 < len(tokens) else None
+            if token == "team":
+                index += 1
+                continue
+            if token == "u" and next_token in YOUTH_AGE_DIGITS:
+                return True
+            if token in active_qualifier_tokens:
+                return True
+            index += 1
+        return False
+
+    for index, token in enumerate(tokens):
+        next_token = tokens[index + 1] if index + 1 < len(tokens) else None
+        if token == "u" and next_token in YOUTH_AGE_DIGITS:
+            qualifiers.add(f"u{next_token}")
+            continue
+        if token in {"b", "2", "ii"}:
+            if index > 0 and (
+                index == len(tokens) - 1
+                or next_token == "team"
+                or suffix_has_qualifier(index + 1)
+            ):
+                qualifiers.add(token)
+            continue
+        if token in WOMEN_QUALIFIER_ALIASES:
+            is_explicit_prefix = (
+                token in ({"women", "wom"} | FOREIGN_WOMEN_TOKENS)
+                and index == 0
+                and len(tokens) > 1
+            )
+            is_suffix = index > 0 and (
+                index == len(tokens) - 1
+                or next_token in {"team", "women"}
+                or suffix_has_qualifier(index + 1)
+            )
+            if is_explicit_prefix or is_suffix:
+                qualifiers.add("women")
+            continue
+        if token == "z":
+            continue
+        if token not in active_qualifier_tokens:
+            continue
+        qualifiers.add(token)
+    return qualifiers
+
+
+def strip_explicit_z_women_markers(name: str) -> str:
+    without_parenthesized = re.sub(
+        r"\(\s*[žz]\s*\)",
+        " ",
+        name,
+        flags=re.IGNORECASE,
+    )
+    without_leading_slash = re.sub(
+        r"^\s*[žz]\s*/",
+        "",
+        without_parenthesized,
+        flags=re.IGNORECASE,
+    )
+    return re.sub(
+        r"(^|\s)ž(?=$|\s)",
+        r"\1",
+        without_leading_slash,
+        flags=re.IGNORECASE,
+    )
+
+
+def is_women_team(qualifiers: AbstractSet[str]) -> bool:
+    return "women" in qualifiers
+
+
+def has_youth_marker(qualifiers: AbstractSet[str]) -> bool:
+    return bool(qualifiers & YOUTH_QUALIFIERS)
+
+
+def has_reserve_marker(qualifiers: AbstractSet[str]) -> bool:
+    return bool(qualifiers & RESERVE_QUALIFIERS)
+
+
+def youth_ages(qualifiers: AbstractSet[str]) -> set[str]:
+    return set(qualifiers & YOUTH_AGES)
+
+
+def comparison_team_text(team_name: str, *, sport: str | None = None) -> str:
+    qualifiers = team_qualifiers(team_name, sport=sport)
+    comparison_name = (
+        strip_explicit_z_women_markers(team_name)
+        if "women" in qualifiers
+        else team_name
+    )
+    tokens = normalize_identity_text(comparison_name).split()
+    if "women" in qualifiers:
+        tokens = [token for token in tokens if token not in WOMEN_MARKER_TOKENS]
+    return " ".join(tokens)
+
+
+def significant_tokens(
+    name: str,
+    *,
+    sport: str | None = None,
+    low_signal_tokens: AbstractSet[str] = LOW_SIGNAL_TEAM_TOKENS,
+) -> set[str]:
+    return {
+        token
+        for token in comparison_team_text(name, sport=sport).split()
+        if token not in low_signal_tokens
+    }
+
+
+def match_unification_significant_tokens(
+    name: str,
+    *,
+    sport: str | None = None,
+) -> set[str]:
+    return significant_tokens(
+        name,
+        sport=sport,
+        low_signal_tokens=MATCH_UNIFICATION_LOW_SIGNAL_TEAM_TOKENS,
+    )
+
+
+def event_similarity_score_from_parts(
+    left_key: str,
+    right_key: str,
+    left_tokens: AbstractSet[str],
+    right_tokens: AbstractSet[str],
+) -> TeamSimilarityScore:
+    if not left_key or not right_key:
+        return TeamSimilarityScore(0.0)
+    if left_key == right_key:
+        return TeamSimilarityScore(100.0)
+    if left_tokens and left_tokens == right_tokens:
+        return TeamSimilarityScore(100.0)
+    return TeamSimilarityScore(
+        float(fuzz.token_sort_ratio(left_key, right_key)),
+        used_fuzzy_score=True,
+    )
+
+
+def team_similarity(left: str, right: str, *, sport: str | None = None) -> float:
+    left_key = comparison_team_text(left, sport=sport)
+    right_key = comparison_team_text(right, sport=sport)
+    left_tokens = significant_tokens(left, sport=sport)
+    right_tokens = significant_tokens(right, sport=sport)
+    return event_similarity_score_from_parts(
+        left_key,
+        right_key,
+        left_tokens,
+        right_tokens,
+    ).score
+
+
+def same_team_context(left: str, right: str, *, sport: str | None = None) -> bool:
+    return team_qualifiers(left, sport=sport) == team_qualifiers(right, sport=sport)
+
+
+def uses_aggressive_dotted_expansion(sport: str | None) -> bool:
+    return sport in AGGRESSIVE_MERGE_SPORTS
+
+
+def expand_dotted_team_token(name: str, counterpart: str) -> str:
+    spaced = re.sub(r"\.(?=\S)", ". ", name)
+    counterpart_spaced = re.sub(r"\.(?=\S)", ". ", counterpart)
+    counterpart_tokens = counterpart_spaced.split()
+    counterpart_token_set = {token.lower().rstrip(".") for token in counterpart_tokens}
+    source_tokens = spaced.split()
+    has_anchor = any(
+        not token.endswith(".") and token.lower() in counterpart_token_set
+        for token in source_tokens
+    )
+    if not has_anchor:
+        return name
+    output: list[str] = []
+    for token in source_tokens:
+        if not token.endswith(".") or len(token) < 3:
+            output.append(token)
+            continue
+        prefix = token[:-1].lower()
+        if len(prefix) < 2:
+            output.append(token)
+            continue
+        if prefix in AMBIGUOUS_DOT_PREFIXES:
+            output.append(token)
+            continue
+        candidates = [
+            candidate
+            for candidate in counterpart_tokens
+            if len(candidate) > len(prefix) and candidate.lower().startswith(prefix)
+        ]
+        if len(candidates) == 1:
+            output.append(candidates[0])
+        else:
+            output.append(token)
+    return " ".join(output)
+
+
+def _meaningfully_expanded(original: str, expanded: str) -> bool:
+    return normalize_identity_text(original) != normalize_identity_text(expanded)
+
+
+def expand_dotted_team_pair(
+    left: str,
+    right: str,
+    *,
+    sport: str | None = None,
+) -> tuple[str, str, bool]:
+    if not uses_aggressive_dotted_expansion(sport):
+        return left, right, False
+    expanded_left = expand_dotted_team_token(left, right)
+    expanded_right = expand_dotted_team_token(right, left)
+    return (
+        expanded_left,
+        expanded_right,
+        _meaningfully_expanded(left, expanded_left)
+        or _meaningfully_expanded(right, expanded_right),
+    )
+
+
+def event_team_similarity(
+    left: str,
+    right: str,
+    *,
+    sport: str | None = None,
+    expand_dotted: bool = False,
+) -> float:
+    expanded_left, expanded_right, _expanded = (
+        expand_dotted_team_pair(left, right, sport=sport)
+        if expand_dotted
+        else (left, right, False)
+    )
+    return team_similarity(expanded_left, expanded_right, sport=sport)
+
+
+def subset_or_equal_significant_tokens(
+    left_name: str,
+    right_name: str,
+    *,
+    sport: str | None = None,
+) -> bool:
+    left_tokens = match_unification_significant_tokens(left_name, sport=sport)
+    right_tokens = match_unification_significant_tokens(right_name, sport=sport)
+    return bool(
+        left_tokens
+        and right_tokens
+        and (left_tokens <= right_tokens or right_tokens <= left_tokens)
+    )
+
+
+def unsafe_compound_subset_match(
+    left_name: str,
+    right_name: str,
+    *,
+    sport: str | None = None,
+) -> bool:
+    left_tokens = match_unification_significant_tokens(left_name, sport=sport)
+    right_tokens = match_unification_significant_tokens(right_name, sport=sport)
+    return bool(
+        left_tokens
+        and right_tokens
+        and (left_tokens < right_tokens or right_tokens < left_tokens)
+    )
+
+
+def comparison_texts_are_compatible_from_parts(
+    left_text: str,
+    right_text: str,
+    left_tokens: AbstractSet[str],
+    right_tokens: AbstractSet[str],
+    *,
+    team_ids: tuple[int, int] | None = None,
+) -> bool:
+    if team_ids is not None and team_ids[0] == team_ids[1]:
+        return True
+    if left_text == right_text:
+        return True
+    if not left_tokens or not right_tokens:
+        return False
+    return left_tokens <= right_tokens or right_tokens <= left_tokens
+
+
+def comparison_texts_are_compatible(
+    left_name: str,
+    right_name: str,
+    *,
+    sport: str | None = None,
+    team_ids: tuple[int, int] | None = None,
+) -> bool:
+    return comparison_texts_are_compatible_from_parts(
+        comparison_team_text(left_name, sport=sport),
+        comparison_team_text(right_name, sport=sport),
+        significant_tokens(left_name, sport=sport),
+        significant_tokens(right_name, sport=sport),
+        team_ids=team_ids,
+    )
+
+
+def canonical_team_similarity_score(
+    left_name: str,
+    right_name: str,
+    *,
+    sport: str | None = None,
+) -> float:
+    left_key = comparison_team_text(left_name, sport=sport)
+    right_key = comparison_team_text(right_name, sport=sport)
+    if not left_key or not right_key:
+        return 0.0
+    if left_key == right_key:
+        return 100.0
+
+    left_tokens = match_unification_significant_tokens(left_name, sport=sport)
+    right_tokens = match_unification_significant_tokens(right_name, sport=sport)
+    if not left_tokens or not right_tokens:
+        return 0.0
+    if left_tokens == right_tokens:
+        return 100.0
+    return float(
+        min(
+            fuzz.ratio(left_key, right_key),
+            fuzz.token_sort_ratio(left_key, right_key),
+        )
+    )
+
+
+def canonical_team_auto_merge_analysis(
+    source_team_name: str,
+    target_team_name: str,
+    *,
+    sport: str | None = None,
+    threshold: float,
+) -> TeamIdentityComparison:
+    left_qualifiers = frozenset(team_qualifiers(source_team_name, sport=sport))
+    right_qualifiers = frozenset(team_qualifiers(target_team_name, sport=sport))
+    left_text = comparison_team_text(source_team_name, sport=sport)
+    right_text = comparison_team_text(target_team_name, sport=sport)
+    left_tokens = frozenset(
+        match_unification_significant_tokens(source_team_name, sport=sport)
+    )
+    right_tokens = frozenset(
+        match_unification_significant_tokens(target_team_name, sport=sport)
+    )
+    unsafe_subset = bool(
+        left_tokens
+        and right_tokens
+        and (left_tokens < right_tokens or right_tokens < left_tokens)
+    )
+    score = canonical_team_similarity_score(
+        source_team_name,
+        target_team_name,
+        sport=sport,
+    )
+    reasons: set[str] = set()
+    if left_qualifiers != right_qualifiers:
+        reasons.add(REASON_QUALIFIER_MISMATCH)
+    elif unsafe_subset:
+        reasons.add(REASON_UNSAFE_SUBSET)
+    elif score < threshold:
+        reasons.add(REASON_LOW_FUZZY_SCORE)
+    else:
+        reasons.add(REASON_AUTO_MERGE_SAFE)
+    if REASON_AUTO_MERGE_SAFE not in reasons:
+        reasons.add(REASON_REVIEW_ONLY)
+    return TeamIdentityComparison(
+        left_name=source_team_name,
+        right_name=target_team_name,
+        sport=sport,
+        policy="canonical_auto_merge",
+        score=score,
+        left_qualifiers=left_qualifiers,
+        right_qualifiers=right_qualifiers,
+        left_comparison_text=left_text,
+        right_comparison_text=right_text,
+        left_significant_tokens=left_tokens,
+        right_significant_tokens=right_tokens,
+        left_expanded_name=source_team_name,
+        right_expanded_name=target_team_name,
+        dotted_expanded=False,
+        unsafe_subset=unsafe_subset,
+        reasons=frozenset(reasons),
+    )
+
+
+def explain_event_team_similarity(
+    left: str,
+    right: str,
+    *,
+    sport: str | None = None,
+    expand_dotted: bool = False,
+    auto_threshold: float | None = None,
+) -> TeamIdentityComparison:
+    expanded_left, expanded_right, dotted_expanded = (
+        expand_dotted_team_pair(left, right, sport=sport)
+        if expand_dotted
+        else (left, right, False)
+    )
+    left_qualifiers = frozenset(team_qualifiers(left, sport=sport))
+    right_qualifiers = frozenset(team_qualifiers(right, sport=sport))
+    left_text = comparison_team_text(expanded_left, sport=sport)
+    right_text = comparison_team_text(expanded_right, sport=sport)
+    left_tokens = frozenset(significant_tokens(expanded_left, sport=sport))
+    right_tokens = frozenset(significant_tokens(expanded_right, sport=sport))
+    score_result = event_similarity_score_from_parts(
+        left_text,
+        right_text,
+        left_tokens,
+        right_tokens,
+    )
+    reasons: set[str] = set()
+    if dotted_expanded:
+        reasons.add(REASON_DOTTED_EXPANSION)
+    if left_qualifiers != right_qualifiers:
+        reasons.add(REASON_QUALIFIER_MISMATCH)
+    if auto_threshold is not None:
+        if left_qualifiers == right_qualifiers and score_result.score >= auto_threshold:
+            reasons.add(REASON_AUTO_MERGE_SAFE)
+        else:
+            reasons.add(REASON_REVIEW_ONLY)
+            if score_result.score < auto_threshold:
+                reasons.add(REASON_LOW_FUZZY_SCORE)
+    return TeamIdentityComparison(
+        left_name=left,
+        right_name=right,
+        sport=sport,
+        policy="event_similarity",
+        score=score_result.score,
+        left_qualifiers=left_qualifiers,
+        right_qualifiers=right_qualifiers,
+        left_comparison_text=left_text,
+        right_comparison_text=right_text,
+        left_significant_tokens=left_tokens,
+        right_significant_tokens=right_tokens,
+        left_expanded_name=expanded_left,
+        right_expanded_name=expanded_right,
+        dotted_expanded=dotted_expanded,
+        unsafe_subset=False,
+        reasons=frozenset(reasons),
+    )
+
+
+def canonical_candidate_qualifier_gate(
+    raw_qualifiers: AbstractSet[str],
+    cand_qualifiers: AbstractSet[str],
+    cand_women_status: str,
+) -> QualifierGateDecision:
+    raw_is_women = is_women_team(raw_qualifiers)
+    if cand_women_status == "women" and not raw_is_women:
+        return QualifierGateDecision(
+            admit=False,
+            women_mismatch=True,
+            reasons=frozenset({REASON_QUALIFIER_MISMATCH, REASON_WOMEN_MISMATCH}),
+        )
+    if cand_women_status == "men" and raw_is_women:
+        return QualifierGateDecision(
+            admit=False,
+            women_mismatch=True,
+            reasons=frozenset({REASON_QUALIFIER_MISMATCH, REASON_WOMEN_MISMATCH}),
+        )
+
+    raw_ages = youth_ages(raw_qualifiers)
+    cand_ages = youth_ages(cand_qualifiers)
+    if raw_ages and cand_ages and not (raw_ages & cand_ages):
+        return QualifierGateDecision(
+            admit=False,
+            explicit_age_mismatch=True,
+            reasons=frozenset({REASON_QUALIFIER_MISMATCH, REASON_YOUTH_AGE_MISMATCH}),
+        )
+
+    reasons: set[str] = set()
+    youth_marker_mismatch = has_youth_marker(raw_qualifiers) != has_youth_marker(
+        cand_qualifiers
+    )
+    reserve_marker_mismatch = has_reserve_marker(raw_qualifiers) != has_reserve_marker(
+        cand_qualifiers
+    )
+    if youth_marker_mismatch:
+        reasons.update({REASON_QUALIFIER_MISMATCH, REASON_YOUTH_MARKER_MISMATCH})
+    if reserve_marker_mismatch:
+        reasons.update({REASON_QUALIFIER_MISMATCH, REASON_RESERVE_MARKER_MISMATCH})
+    return QualifierGateDecision(
+        admit=True,
+        youth_marker_mismatch=youth_marker_mismatch,
+        reserve_marker_mismatch=reserve_marker_mismatch,
+        reasons=frozenset(reasons),
+    )

--- a/backend/app/services/team_qualifiers.py
+++ b/backend/app/services/team_qualifiers.py
@@ -1,229 +1,29 @@
-"""Team-qualifier detection (women / youth / reserve markers).
-
-Hoisted out of ``outcome_normalizer.py`` so the team matcher
-(``team_registry.search_canonical_team_candidates`` and the slot ranker in
-``normalizer.py``) can apply the same qualifier rules without dragging in
-the entire outcome-resolution stack.
-
-A *qualifier* is a normalized marker token attached to a team name that
-signals "this is the women's team", "this is the U19 youth team",
-"this is the reserve / B team", etc. Cross-bookmaker matching of these
-markers is brittle because:
-
-* The same marker is written many ways (``B``, ``II``, ``2``, ``(R)``,
-  ``Am``, ``Mladi``, ``M19``/``U19``, ``Frauen``, ``DFF`` …).
-* Some bookmakers omit them entirely.
-* Some markers collide with location abbreviations (``z`` in football is
-  often a location suffix; ``B`` can mean Belgium).
-
-The qualifier set returned by :func:`team_qualifiers` is the canonical
-normalized form ``{"women", "u19", "b", "ii", "2", "res", "reserve",
-"reserves", "u17"..."u23", "youth"}`` plus any foreign-women token from
-:data:`FOREIGN_WOMEN_TOKENS`. It is the input to higher-level decisions
-like "hard-block this candidate" or "demote this candidate".
-
-Convenience predicates (:func:`is_women_team`, :func:`has_youth_marker`,
-:func:`has_reserve_marker`, :func:`youth_ages`) classify the qualifier
-set into the tiers the matcher cares about.
-"""
 from __future__ import annotations
 
-import re
-
-from .text_normalizer import normalize_identity_text
-
-
-# Foreign-language women markers seen in real-world team names. Tokens are
-# matched after ``normalize_identity_text`` (NFKD strip + lower + alnum-only),
-# so include the post-normalization form (e.g. "feminin" covers French
-# "Féminin" because diacritics are stripped). Conservative additions only —
-# tokens that could plausibly appear as part of a regular team name (e.g.
-# bare "fem") are intentionally omitted.
-FOREIGN_WOMEN_TOKENS: frozenset[str] = frozenset(
-    {
-        "frauen",      # German
-        "damen",       # German (formal)
-        "feminino",    # Portuguese (m.)
-        "feminina",    # Portuguese (f.)
-        "femminile",   # Italian
-        "femenino",    # Spanish (m.)
-        "femenina",    # Spanish (f.)
-        "feminin",     # French/Romanian (post-diacritic strip)
-        "feminines",   # French plural
-        "kvinnor",     # Swedish
-        "naiset",      # Finnish
-        "vrouwen",     # Dutch
-        "kvinder",     # Danish
-        "dff",         # Swedish "Damfotboll Förening" club designation
-    }
+from .team_identity import (
+    EXPLICIT_Z_WOMEN_MARKER_RE,
+    FOREIGN_WOMEN_TOKENS,
+    TEAM_QUALIFIER_TOKENS,
+    WOMEN_MARKER_TOKENS,
+    WOMEN_QUALIFIER_ALIASES,
+    has_reserve_marker,
+    has_youth_marker,
+    is_women_team,
+    strip_explicit_z_women_markers,
+    team_qualifiers,
+    youth_ages,
 )
 
-
-TEAM_QUALIFIER_TOKENS: frozenset[str] = frozenset(
-    {
-        "2",
-        "ii",
-        "b",
-        "res",
-        "reserve",
-        "reserves",
-        "u17",
-        "u18",
-        "u19",
-        "u20",
-        "u21",
-        "u23",
-        "w",
-        "women",
-        "youth",
-    }
-) | FOREIGN_WOMEN_TOKENS
-
-
-# Cross-sport aliases for explicit women markers. Plain ASCII "z" is not in
-# this set because it is a common location abbreviation in football; only
-# explicit marker syntax such as "(Ž)" or "Ž/" is treated as women.
-WOMEN_QUALIFIER_ALIASES: frozenset[str] = (
-    frozenset({"w", "wom", "women"}) | FOREIGN_WOMEN_TOKENS
-)
-
-WOMEN_MARKER_TOKENS: frozenset[str] = (
-    frozenset({"w", "wom", "women"}) | FOREIGN_WOMEN_TOKENS
-)
-
-
-EXPLICIT_Z_WOMEN_MARKER_RE = re.compile(
-    r"(^|\s)ž(?=$|\s)|\(\s*[žz]\s*\)|^\s*[žz]\s*/",
-    re.IGNORECASE,
-)
-
-
-_YOUTH_AGES: frozenset[str] = frozenset({"17", "18", "19", "20", "21", "23"})
-
-
-def team_qualifiers(name: str, *, sport: str | None = None) -> set[str]:
-    """Return the set of qualifier markers detected in ``name``.
-
-    The returned set is a subset of :data:`TEAM_QUALIFIER_TOKENS` plus the
-    sentinel ``"women"`` (which subsumes ``"w"`` / ``"wom"`` / explicit
-    Ž markers). Empty set means "no qualifiers detected" — i.e. the team
-    is treated as the senior men's first-team.
-
-    ``sport`` is reserved for future per-sport adjustments and currently
-    ignored.
-    """
-    del sport  # currently unused; kept in signature for backwards compat
-    tokens = normalize_identity_text(name).split()
-    qualifiers: set[str] = set()
-    active_qualifier_tokens = TEAM_QUALIFIER_TOKENS | {"wom"}
-
-    if EXPLICIT_Z_WOMEN_MARKER_RE.search(name):
-        qualifiers.add("women")
-
-    def suffix_has_qualifier(start_index: int) -> bool:
-        index = start_index
-        while index < len(tokens):
-            token = tokens[index]
-            next_token = tokens[index + 1] if index + 1 < len(tokens) else None
-            if token == "team":
-                index += 1
-                continue
-            if token == "u" and next_token in _YOUTH_AGES:
-                return True
-            if token in active_qualifier_tokens:
-                return True
-            index += 1
-        return False
-
-    for index, token in enumerate(tokens):
-        next_token = tokens[index + 1] if index + 1 < len(tokens) else None
-        if token == "u" and next_token in _YOUTH_AGES:
-            qualifiers.add(f"u{next_token}")
-            continue
-        if token in {"b", "2", "ii"}:
-            if index > 0 and (
-                index == len(tokens) - 1
-                or next_token == "team"
-                or suffix_has_qualifier(index + 1)
-            ):
-                qualifiers.add(token)
-            continue
-        if token in WOMEN_QUALIFIER_ALIASES:
-            is_explicit_prefix = (
-                token in ({"women", "wom"} | FOREIGN_WOMEN_TOKENS)
-                and index == 0
-                and len(tokens) > 1
-            )
-            is_suffix = index > 0 and (
-                index == len(tokens) - 1
-                or next_token in {"team", "women"}
-                or suffix_has_qualifier(index + 1)
-            )
-            if is_explicit_prefix or is_suffix:
-                qualifiers.add("women")
-            continue
-        if token == "z":
-            # Plain ASCII Z is intentionally not a universal women alias.
-            # The explicit-marker regex above handles "(Ž)", "(Z)", "Ž/",
-            # and "Z/" without breaking football abbreviations such as
-            # "FK Borac Z" for Zvornik.
-            continue
-        if token not in active_qualifier_tokens:
-            continue
-        qualifiers.add(token)
-    return qualifiers
-
-
-def strip_explicit_z_women_markers(name: str) -> str:
-    """Strip the explicit "Ž" / "(Z)" / "Z/" women markers from ``name``.
-
-    Leaves the rest of the string intact so the matcher can still see the
-    base team name. Inverse of the ``EXPLICIT_Z_WOMEN_MARKER_RE`` check in
-    :func:`team_qualifiers`.
-    """
-    without_parenthesized = re.sub(
-        r"\(\s*[žz]\s*\)",
-        " ",
-        name,
-        flags=re.IGNORECASE,
-    )
-    without_leading_slash = re.sub(
-        r"^\s*[žz]\s*/",
-        "",
-        without_parenthesized,
-        flags=re.IGNORECASE,
-    )
-    return re.sub(
-        r"(^|\s)ž(?=$|\s)",
-        r"\1",
-        without_leading_slash,
-        flags=re.IGNORECASE,
-    )
-
-
-def is_women_team(qualifiers: set[str]) -> bool:
-    """Convenience: True iff the qualifier set marks a women's team."""
-    return "women" in qualifiers
-
-
-_YOUTH_QUALIFIERS: frozenset[str] = frozenset(
-    {"u17", "u18", "u19", "u20", "u21", "u23", "youth"}
-)
-_RESERVE_QUALIFIERS: frozenset[str] = frozenset(
-    {"b", "ii", "2", "res", "reserve", "reserves"}
-)
-
-
-def has_youth_marker(qualifiers: set[str]) -> bool:
-    """True iff the qualifier set contains any youth-team marker."""
-    return bool(qualifiers & _YOUTH_QUALIFIERS)
-
-
-def has_reserve_marker(qualifiers: set[str]) -> bool:
-    """True iff the qualifier set contains any reserve / B-team marker."""
-    return bool(qualifiers & _RESERVE_QUALIFIERS)
-
-
-def youth_ages(qualifiers: set[str]) -> set[str]:
-    """Return the explicit youth-age qualifiers (``u17`` … ``u23``)."""
-    return qualifiers & frozenset({"u17", "u18", "u19", "u20", "u21", "u23"})
+__all__ = [
+    "EXPLICIT_Z_WOMEN_MARKER_RE",
+    "FOREIGN_WOMEN_TOKENS",
+    "TEAM_QUALIFIER_TOKENS",
+    "WOMEN_MARKER_TOKENS",
+    "WOMEN_QUALIFIER_ALIASES",
+    "has_reserve_marker",
+    "has_youth_marker",
+    "is_women_team",
+    "strip_explicit_z_women_markers",
+    "team_qualifiers",
+    "youth_ages",
+]

--- a/backend/app/services/team_registry.py
+++ b/backend/app/services/team_registry.py
@@ -14,12 +14,12 @@ from rapidfuzz import fuzz, process
 from ..config import settings
 from .team_seed_data import SPORT_ALIAS_SEEDS
 from .team_abbreviations import expand_team_abbreviations
-from .team_qualifiers import (
-    has_reserve_marker,
-    has_youth_marker,
-    is_women_team,
+from .team_identity import (
+    REASON_QUALIFIER_MISMATCH,
+    REASON_UNSAFE_SUBSET,
+    canonical_candidate_qualifier_gate,
+    canonical_team_auto_merge_analysis,
     team_qualifiers,
-    youth_ages,
 )
 from .text_normalizer import normalize_identity_text
 
@@ -1180,6 +1180,72 @@ def _partial_ratio_admissible(raw_key: str, candidate_key: str) -> bool:
 # fuzzy match (>= 80) can still surface a mismatched candidate near the top
 # of the result list as a *suggestion* the operator can review.
 _QUALIFIER_MISMATCH_PENALTY: float = 15.0
+_MANUAL_MERGE_BLOCK_REASONS = frozenset(
+    {REASON_QUALIFIER_MISMATCH, REASON_UNSAFE_SUBSET}
+)
+
+
+def _validate_manual_canonical_merge_identity(
+    source_row: sqlite3.Row,
+    target_row: sqlite3.Row,
+    *,
+    allow_unsafe_subset: bool = False,
+) -> None:
+    validate_team_name_identity(
+        str(source_row["display_name"]),
+        str(target_row["display_name"]),
+        sport=str(source_row["sport"]),
+        allow_unsafe_subset=allow_unsafe_subset,
+    )
+
+
+def validate_team_name_identity(
+    source_team_name: str,
+    target_team_name: str,
+    *,
+    sport: str,
+    allow_unsafe_subset: bool = False,
+) -> None:
+    analysis = canonical_team_auto_merge_analysis(
+        source_team_name,
+        target_team_name,
+        sport=sport,
+        threshold=0.0,
+    )
+    block_reasons = (
+        _MANUAL_MERGE_BLOCK_REASONS
+        if not allow_unsafe_subset
+        else frozenset({REASON_QUALIFIER_MISMATCH})
+    )
+    blocking_reasons = sorted(analysis.reasons & block_reasons)
+    if blocking_reasons:
+        joined_reasons = ", ".join(blocking_reasons)
+        raise ValueError(
+            "Cannot use incompatible team identity "
+            f"({joined_reasons}): "
+            f"{source_team_name} -> {target_team_name}"
+        )
+
+
+def validate_canonical_team_merge_identity(
+    *,
+    source_team_id: int,
+    target_team_id: int,
+    allow_unsafe_subset: bool = False,
+) -> None:
+    _ensure_bootstrapped()
+    with _connect() as conn:
+        source_row = _query_team_by_id(conn, source_team_id)
+        target_row = _query_team_by_id(conn, target_team_id)
+        if source_row is None or target_row is None:
+            raise ValueError("Both canonical teams must exist before merging")
+        if str(source_row["sport"]) != str(target_row["sport"]):
+            raise ValueError("Only canonical teams from the same sport can be merged")
+        _validate_manual_canonical_merge_identity(
+            source_row,
+            target_row,
+            allow_unsafe_subset=allow_unsafe_subset,
+        )
 
 
 def _qualifier_gate(
@@ -1217,24 +1283,17 @@ def _qualifier_gate(
 
     * ``admit=True, penalty=0`` means no qualifier-driven adjustment.
     """
-    raw_is_women = is_women_team(raw_qualifiers)
-    # Women hard-block fires only when the candidate's *team* unambiguously
-    # identifies as one gender (every alias agrees). NWSL-style canonicals
-    # whose display_name carries the only ``W`` marker while bookmaker
-    # aliases omit it land in ``"mixed"`` status, suppressing the block so
-    # the canonical stays reachable from un-marked queries.
-    if cand_women_status == "women" and not raw_is_women:
-        return (False, 0.0)
-    if cand_women_status == "men" and raw_is_women:
-        return (False, 0.0)
-    raw_ages = youth_ages(raw_qualifiers)
-    cand_ages = youth_ages(cand_qualifiers)
-    if raw_ages and cand_ages and not (raw_ages & cand_ages):
+    decision = canonical_candidate_qualifier_gate(
+        raw_qualifiers,
+        cand_qualifiers,
+        cand_women_status,
+    )
+    if not decision.admit:
         return (False, 0.0)
     penalty = 0.0
-    if has_youth_marker(raw_qualifiers) != has_youth_marker(cand_qualifiers):
+    if decision.youth_marker_mismatch:
         penalty += _QUALIFIER_MISMATCH_PENALTY
-    if has_reserve_marker(raw_qualifiers) != has_reserve_marker(cand_qualifiers):
+    if decision.reserve_marker_mismatch:
         penalty += _QUALIFIER_MISMATCH_PENALTY
     return (True, penalty)
 
@@ -1836,6 +1895,7 @@ def merge_canonical_teams(
     *,
     source_team_id: int,
     target_team_id: int,
+    allow_unsafe_subset: bool = False,
 ) -> CanonicalTeamSummary:
     if source_team_id == target_team_id:
         raise ValueError("Cannot merge a canonical team into itself")
@@ -1849,6 +1909,11 @@ def merge_canonical_teams(
             raise ValueError("Both canonical teams must exist before merging")
         if str(source_row["sport"]) != str(target_row["sport"]):
             raise ValueError("Only canonical teams from the same sport can be merged")
+        _validate_manual_canonical_merge_identity(
+            source_row,
+            target_row,
+            allow_unsafe_subset=allow_unsafe_subset,
+        )
 
         alias_snapshot = _team_alias_snapshot(
             conn,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -2349,6 +2349,65 @@ async def test_team_review_approval_rejects_circular_alias(
 
 
 @pytest.mark.asyncio
+async def test_team_review_approval_rejects_qualifier_mismatch(
+    client: AsyncClient,
+    team_registry_file,
+):
+    batch_scraped_at = "2026-04-16T21:48:00+00:00"
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball", "Europe")
+    target = create_canonical_team(display_name="Partizan", sport="basketball")
+    case_id = await odds_store.insert_team_review_case(
+        TeamReviewDiagnostic.model_validate(
+            {
+                "bookmaker_id": "meridian",
+                "raw_league_id": "Euroleague",
+                "normalized_raw_league_id": "euroleague",
+                "sport": "basketball",
+                "scope_league_id": "euroleague",
+                "raw_team_name": "Partizan Women",
+                "normalized_raw_team_name": "partizan women",
+                "suggested_team_id": target.team_id,
+                "suggested_team_name": target.team_name,
+                "start_time": batch_scraped_at,
+                "reason_code": "candidate_team_match_same_start_time",
+                "confidence": "high",
+                "similarity_score": 100,
+                "evidence": ["Exact start time: 2026-04-16T21:48:00+00:00"],
+                "status": "pending",
+            }
+        ),
+        scraped_at=batch_scraped_at,
+    )
+    await odds_store.set_current_snapshot(batch_scraped_at)
+
+    approve_resp = await client.post(
+        f"/api/v1/team-review/cases/{case_id}/approve",
+        json={"team_id": target.team_id},
+    )
+
+    assert approve_resp.status_code == 400
+    assert "qualifier_mismatch" in approve_resp.json()["detail"]
+    case = await odds_store.get_team_review_case(case_id)
+    assert case is not None
+    assert case.status == "pending"
+
+    create_resp = await client.post(
+        f"/api/v1/team-review/cases/{case_id}/approve",
+        json={"create_team_name": "Partizan Men Created"},
+    )
+    db = await get_db()
+    created_rows = await db.execute_fetchall(
+        "SELECT id FROM canonical_teams WHERE display_name = ?",
+        ("Partizan Men Created",),
+    )
+
+    assert create_resp.status_code == 400
+    assert "qualifier_mismatch" in create_resp.json()["detail"]
+    assert created_rows == []
+
+
+@pytest.mark.asyncio
 async def test_team_review_approval_merges_existing_canonical_duplicate(
     client: AsyncClient,
     team_registry_file,

--- a/backend/tests/test_match_merge.py
+++ b/backend/tests/test_match_merge.py
@@ -146,6 +146,168 @@ async def test_merge_matches_happy_path(client: AsyncClient, team_registry_file)
 
 
 @pytest.mark.asyncio
+async def test_merge_matches_allows_explicit_reversed_pairings(
+    client: AsyncClient,
+    team_registry_file,
+):
+    teams = await _seed_two_matches()
+
+    resp = await client.post(
+        "/api/v1/matches/merge",
+        json={
+            "target_match_id": "target-match",
+            "source_match_ids": ["source-match"],
+            "team_pairings": [
+                {
+                    "source_team_id": teams["home_source_id"],
+                    "target_team_id": teams["away_target_id"],
+                },
+                {
+                    "source_team_id": teams["away_source_id"],
+                    "target_team_id": teams["home_target_id"],
+                },
+            ],
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_merge_matches_explicit_self_pairings_suppress_derived_fallback(
+    client: AsyncClient,
+    team_registry_file,
+):
+    await odds_store.upsert_league("laliga", "La Liga", "football")
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.set_current_snapshot(SCRAPED_AT)
+
+    barcelona_b = create_canonical_team(display_name="Barcelona B", sport="football")
+    real_madrid = create_canonical_team(display_name="Real Madrid", sport="football")
+    await odds_store.upsert_match(
+        id="target-match",
+        league_id="laliga",
+        home_team="Barcelona B",
+        away_team="Real Madrid",
+        home_team_id=barcelona_b.team_id,
+        away_team_id=real_madrid.team_id,
+        start_time=START_TIME,
+    )
+    await odds_store.upsert_match(
+        id="source-match",
+        league_id="laliga",
+        home_team="Real Madrid",
+        away_team="Barcelona B",
+        home_team_id=real_madrid.team_id,
+        away_team_id=barcelona_b.team_id,
+        start_time=START_TIME,
+    )
+
+    resp = await client.post(
+        "/api/v1/matches/merge",
+        json={
+            "target_match_id": "target-match",
+            "source_match_ids": ["source-match"],
+            "team_pairings": [
+                {
+                    "source_team_id": real_madrid.team_id,
+                    "target_team_id": real_madrid.team_id,
+                },
+                {
+                    "source_team_id": barcelona_b.team_id,
+                    "target_team_id": barcelona_b.team_id,
+                },
+            ],
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_merge_matches_rejects_pairing_source_outside_source_matches(
+    client: AsyncClient,
+    team_registry_file,
+):
+    teams = await _seed_two_matches()
+    unrelated = create_canonical_team(display_name="Unrelated Team")
+
+    resp = await client.post(
+        "/api/v1/matches/merge",
+        json={
+            "target_match_id": "target-match",
+            "source_match_ids": ["source-match"],
+            "team_pairings": [
+                {
+                    "source_team_id": unrelated.team_id,
+                    "target_team_id": teams["home_target_id"],
+                },
+            ],
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "not part of the source matches" in resp.json()["detail"]
+    assert await odds_store.get_match("source-match") is not None
+
+
+@pytest.mark.asyncio
+async def test_merge_matches_rejects_conflicting_derived_pairings(
+    client: AsyncClient,
+    team_registry_file,
+):
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.set_current_snapshot(SCRAPED_AT)
+
+    target_home = create_canonical_team(display_name="Target Home")
+    target_away = create_canonical_team(display_name="Target Away")
+    shared_source = create_canonical_team(display_name="Shared Source")
+    source_a_away = create_canonical_team(display_name="Source A Away")
+    source_b_home = create_canonical_team(display_name="Source B Home")
+    await odds_store.upsert_match(
+        id="target-match",
+        league_id="euroleague",
+        home_team="Target Home",
+        away_team="Target Away",
+        home_team_id=target_home.team_id,
+        away_team_id=target_away.team_id,
+        start_time=START_TIME,
+    )
+    await odds_store.upsert_match(
+        id="source-a",
+        league_id="euroleague",
+        home_team="Shared Source",
+        away_team="Source A Away",
+        home_team_id=shared_source.team_id,
+        away_team_id=source_a_away.team_id,
+        start_time=START_TIME,
+    )
+    await odds_store.upsert_match(
+        id="source-b",
+        league_id="euroleague",
+        home_team="Source B Home",
+        away_team="Shared Source",
+        home_team_id=source_b_home.team_id,
+        away_team_id=shared_source.team_id,
+        start_time=START_TIME,
+    )
+
+    resp = await client.post(
+        "/api/v1/matches/merge",
+        json={
+            "target_match_id": "target-match",
+            "source_match_ids": ["source-a", "source-b"],
+            "team_pairings": [],
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "Conflicting pairings" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_merge_matches_rejects_different_start_time(client: AsyncClient, team_registry_file):
     teams = await _seed_two_matches(same_start=False)
 
@@ -162,6 +324,100 @@ async def test_merge_matches_rejects_different_start_time(client: AsyncClient, t
     # Both matches still exist
     assert await odds_store.get_match("source-match") is not None
     assert await odds_store.get_match("target-match") is not None
+
+
+@pytest.mark.asyncio
+async def test_merge_matches_rejects_qualifier_mismatch_before_mutation(
+    client: AsyncClient,
+    team_registry_file,
+):
+    await odds_store.upsert_league("euroleague", "Euroleague", "basketball")
+    await odds_store.upsert_bookmaker("mozzart", "Mozzart")
+    await odds_store.upsert_bookmaker("meridian", "Meridian")
+    await odds_store.set_current_snapshot(SCRAPED_AT)
+
+    target_home = create_canonical_team(display_name="Partizan")
+    source_home = create_canonical_team(display_name="Partizan Women")
+    away = create_canonical_team(display_name="Rival")
+    await odds_store.upsert_match(
+        id="target-match",
+        league_id="euroleague",
+        home_team="Partizan",
+        away_team="Rival",
+        home_team_id=target_home.team_id,
+        away_team_id=away.team_id,
+        start_time=START_TIME,
+    )
+    await odds_store.upsert_match(
+        id="source-match",
+        league_id="euroleague",
+        home_team="Partizan Women",
+        away_team="Rival",
+        home_team_id=source_home.team_id,
+        away_team_id=away.team_id,
+        start_time=START_TIME,
+    )
+    await odds_store.upsert_odds(
+        NormalizedOdds(
+            match_id="target-match",
+            bookmaker_id="mozzart",
+            league_id="euroleague",
+            home_team="Partizan",
+            away_team="Rival",
+            market_type="game_total",
+            threshold=160.5,
+            over_odds=1.85,
+            under_odds=1.95,
+        ),
+        scraped_at=SCRAPED_AT,
+    )
+    await odds_store.upsert_odds(
+        NormalizedOdds(
+            match_id="source-match",
+            bookmaker_id="meridian",
+            league_id="euroleague",
+            home_team="Partizan Women",
+            away_team="Rival",
+            market_type="game_total",
+            threshold=161.5,
+            over_odds=1.90,
+            under_odds=1.92,
+        ),
+        scraped_at=SCRAPED_AT,
+    )
+
+    resp = await client.post(
+        "/api/v1/matches/merge",
+        json={
+            "target_match_id": "target-match",
+            "source_match_ids": ["source-match"],
+            "team_pairings": [],
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "qualifier_mismatch" in resp.json()["detail"]
+    assert await odds_store.get_match("source-match") is not None
+    assert await odds_store.get_match("target-match") is not None
+    assert len(await odds_store.get_odds_for_match("source-match")) == 1
+
+    self_pair_resp = await client.post(
+        "/api/v1/matches/merge",
+        json={
+            "target_match_id": "target-match",
+            "source_match_ids": ["source-match"],
+            "team_pairings": [
+                {
+                    "source_team_id": source_home.team_id,
+                    "target_team_id": source_home.team_id,
+                },
+            ],
+        },
+    )
+
+    assert self_pair_resp.status_code == 400
+    assert "not part of the target match" in self_pair_resp.json()["detail"]
+    assert await odds_store.get_match("source-match") is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_team_identity.py
+++ b/backend/tests/test_team_identity.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.team_identity import (
+    REASON_DOTTED_EXPANSION,
+    REASON_QUALIFIER_MISMATCH,
+    REASON_UNSAFE_SUBSET,
+    canonical_candidate_qualifier_gate,
+    canonical_team_auto_merge_analysis,
+    comparison_team_text,
+    event_team_similarity,
+    expand_dotted_team_pair,
+    explain_event_team_similarity,
+    same_team_context,
+    significant_tokens,
+    subset_or_equal_significant_tokens,
+    team_qualifiers,
+    unsafe_compound_subset_match,
+)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "ž Partizan",
+        "W/Partizan",
+        "Partizan W",
+        "Partizan Women",
+        "Partizan Wom",
+    ],
+)
+def test_team_qualifiers_detect_women_markers(name):
+    assert team_qualifiers(name, sport="football") == {"women"}
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Barcelona 2", {"2"}),
+        ("Barcelona II", {"ii"}),
+        ("Barcelona B", {"b"}),
+        ("Barcelona res", {"res"}),
+        ("Barcelona reserve", {"reserve"}),
+        ("Barcelona reserves", {"reserves"}),
+    ],
+)
+def test_team_qualifiers_detect_reserve_markers(name, expected):
+    assert team_qualifiers(name, sport="football") == expected
+
+
+@pytest.mark.parametrize("age", ["17", "18", "19", "20", "21", "23"])
+def test_team_qualifiers_detect_youth_markers(age):
+    assert team_qualifiers(f"Crvena zvezda U{age}", sport="football") == {f"u{age}"}
+    assert team_qualifiers(f"Crvena zvezda U-{age}", sport="football") == {f"u{age}"}
+
+
+def test_same_team_context_requires_matching_qualifier_semantics():
+    assert same_team_context("W/Partizan", "Partizan Women", sport="football")
+    assert not same_team_context("Partizan", "Partizan W", sport="football")
+    assert not same_team_context("Barcelona", "Barcelona B", sport="football")
+    assert not same_team_context("Real Madrid U19", "Real Madrid U21", sport="football")
+    assert team_qualifiers("W Connection", sport="football") == set()
+    assert team_qualifiers("W. Bromwich Albion", sport="football") == set()
+
+
+def test_low_signal_tokens_are_stripped_consistently():
+    assert comparison_team_text("FC Barcelona Women", sport="football") == "fc barcelona"
+    assert significant_tokens("FC Barcelona Women", sport="football") == {"barcelona"}
+    assert significant_tokens("CD CE SC FK Barcelona Team", sport="football") == {
+        "barcelona"
+    }
+
+
+def test_dotted_expansion_is_sport_gated_to_aggressive_sports():
+    basketball = explain_event_team_similarity(
+        "Ch.More",
+        "Cherno More",
+        sport="basketball",
+        expand_dotted=True,
+        auto_threshold=90.0,
+    )
+    football = explain_event_team_similarity(
+        "Ch.More",
+        "Cherno More",
+        sport="football",
+        expand_dotted=True,
+        auto_threshold=90.0,
+    )
+
+    assert basketball.score == 100.0
+    assert basketball.dotted_expanded
+    assert REASON_DOTTED_EXPANSION in basketball.reasons
+    assert football.score < 100.0
+    assert not football.dotted_expanded
+    assert REASON_DOTTED_EXPANSION not in football.reasons
+
+
+def test_ambiguous_dotted_prefixes_do_not_expand():
+    left, right, expanded = expand_dotted_team_pair(
+        "St.Petersburg",
+        "Stockholm Petersburg",
+        sport="basketball",
+    )
+
+    assert left == "St. Petersburg"
+    assert right == "Stockholm Petersburg"
+    assert not expanded
+    assert (
+        event_team_similarity(
+            "St.Petersburg",
+            "Stockholm Petersburg",
+            sport="basketball",
+            expand_dotted=True,
+        )
+        < 100.0
+    )
+
+
+def test_unsafe_subset_cases_are_named_separately_from_event_subset_anchors():
+    assert unsafe_compound_subset_match("FC Barcelona", "Barcelona B", sport="football")
+    assert not unsafe_compound_subset_match("FC Barcelona", "Barcelona", sport="football")
+    assert unsafe_compound_subset_match("Arsenal CF", "Arsenal", sport="football")
+    assert subset_or_equal_significant_tokens(
+        "Hermine Nantes",
+        "Hermine Nantes Basket",
+        sport="basketball",
+    )
+
+
+def test_canonical_auto_merge_analysis_distinguishes_blocking_reasons():
+    safe = canonical_team_auto_merge_analysis(
+        "Sao Jose W",
+        "Sao Jose Women",
+        sport="basketball",
+        threshold=88.0,
+    )
+    qualifier_mismatch = canonical_team_auto_merge_analysis(
+        "Partizan",
+        "Partizan W",
+        sport="basketball",
+        threshold=88.0,
+    )
+    unsafe_subset = canonical_team_auto_merge_analysis(
+        "Arsenal",
+        "Arsenal Tula",
+        sport="football",
+        threshold=88.0,
+    )
+    low_score = canonical_team_auto_merge_analysis(
+        "Manchester United",
+        "Manchester City",
+        sport="football",
+        threshold=88.0,
+    )
+
+    assert safe.auto_merge_safe
+    assert not safe.review_only
+    assert qualifier_mismatch.review_only
+    assert REASON_QUALIFIER_MISMATCH in qualifier_mismatch.reasons
+    assert unsafe_subset.review_only
+    assert REASON_UNSAFE_SUBSET in unsafe_subset.reasons
+    assert low_score.review_only
+    assert low_score.low_fuzzy_score
+
+
+def test_canonical_candidate_qualifier_gate_returns_structural_decision():
+    women_mismatch = canonical_candidate_qualifier_gate(
+        frozenset({"women"}),
+        frozenset(),
+        "men",
+    )
+    age_mismatch = canonical_candidate_qualifier_gate(
+        frozenset({"u19"}),
+        frozenset({"u23"}),
+        "men",
+    )
+    marker_mismatch = canonical_candidate_qualifier_gate(
+        frozenset({"u19"}),
+        frozenset(),
+        "men",
+    )
+
+    assert not women_mismatch.admit
+    assert women_mismatch.women_mismatch
+    assert not age_mismatch.admit
+    assert age_mismatch.explicit_age_mismatch
+    assert marker_mismatch.admit
+    assert marker_mismatch.youth_marker_mismatch

--- a/backend/tests/test_team_registry.py
+++ b/backend/tests/test_team_registry.py
@@ -38,6 +38,55 @@ def test_create_canonical_team_reuses_inactive_merged_display_name(team_registry
     assert alias_resolution.team_name == target.team_name
 
 
+def test_merge_canonical_teams_rejects_qualifier_mismatch(team_registry_file):
+    men = create_canonical_team(display_name="Barcelona", sport="football")
+    women = create_canonical_team(display_name="Barcelona Women", sport="football")
+
+    with pytest.raises(ValueError, match="qualifier_mismatch"):
+        merge_canonical_teams(
+            source_team_id=women.team_id,
+            target_team_id=men.team_id,
+        )
+
+
+def test_merge_canonical_teams_rejects_unsafe_subset(team_registry_file):
+    base = create_canonical_team(display_name="Arsenal", sport="football")
+    compound = create_canonical_team(display_name="Arsenal Tula", sport="football")
+
+    with pytest.raises(ValueError, match="unsafe_subset"):
+        merge_canonical_teams(
+            source_team_id=compound.team_id,
+            target_team_id=base.team_id,
+        )
+
+
+def test_merge_canonical_teams_allows_review_opt_in_for_unsafe_subset(team_registry_file):
+    base = create_canonical_team(display_name="Deportivo Amambay", sport="basketball")
+    subset = create_canonical_team(display_name="Amambay", sport="basketball")
+
+    merged = merge_canonical_teams(
+        source_team_id=subset.team_id,
+        target_team_id=base.team_id,
+        allow_unsafe_subset=True,
+    )
+
+    assert merged.id == base.team_id
+
+
+def test_merge_canonical_teams_review_opt_in_still_rejects_qualifier_mismatch(
+    team_registry_file,
+):
+    men = create_canonical_team(display_name="Partizan", sport="basketball")
+    women = create_canonical_team(display_name="Partizan Women", sport="basketball")
+
+    with pytest.raises(ValueError, match="qualifier_mismatch"):
+        merge_canonical_teams(
+            source_team_id=women.team_id,
+            target_team_id=men.team_id,
+            allow_unsafe_subset=True,
+        )
+
+
 def test_bootstrap_seed_reuses_inactive_merged_display_name(
     team_registry_file,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Add a centralized team identity policy module for qualifiers, comparison text, dotted expansion, unsafe subset detection, and merge eligibility reasons
- Route Match Unification, outcome normalization, canonical team lookup, team review, and match merge guardrails through the shared policy
- Add regression coverage for qualifier semantics, dotted expansion, unsafe canonical merges, review approvals, and match merge pairing validation

Closes #136

## Validation
- cd backend && ./venv/bin/pytest -q