### PR TITLE
Add typed Match Unification result modules

### DIFF
--- a/backend/app/api/status.py
+++ b/backend/app/api/status.py
@@ -9,6 +9,10 @@ from ..models.schemas import (
     SystemStatus,
 )
 from ..scrapers.registry import registry
+from ..services.match_unification import (
+    MATCH_UNIFICATION_RESULT_KEY,
+    match_unification_cycle_status_out,
+)
 from ..services.scheduler import scheduler
 from ..store import odds_store
 
@@ -44,5 +48,7 @@ async def trigger_scrape():
         matches_scraped=result["matches_scraped"],
         odds_scraped=result["odds_scraped"],
         opportunities_found=result["opportunities_found"],
-        match_unification=result.get("match_unification", {}),
+        match_unification=match_unification_cycle_status_out(
+            result[MATCH_UNIFICATION_RESULT_KEY]
+        ),
     )

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1012,7 +1012,7 @@ class MatchUnificationResolutionBenchmarkOut(BaseModel):
 
 
 class MatchUnificationBenchmarkOut(MatchUnificationResolutionBenchmarkOut):
-    """Subphase metrics for Match Unification."""
+    """Subphase metrics plus retained status fields for benchmark JSON compatibility."""
 
     state: str = "pending_unification"
     mode: str = "resolved_event_graph"

--- a/backend/app/services/match_unification/__init__.py
+++ b/backend/app/services/match_unification/__init__.py
@@ -1,7 +1,10 @@
 __all__ = [
     "InMemoryMatchUnificationStore",
+    "MATCH_UNIFICATION_RESULT_KEY",
     "MatchUnification",
     "MatchUnificationInputError",
+    "MatchUnificationPersistenceMetrics",
+    "MatchUnificationPersistenceMetricsError",
     "MatchUnificationResult",
     "MatchUnificationRows",
     "MatchUnificationStatus",
@@ -9,6 +12,8 @@ __all__ = [
     "MatchUnificationWarning",
     "OddsStoreMatchUnificationAdapter",
     "PersistedScrapeSnapshot",
+    "match_unification_cycle_status_out",
+    "match_unification_status_from_cycle_value",
 ]
 
 
@@ -29,12 +34,17 @@ def __getattr__(name: str):
         }[name]
     if name in {
         "MatchUnificationInputError",
+        "MATCH_UNIFICATION_RESULT_KEY",
+        "MatchUnificationPersistenceMetrics",
+        "MatchUnificationPersistenceMetricsError",
         "MatchUnificationResult",
         "MatchUnificationRows",
         "MatchUnificationStatus",
         "MatchUnificationStoreStateError",
         "MatchUnificationWarning",
         "PersistedScrapeSnapshot",
+        "match_unification_cycle_status_out",
+        "match_unification_status_from_cycle_value",
     }:
         from . import types
 

--- a/backend/app/services/match_unification/resolution.py
+++ b/backend/app/services/match_unification/resolution.py
@@ -2139,7 +2139,7 @@ async def persist_event_resolution_groups(
 
     return MatchUnificationPersistenceResult(
         candidates=len(members),
-        resolved_events=result["resolved_events"],
-        resolved_event_members=result["resolved_event_members"],
-        review_cases=result["review_cases"],
+        resolved_events=result.resolved_events,
+        resolved_event_members=result.resolved_event_members,
+        review_cases=result.review_cases,
     )

--- a/backend/app/services/match_unification/store.py
+++ b/backend/app/services/match_unification/store.py
@@ -5,6 +5,7 @@ from typing import Protocol
 
 from ...models.schemas import EventReviewCaseIn, ResolvedEventIn, ResolvedEventMemberIn
 from ...store import odds_store
+from .types import MatchUnificationPersistenceMetrics
 
 
 class MatchUnificationStore(Protocol):
@@ -15,7 +16,7 @@ class MatchUnificationStore(Protocol):
         events: list[ResolvedEventIn],
         members: list[ResolvedEventMemberIn],
         review_cases: list[EventReviewCaseIn],
-    ) -> dict[str, int]:
+    ) -> MatchUnificationPersistenceMetrics:
         ...
 
 
@@ -32,13 +33,14 @@ class OddsStoreMatchUnificationAdapter:
         events: list[ResolvedEventIn],
         members: list[ResolvedEventMemberIn],
         review_cases: list[EventReviewCaseIn],
-    ) -> dict[str, int]:
-        return await self._store.persist_event_resolution_batch(
+    ) -> MatchUnificationPersistenceMetrics:
+        result = await self._store.persist_event_resolution_batch(
             snapshot_id=snapshot_id,
             events=events,
             members=members,
             review_cases=review_cases,
         )
+        return MatchUnificationPersistenceMetrics.from_legacy_dict(result)
 
 
 class InMemoryMatchUnificationStore:
@@ -55,7 +57,7 @@ class InMemoryMatchUnificationStore:
         events: list[ResolvedEventIn],
         members: list[ResolvedEventMemberIn],
         review_cases: list[EventReviewCaseIn],
-    ) -> dict[str, int]:
+    ) -> MatchUnificationPersistenceMetrics:
         if self.fail:
             raise RuntimeError("in-memory match unification persistence failure")
         self.batches.append(
@@ -66,8 +68,8 @@ class InMemoryMatchUnificationStore:
                 "review_cases": deepcopy(review_cases),
             }
         )
-        return {
-            "resolved_events": len(events),
-            "resolved_event_members": len(members),
-            "review_cases": len(review_cases),
-        }
+        return MatchUnificationPersistenceMetrics(
+            resolved_events=len(events),
+            resolved_event_members=len(members),
+            review_cases=len(review_cases),
+        )

--- a/backend/app/services/match_unification/types.py
+++ b/backend/app/services/match_unification/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Literal
@@ -8,6 +9,8 @@ from ...models.schemas import (
     BenchmarkEventCoverageOut,
     BenchmarkSplitDiagnosticsOut,
     MatchUnificationBenchmarkOut,
+    MatchUnificationCycleStatusOut,
+    MatchUnificationResolutionBenchmarkOut,
     NormalizedOdds,
     NormalizedOutcomeOffer,
     RawOddsData,
@@ -21,6 +24,7 @@ MatchUnificationState = Literal[
     "match_id_only",
     "unification_failed",
 ]
+MATCH_UNIFICATION_RESULT_KEY = "match_unification"
 
 
 class MatchUnificationInputError(ValueError):
@@ -29,6 +33,10 @@ class MatchUnificationInputError(ValueError):
 
 class MatchUnificationStoreStateError(RuntimeError):
     """Raised when fallback cannot be made visible after persistence state is uncertain."""
+
+
+class MatchUnificationPersistenceMetricsError(MatchUnificationStoreStateError):
+    """Raised when legacy persistence metrics cannot be adapted safely."""
 
 
 @dataclass(frozen=True)
@@ -53,32 +61,178 @@ class MatchUnificationWarning:
 
 
 @dataclass(frozen=True)
+class MatchUnificationPersistenceMetrics:
+    resolved_events: int
+    resolved_event_members: int
+    review_cases: int
+
+    @classmethod
+    def from_legacy_dict(
+        cls,
+        value: Mapping[str, object],
+    ) -> "MatchUnificationPersistenceMetrics":
+        required_keys = (
+            "resolved_events",
+            "resolved_event_members",
+            "review_cases",
+        )
+        missing_keys = [key for key in required_keys if key not in value]
+        if missing_keys:
+            joined = ", ".join(missing_keys)
+            raise MatchUnificationPersistenceMetricsError(
+                f"legacy Match Unification persistence metrics missing key(s): {joined}"
+            )
+        return cls(
+            resolved_events=_required_non_negative_int(
+                value["resolved_events"],
+                key="resolved_events",
+            ),
+            resolved_event_members=_required_non_negative_int(
+                value["resolved_event_members"],
+                key="resolved_event_members",
+            ),
+            review_cases=_required_non_negative_int(
+                value["review_cases"],
+                key="review_cases",
+            ),
+        )
+
+
+def _required_non_negative_int(value: object, *, key: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise MatchUnificationPersistenceMetricsError(
+            "legacy Match Unification persistence metrics key "
+            f"{key!r} must be a non-negative int, got {type(value).__name__}"
+        )
+    if value < 0:
+        raise MatchUnificationPersistenceMetricsError(
+            "legacy Match Unification persistence metrics key "
+            f"{key!r} must be non-negative, got {value}"
+        )
+    return value
+
+
+@dataclass(frozen=True)
 class MatchUnificationStatus:
-    snapshot_id: str
     state: MatchUnificationState
     mode: MatchUnificationMode
+    snapshot_id: str | None = None
     warnings: tuple[MatchUnificationWarning, ...] = ()
     fallback_reason: str | None = None
+
+    @classmethod
+    def pending(cls) -> "MatchUnificationStatus":
+        return cls(state="pending_unification", mode="resolved_event_graph")
+
+    @classmethod
+    def unified(cls, *, snapshot_id: str) -> "MatchUnificationStatus":
+        return cls(
+            snapshot_id=snapshot_id,
+            state="unified",
+            mode="resolved_event_graph",
+        )
+
+    @classmethod
+    def match_id_only(
+        cls,
+        *,
+        snapshot_id: str,
+        warning: MatchUnificationWarning,
+        fallback_reason: str,
+    ) -> "MatchUnificationStatus":
+        return cls(
+            snapshot_id=snapshot_id,
+            state="match_id_only",
+            mode="match_id_only",
+            warnings=(warning,),
+            fallback_reason=fallback_reason,
+        )
+
+    def to_cycle_status_out(self) -> MatchUnificationCycleStatusOut:
+        return MatchUnificationCycleStatusOut(
+            state=self.state,
+            mode=self.mode,
+            warnings=[warning.detail for warning in self.warnings],
+            fallback_reason=self.fallback_reason,
+        )
 
 
 @dataclass(frozen=True)
 class MatchUnificationResult:
-    snapshot_id: str
-    mode: MatchUnificationMode
+    status: MatchUnificationStatus
     candidates: int = 0
     resolved_events: int = 0
     resolved_event_members: int = 0
     review_cases: int = 0
-    benchmark: MatchUnificationBenchmarkOut = field(
-        default_factory=MatchUnificationBenchmarkOut
+    benchmark: MatchUnificationResolutionBenchmarkOut = field(
+        default_factory=MatchUnificationResolutionBenchmarkOut
     )
     coverage: tuple[BenchmarkEventCoverageOut, ...] = ()
     split_diagnostics: BenchmarkSplitDiagnosticsOut = field(
         default_factory=BenchmarkSplitDiagnosticsOut
     )
-    warnings: tuple[MatchUnificationWarning, ...] = ()
-    status: MatchUnificationStatus | None = None
+
+    def __post_init__(self) -> None:
+        if self.status.snapshot_id is None:
+            raise ValueError("MatchUnificationResult.status.snapshot_id is required")
+
+    @property
+    def snapshot_id(self) -> str:
+        snapshot_id = self.status.snapshot_id
+        if snapshot_id is None:
+            raise ValueError("MatchUnificationResult.status.snapshot_id is required")
+        return snapshot_id
+
+    @property
+    def mode(self) -> MatchUnificationMode:
+        return self.status.mode
+
+    @property
+    def warnings(self) -> tuple[MatchUnificationWarning, ...]:
+        return self.status.warnings
+
+    @property
+    def fallback_reason(self) -> str | None:
+        return self.status.fallback_reason
 
     @property
     def warning_codes(self) -> tuple[str, ...]:
         return tuple(warning.code for warning in self.warnings)
+
+    def to_cycle_status_out(self) -> MatchUnificationCycleStatusOut:
+        return self.status.to_cycle_status_out()
+
+    def to_benchmark_out(self) -> MatchUnificationBenchmarkOut:
+        """Build the benchmark API compatibility shape from metrics + status."""
+        metric_fields = self.benchmark.model_dump(
+            exclude={"state", "mode", "warnings", "fallback_reason"}
+        )
+        return MatchUnificationBenchmarkOut(
+            **metric_fields,
+            state=self.status.state,
+            mode=self.status.mode,
+            warnings=list(self.warning_codes),
+            fallback_reason=self.status.fallback_reason,
+        )
+
+
+def match_unification_cycle_status_out(
+    status: MatchUnificationStatus,
+) -> MatchUnificationCycleStatusOut:
+    if isinstance(status, MatchUnificationStatus):
+        return status.to_cycle_status_out()
+    raise TypeError(
+        "match_unification status must be a MatchUnificationStatus, "
+        f"got {type(status).__name__}"
+    )
+
+
+def match_unification_status_from_cycle_value(
+    status: MatchUnificationStatus,
+) -> MatchUnificationStatus:
+    if isinstance(status, MatchUnificationStatus):
+        return status
+    raise TypeError(
+        "match_unification status must be a MatchUnificationStatus, "
+        f"got {type(status).__name__}"
+    )

--- a/backend/app/services/match_unification/unifier.py
+++ b/backend/app/services/match_unification/unifier.py
@@ -5,7 +5,7 @@ import logging
 import time
 
 from ...models.schemas import (
-    MatchUnificationBenchmarkOut,
+    MatchUnificationResolutionBenchmarkOut,
     MatchUnificationSourceMatchSlotBenchmarkOut,
 )
 from . import candidate_extraction, resolution
@@ -155,9 +155,7 @@ class MatchUnification:
             ),
             reverse=True,
         )
-        benchmark = MatchUnificationBenchmarkOut(
-            state="unified",
-            mode="resolved_event_graph",
+        benchmark = MatchUnificationResolutionBenchmarkOut(
             extract_event_candidates_ms=extract_event_candidates_ms,
             extract_raw_odds_sources_ms=extraction_stats.extract_raw_odds_sources_ms,
             extract_raw_outcome_sources_ms=(
@@ -233,11 +231,7 @@ class MatchUnification:
             persisted_review_case_count=persisted.review_cases,
             top_source_match_slots=source_match_slot_rows[:20],
         )
-        status = MatchUnificationStatus(
-            snapshot_id=snapshot.id,
-            state="unified",
-            mode="resolved_event_graph",
-        )
+        status = MatchUnificationStatus.unified(snapshot_id=snapshot.id)
         logger.info(
             "Unified %d source-event candidates into %d events (%d members, %d review cases)",
             len(candidates),
@@ -246,8 +240,7 @@ class MatchUnification:
             persisted.review_cases,
         )
         return MatchUnificationResult(
-            snapshot_id=snapshot.id,
-            mode="resolved_event_graph",
+            status=status,
             candidates=len(candidates),
             resolved_events=persisted.resolved_events,
             resolved_event_members=persisted.resolved_event_members,
@@ -255,7 +248,6 @@ class MatchUnification:
             benchmark=benchmark,
             coverage=coverage,
             split_diagnostics=split_diagnostics,
-            status=status,
         )
 
     def _fallback(
@@ -270,23 +262,13 @@ class MatchUnification:
             code="match_unification_failed",
             detail=reason,
         )
-        benchmark = MatchUnificationBenchmarkOut(
-            state="match_id_only",
-            mode="match_id_only",
-            warnings=[warning.code],
-            fallback_reason=reason,
-        )
-        status = MatchUnificationStatus(
+        benchmark = MatchUnificationResolutionBenchmarkOut()
+        status = MatchUnificationStatus.match_id_only(
             snapshot_id=snapshot.id,
-            state="match_id_only",
-            mode="match_id_only",
-            warnings=(warning,),
+            warning=warning,
             fallback_reason=reason,
         )
         return MatchUnificationResult(
-            snapshot_id=snapshot.id,
-            mode="match_id_only",
-            benchmark=benchmark,
-            warnings=(warning,),
             status=status,
+            benchmark=benchmark,
         )

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -22,6 +22,7 @@ from ..models.schemas import (
     ScrapeRuntimeSettings,
     ScrapeRuntimeSettingsUpdate,
     ScrapeSettingsResponse,
+    MatchUnificationCycleStatusOut,
     TeamReviewDiagnostic,
     UnresolvedOddsDiagnostic,
 )
@@ -52,7 +53,12 @@ from ..services.match_unification.resolution import (
     _normalize_merge_pairings,
     _same_time_slot_orientation,
 )
-from ..services.match_unification import MatchUnification
+from ..services.match_unification import (
+    MATCH_UNIFICATION_RESULT_KEY,
+    MatchUnification,
+    MatchUnificationStatus,
+    match_unification_status_from_cycle_value,
+)
 from ..services.match_unification.team_text import same_team_context as _same_team_context
 from ..services.outcome_normalizer import (
     FootballEventResolutionMap,
@@ -1051,12 +1057,7 @@ class Scheduler:
         self._scan_completed_tasks = 0
         self._scan_failed_tasks = 0
         self._scan_active_tasks = 0
-        self._match_unification_status = {
-            "state": "pending_unification",
-            "mode": "resolved_event_graph",
-            "warnings": [],
-            "fallback_reason": None,
-        }
+        self._match_unification_status = MatchUnificationStatus.pending()
         self._notification_service = NotificationService(
             gap_threshold=settings.notification_gap_threshold
         )
@@ -1098,13 +1099,14 @@ class Scheduler:
             active_tasks=self._scan_active_tasks,
         )
 
-    def match_unification_status_snapshot(self) -> dict:
-        return {
-            "state": self._match_unification_status.get("state", "pending_unification"),
-            "mode": self._match_unification_status.get("mode", "resolved_event_graph"),
-            "warnings": list(self._match_unification_status.get("warnings", [])),
-            "fallback_reason": self._match_unification_status.get("fallback_reason"),
-        }
+    def match_unification_status_snapshot(self) -> MatchUnificationCycleStatusOut:
+        return self._match_unification_status.to_cycle_status_out()
+
+    def _record_match_unification_status(
+        self,
+        status: MatchUnificationStatus,
+    ) -> None:
+        self._match_unification_status = match_unification_status_from_cycle_value(status)
 
     def _reset_progress(self) -> None:
         self._scan_phase = "idle"
@@ -2056,20 +2058,7 @@ class Scheduler:
                     ),
                 )
             )
-            match_unification_status = result.get("match_unification")
-            if isinstance(match_unification_status, dict):
-                self._match_unification_status = {
-                    "state": match_unification_status.get(
-                        "state",
-                        "pending_unification",
-                    ),
-                    "mode": match_unification_status.get(
-                        "mode",
-                        "resolved_event_graph",
-                    ),
-                    "warnings": list(match_unification_status.get("warnings", [])),
-                    "fallback_reason": match_unification_status.get("fallback_reason"),
-                }
+            self._record_match_unification_status(result[MATCH_UNIFICATION_RESULT_KEY])
             return result
         finally:
             self._reset_progress()

--- a/backend/app/services/scrape_pipeline.py
+++ b/backend/app/services/scrape_pipeline.py
@@ -46,6 +46,7 @@ from ..services.match_unification.resolution import (
     _same_time_slot_orientation,
 )
 from ..services.match_unification import (
+    MATCH_UNIFICATION_RESULT_KEY,
     MatchUnification,
     MatchUnificationRows,
     PersistedScrapeSnapshot,
@@ -1748,10 +1749,9 @@ class ScrapePipeline:
                 "match_unification",
                 int((time.perf_counter() - match_unification_started_at) * 1000),
             )
-            if match_unification_result.benchmark is not None:
-                self.benchmark.record_match_unification(
-                    match_unification_result.benchmark
-                )
+            self.benchmark.record_match_unification(
+                match_unification_result.to_benchmark_out()
+            )
             self.benchmark.record_event_split_diagnostics(
                 match_unification_result.split_diagnostics
             )
@@ -1898,20 +1898,6 @@ class ScrapePipeline:
         except Exception:
             logger.exception("Retention cleanup failed after a successful scrape cycle")
 
-        match_unification_state = (
-            match_unification_result.status.state
-            if match_unification_result.status is not None
-            else (
-                match_unification_result.benchmark.state
-                if match_unification_result.benchmark is not None
-                else "pending_unification"
-            )
-        )
-        match_unification_fallback_reason = (
-            match_unification_result.benchmark.fallback_reason
-            if match_unification_result.benchmark is not None
-            else None
-        )
         result = {
             "matches_scraped": len(seen_matches),
             "odds_scraped": len(normalized),
@@ -1920,14 +1906,7 @@ class ScrapePipeline:
             "canonical_offers_analyzed": canonical_shadow.offers_analyzed,
             "canonical_opportunities_found": canonical_shadow.opportunities_found,
             "canonical_shadow_warnings": list(canonical_shadow.warnings),
-            "match_unification": {
-                "state": match_unification_state,
-                "mode": match_unification_result.mode,
-                "warnings": [
-                    warning.detail for warning in match_unification_result.warnings
-                ],
-                "fallback_reason": match_unification_fallback_reason,
-            },
+            MATCH_UNIFICATION_RESULT_KEY: match_unification_result.status,
             "notifications_sent": notified,
             "scrape_duration_ms": scrape_duration_ms,
             "cycle_duration_ms": int((time.perf_counter() - cycle_started_at) * 1000),

--- a/backend/app/services/telegram_commands.py
+++ b/backend/app/services/telegram_commands.py
@@ -12,6 +12,7 @@ from ..config import settings
 from ..models.schemas import (
     BookmakerOut,
     BookmakerCoverageOut,
+    MatchUnificationCycleStatusOut,
     ScanProgressOut,
     SystemStatus,
     TelegramNotificationProfileOut,
@@ -65,6 +66,9 @@ class TelegramCommandScheduler(Protocol):
         ...
 
     def progress_snapshot(self) -> ScanProgressOut:
+        ...
+
+    def match_unification_status_snapshot(self) -> MatchUnificationCycleStatusOut:
         ...
 
     async def run_cycle(self) -> dict:
@@ -191,6 +195,7 @@ class StatusCommand:
         status = await odds_store.get_system_status(
             scheduler_running=context.scheduler.is_running,
             scan_progress=context.scheduler.progress_snapshot(),
+            match_unification=context.scheduler.match_unification_status_snapshot(),
         )
         await context.reply(_format_system_status(status))
 
@@ -718,6 +723,19 @@ def _format_system_status(status: SystemStatus) -> str:
         lines.append(f"Cycle: {html.escape(scan.phase)} — {progress}")
     else:
         lines.append("Cycle: idle")
+    match_unification = status.match_unification
+    lines.append(
+        "Match Unification: "
+        f"{html.escape(match_unification.state)} "
+        f"({html.escape(match_unification.mode)})"
+    )
+    if match_unification.fallback_reason:
+        lines.append(
+            "Match Unification fallback: "
+            f"{html.escape(match_unification.fallback_reason)}"
+        )
+    for warning in match_unification.warnings:
+        lines.append(f"Match Unification warning: {html.escape(warning)}")
     return "\n".join(lines)
 
 

--- a/backend/app/store/odds_store.py
+++ b/backend/app/store/odds_store.py
@@ -5324,7 +5324,7 @@ async def cleanup_retained_data(current_snapshot_at: str) -> dict[str, int]:
 async def get_system_status(
     scheduler_running: bool = False,
     scan_progress: ScanProgressOut | None = None,
-    match_unification: MatchUnificationCycleStatusOut | dict | None = None,
+    match_unification: MatchUnificationCycleStatusOut | None = None,
 ) -> SystemStatus:
     db = await get_db()
     current_snapshot_id, current_snapshot_at = await _get_current_snapshot(db)

--- a/backend/tests/test_match_unification.py
+++ b/backend/tests/test_match_unification.py
@@ -2,13 +2,21 @@ from __future__ import annotations
 
 import pytest
 
+from app.models.schemas import MatchUnificationBenchmarkOut
 from app.services.match_unification import (
     InMemoryMatchUnificationStore,
     MatchUnification,
     MatchUnificationInputError,
+    MatchUnificationPersistenceMetrics,
+    MatchUnificationPersistenceMetricsError,
+    MatchUnificationResult,
+    MatchUnificationStatus,
     MatchUnificationRows,
+    OddsStoreMatchUnificationAdapter,
     PersistedScrapeSnapshot,
 )
+from app.services.match_unification.resolution import persist_event_resolution_groups
+from app.store import odds_store
 
 
 def _snapshot() -> PersistedScrapeSnapshot:
@@ -28,6 +36,14 @@ def _empty_rows() -> MatchUnificationRows:
     )
 
 
+class _LegacyPersistenceStore:
+    def __init__(self, result: dict[str, object]) -> None:
+        self.result = result
+
+    async def persist_event_resolution_batch(self, **_kwargs):
+        return self.result
+
+
 @pytest.mark.asyncio
 async def test_match_unification_persists_empty_snapshot_through_adapter():
     store = InMemoryMatchUnificationStore()
@@ -39,9 +55,13 @@ async def test_match_unification_persists_empty_snapshot_through_adapter():
     )
 
     assert result.mode == "resolved_event_graph"
-    assert result.status is not None
     assert result.status.state == "unified"
-    assert result.benchmark.state == "unified"
+    assert result.status.mode == "resolved_event_graph"
+    assert result.snapshot_id == result.status.snapshot_id == "snapshot-1"
+    assert result.mode == result.status.mode
+    assert result.warnings == result.status.warnings
+    assert result.fallback_reason == result.status.fallback_reason
+    assert result.to_benchmark_out().state == "unified"
     assert store.batches == [
         {
             "snapshot_id": "snapshot-1",
@@ -50,6 +70,126 @@ async def test_match_unification_persists_empty_snapshot_through_adapter():
             "review_cases": [],
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_returns_typed_persistence_metrics():
+    store = InMemoryMatchUnificationStore()
+
+    result = await store.persist_event_resolution_batch(
+        snapshot_id="snapshot-1",
+        events=[],
+        members=[],
+        review_cases=[],
+    )
+
+    assert result == MatchUnificationPersistenceMetrics(
+        resolved_events=0,
+        resolved_event_members=0,
+        review_cases=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_adapter_wraps_legacy_persistence_metrics():
+    adapter = OddsStoreMatchUnificationAdapter(
+        _LegacyPersistenceStore(
+            {
+                "resolved_events": 2,
+                "resolved_event_members": 5,
+                "review_cases": 1,
+            }
+        )
+    )
+
+    result = await adapter.persist_event_resolution_batch(
+        snapshot_id="snapshot-1",
+        events=[],
+        members=[],
+        review_cases=[],
+    )
+
+    assert result == MatchUnificationPersistenceMetrics(
+        resolved_events=2,
+        resolved_event_members=5,
+        review_cases=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_adapter_wraps_real_odds_store_metrics():
+    adapter = OddsStoreMatchUnificationAdapter(odds_store)
+
+    result = await adapter.persist_event_resolution_batch(
+        snapshot_id="snapshot-1",
+        events=[],
+        members=[],
+        review_cases=[],
+    )
+
+    assert result == MatchUnificationPersistenceMetrics(
+        resolved_events=0,
+        resolved_event_members=0,
+        review_cases=0,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("legacy_result", "message"),
+    [
+        (
+            {"resolved_events": 1, "resolved_event_members": 2},
+            "missing key",
+        ),
+        (
+            {
+                "resolved_events": "1",
+                "resolved_event_members": 2,
+                "review_cases": 3,
+            },
+            "must be a non-negative int",
+        ),
+        (
+            {
+                "resolved_events": 1,
+                "resolved_event_members": -2,
+                "review_cases": 3,
+            },
+            "must be non-negative",
+        ),
+    ],
+)
+async def test_store_adapter_rejects_malformed_legacy_metrics(
+    legacy_result,
+    message,
+):
+    adapter = OddsStoreMatchUnificationAdapter(_LegacyPersistenceStore(legacy_result))
+
+    with pytest.raises(MatchUnificationPersistenceMetricsError, match=message):
+        await adapter.persist_event_resolution_batch(
+            snapshot_id="snapshot-1",
+            events=[],
+            members=[],
+            review_cases=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolution_persistence_consumes_typed_metrics():
+    class MetricsStore:
+        async def persist_event_resolution_batch(self, **_kwargs):
+            return MatchUnificationPersistenceMetrics(
+                resolved_events=3,
+                resolved_event_members=7,
+                review_cases=2,
+            )
+
+    result = await persist_event_resolution_groups([], [], store=MetricsStore())
+
+    assert result.resolved_events == 3
+    assert result.resolved_event_members == 7
+    assert result.review_cases == 2
 
 
 @pytest.mark.asyncio
@@ -62,11 +202,70 @@ async def test_match_unification_fallback_is_visible_when_adapter_fails():
     )
 
     assert result.mode == "match_id_only"
-    assert result.status is not None
     assert result.status.state == "match_id_only"
-    assert result.benchmark.state == "match_id_only"
-    assert result.benchmark.warnings == ["match_unification_failed"]
+    assert result.status.mode == "match_id_only"
+    assert result.status.fallback_reason is not None
+    assert result.status.warnings[0].detail == result.status.fallback_reason
+    benchmark = result.to_benchmark_out()
+    assert benchmark.state == "match_id_only"
+    assert benchmark.mode == "match_id_only"
+    assert benchmark.warnings == ["match_unification_failed"]
+    assert benchmark.fallback_reason == result.status.fallback_reason
     assert result.warnings[0].code == "match_unification_failed"
+
+
+@pytest.mark.asyncio
+async def test_malformed_adapter_metrics_fall_back_visibly():
+    unification = MatchUnification(
+        store=OddsStoreMatchUnificationAdapter(
+            _LegacyPersistenceStore(
+                {
+                    "resolved_events": 0,
+                    "resolved_event_members": 0,
+                }
+            )
+        )
+    )
+
+    result = await unification.unify_after_snapshot(
+        snapshot=_snapshot(),
+        rows=_empty_rows(),
+    )
+
+    assert result.status == MatchUnificationStatus.match_id_only(
+        snapshot_id="snapshot-1",
+        warning=result.warnings[0],
+        fallback_reason=result.fallback_reason or "",
+    )
+    assert "MatchUnificationPersistenceMetricsError" in (result.fallback_reason or "")
+    assert result.to_cycle_status_out().warnings == [result.warnings[0].detail]
+    assert result.to_benchmark_out().warnings == ["match_unification_failed"]
+
+
+def test_match_unification_result_requires_status_snapshot_id():
+    with pytest.raises(ValueError, match="status.snapshot_id is required"):
+        MatchUnificationResult(status=MatchUnificationStatus.pending())
+
+
+def test_match_unification_result_adapts_legacy_benchmark_object():
+    result = MatchUnificationResult(
+        status=MatchUnificationStatus.unified(snapshot_id="snapshot-1"),
+        benchmark=MatchUnificationBenchmarkOut(
+            state="pending_unification",
+            mode="match_id_only",
+            warnings=["legacy_warning"],
+            fallback_reason="legacy fallback",
+            candidate_count=4,
+        ),
+    )
+
+    benchmark = result.to_benchmark_out()
+
+    assert benchmark.candidate_count == 4
+    assert benchmark.state == "unified"
+    assert benchmark.mode == "resolved_event_graph"
+    assert benchmark.warnings == []
+    assert benchmark.fallback_reason is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -43,6 +43,7 @@ from app.services.scheduler import (
     _runtime_detail_modes,
     _team_review_case_references_merged_team,
 )
+from app.services.match_unification import MatchUnificationStatus, MatchUnificationWarning
 from app.services.normalizer import normalize_team_name
 from app.services.notifications import (
     InAppNotificationProvider,
@@ -2080,6 +2081,60 @@ async def test_scheduler_progress_snapshot_updates_while_cycle_runs():
 
     await cycle_task
     assert scheduler_under_test.progress_snapshot().in_progress is False
+
+
+def test_scheduler_match_unification_status_snapshot_is_typed_and_compatible():
+    scheduler_under_test = Scheduler(interval_minutes=1)
+
+    assert isinstance(scheduler_under_test._match_unification_status, MatchUnificationStatus)
+    assert scheduler_under_test.match_unification_status_snapshot().model_dump() == {
+        "state": "pending_unification",
+        "mode": "resolved_event_graph",
+        "warnings": [],
+        "fallback_reason": None,
+    }
+
+
+def test_scheduler_records_typed_match_unification_status_and_clears_fallback():
+    scheduler_under_test = Scheduler(interval_minutes=1)
+    warning = MatchUnificationWarning(
+        code="match_unification_failed",
+        detail="RuntimeError: store failed",
+    )
+
+    scheduler_under_test._record_match_unification_status(
+        MatchUnificationStatus.match_id_only(
+            snapshot_id="snapshot-1",
+            warning=warning,
+            fallback_reason=warning.detail,
+        )
+    )
+
+    assert scheduler_under_test.match_unification_status_snapshot().model_dump() == {
+        "state": "match_id_only",
+        "mode": "match_id_only",
+        "warnings": ["RuntimeError: store failed"],
+        "fallback_reason": "RuntimeError: store failed",
+    }
+
+    scheduler_under_test._record_match_unification_status(
+        MatchUnificationStatus.unified(snapshot_id="snapshot-2")
+    )
+
+    assert isinstance(scheduler_under_test._match_unification_status, MatchUnificationStatus)
+    assert scheduler_under_test.match_unification_status_snapshot().model_dump() == {
+        "state": "unified",
+        "mode": "resolved_event_graph",
+        "warnings": [],
+        "fallback_reason": None,
+    }
+
+
+def test_scheduler_rejects_missing_match_unification_status_after_cycle():
+    scheduler_under_test = Scheduler(interval_minutes=1)
+
+    with pytest.raises(TypeError, match="MatchUnificationStatus"):
+        scheduler_under_test._record_match_unification_status(None)  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scrape_pipeline.py
+++ b/backend/tests/test_scrape_pipeline.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.models.schemas import ScrapeRuntimeSettings
+from app.models.schemas import (
+    MatchUnificationResolutionBenchmarkOut,
+    ScrapeRuntimeSettings,
+)
 from app.services.market_allowlist import analysis_market_allowlist
 from app.services.scrape_pipeline import (
     BookmakerIdentity,
@@ -14,9 +17,17 @@ from app.services.scrape_pipeline import (
     _CanonicalAnalysisResult,
 )
 from app.services import scrape_pipeline
+from app.services.match_unification import (
+    MatchUnificationResult,
+    MatchUnificationStatus,
+    MatchUnificationWarning,
+)
 
 
 class FakeBenchmark:
+    def __init__(self) -> None:
+        self.match_unification_metrics = []
+
     def record_phase_duration(self, *_args, **_kwargs):
         pass
 
@@ -29,8 +40,8 @@ class FakeBenchmark:
     def record_persistence(self, *_args, **_kwargs):
         pass
 
-    def record_match_unification(self, *_args, **_kwargs):
-        pass
+    def record_match_unification(self, metrics, *_args, **_kwargs):
+        self.match_unification_metrics.append(metrics)
 
     def record_event_split_diagnostics(self, *_args, **_kwargs):
         pass
@@ -126,14 +137,12 @@ async def _load_empty_canonical_analysis(_store, **_kwargs):
 
 
 class FakeMatchUnification:
+    def __init__(self, result: MatchUnificationResult | None = None) -> None:
+        self.result = result
+
     async def unify_after_snapshot(self, **_kwargs):
-        return SimpleNamespace(
-            mode="resolved_event_graph",
-            status=SimpleNamespace(state="unified"),
-            warnings=(),
-            benchmark=None,
-            split_diagnostics=(),
-            coverage=(),
+        return self.result or MatchUnificationResult(
+            status=MatchUnificationStatus.unified(snapshot_id="snapshot-1"),
         )
 
 
@@ -160,15 +169,17 @@ def _pipeline(
     notification_service: FakeNotificationService | None = None,
     team_actions: FakeTeamActions | None = None,
     phase_callback=None,
+    benchmark: FakeBenchmark | None = None,
+    match_unification: FakeMatchUnification | None = None,
 ) -> ScrapePipeline:
     return ScrapePipeline(
         store=store,
-        benchmark=FakeBenchmark(),
+        benchmark=benchmark or FakeBenchmark(),
         notification_service=notification_service or FakeNotificationService(),
         team_actions=team_actions or FakeTeamActions(),
         phase_callback=phase_callback,
         load_canonical_analysis=_load_empty_canonical_analysis,
-        match_unification=FakeMatchUnification(),
+        match_unification=match_unification or FakeMatchUnification(),
     )
 
 
@@ -228,6 +239,46 @@ async def test_pipeline_phase_callback_failure_is_non_fatal():
 
     assert result["matches_scraped"] == 0
     assert store.cleanup_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_returns_typed_match_unification_status_and_compatible_benchmark():
+    store = FakeStore()
+    benchmark = FakeBenchmark()
+    warning = MatchUnificationWarning(
+        code="match_unification_failed",
+        detail="RuntimeError: store failed",
+    )
+    match_unification_result = MatchUnificationResult(
+        status=MatchUnificationStatus.match_id_only(
+            snapshot_id="snapshot-1",
+            warning=warning,
+            fallback_reason=warning.detail,
+        ),
+        benchmark=MatchUnificationResolutionBenchmarkOut(candidate_count=4),
+    )
+
+    result = await _pipeline(
+        store=store,
+        benchmark=benchmark,
+        match_unification=FakeMatchUnification(match_unification_result),
+    ).run(_pipeline_input())
+
+    match_unification_status = result["match_unification"]
+    assert isinstance(match_unification_status, MatchUnificationStatus)
+    assert match_unification_status.state == "match_id_only"
+    assert match_unification_status.to_cycle_status_out().model_dump() == {
+        "state": "match_id_only",
+        "mode": "match_id_only",
+        "warnings": ["RuntimeError: store failed"],
+        "fallback_reason": "RuntimeError: store failed",
+    }
+    recorded = benchmark.match_unification_metrics[-1]
+    assert recorded.candidate_count == 4
+    assert recorded.state == "match_id_only"
+    assert recorded.mode == "match_id_only"
+    assert recorded.warnings == ["match_unification_failed"]
+    assert recorded.fallback_reason == "RuntimeError: store failed"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -7,6 +7,7 @@ import pytest
 from app.models.schemas import (
     BookmakerOut,
     BookmakerCoverageOut,
+    MatchUnificationCycleStatusOut,
     OpportunityLeg,
     OpportunityOut,
     ScanProgressOut,
@@ -168,9 +169,18 @@ class RecordingDispatcher:
 
 
 class StubScheduler:
-    def __init__(self, *, in_progress: bool = False, is_running: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        in_progress: bool = False,
+        is_running: bool = True,
+        match_unification: MatchUnificationCycleStatusOut | None = None,
+    ) -> None:
         self._in_progress = in_progress
         self._is_running = is_running
+        self._match_unification = (
+            match_unification or MatchUnificationCycleStatusOut()
+        )
         self.run_count = 0
         self.finished = asyncio.Event()
 
@@ -191,6 +201,9 @@ class StubScheduler:
             failed_tasks=1,
             active_tasks=1,
         )
+
+    def match_unification_status_snapshot(self) -> MatchUnificationCycleStatusOut:
+        return self._match_unification
 
     async def run_cycle(self) -> dict:
         self.run_count += 1
@@ -445,6 +458,7 @@ async def test_status_command_returns_idle_system_status(
         *,
         scheduler_running: bool = False,
         scan_progress: ScanProgressOut | None = None,
+        match_unification: MatchUnificationCycleStatusOut | None = None,
     ) -> SystemStatus:
         return SystemStatus(
             status="ok <safe>",
@@ -455,6 +469,7 @@ async def test_status_command_returns_idle_system_status(
             active_bookmakers=13,
             scheduler_running=scheduler_running,
             scan=scan_progress or ScanProgressOut(),
+            match_unification=match_unification or MatchUnificationCycleStatusOut(),
         )
 
     monkeypatch.setattr(odds_store, "get_system_status", fake_get_system_status)
@@ -474,6 +489,7 @@ async def test_status_command_returns_idle_system_status(
     assert "Last scrape: 2026-05-13T17:15:32&lt;&amp;" in message
     assert "Totals: 824 matches · 26186 odds · 89 opportunities · 13 bookmakers" in message
     assert "Cycle: idle" in message
+    assert "Match Unification: pending_unification (resolved_event_graph)" in message
 
 
 @pytest.mark.asyncio
@@ -486,6 +502,7 @@ async def test_status_command_returns_in_progress_system_status(
         *,
         scheduler_running: bool = False,
         scan_progress: ScanProgressOut | None = None,
+        match_unification: MatchUnificationCycleStatusOut | None = None,
     ) -> SystemStatus:
         return SystemStatus(
             status="ok",
@@ -495,6 +512,7 @@ async def test_status_command_returns_in_progress_system_status(
             active_bookmakers=2,
             scheduler_running=scheduler_running,
             scan=scan_progress or ScanProgressOut(),
+            match_unification=match_unification or MatchUnificationCycleStatusOut(),
         )
 
     monkeypatch.setattr(odds_store, "get_system_status", fake_get_system_status)
@@ -509,6 +527,47 @@ async def test_status_command_returns_in_progress_system_status(
     message = bot.messages[0][1]
     assert "Scheduler: running" in message
     assert "Cycle: scraping — 2/5 completed, 1 active, 1 failed" in message
+
+
+@pytest.mark.asyncio
+async def test_status_command_shows_match_unification_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    await create_command_profile()
+
+    async def fake_get_system_status(
+        *,
+        scheduler_running: bool = False,
+        scan_progress: ScanProgressOut | None = None,
+        match_unification: MatchUnificationCycleStatusOut | None = None,
+    ) -> SystemStatus:
+        return SystemStatus(
+            status="ok",
+            scheduler_running=scheduler_running,
+            scan=scan_progress or ScanProgressOut(),
+            match_unification=match_unification or MatchUnificationCycleStatusOut(),
+        )
+
+    monkeypatch.setattr(odds_store, "get_system_status", fake_get_system_status)
+    bot = StubBotClient()
+    dispatcher = TelegramCommandDispatcher(
+        bot_client=bot,  # type: ignore[arg-type]
+        scheduler=StubScheduler(
+            match_unification=MatchUnificationCycleStatusOut(
+                state="match_id_only",
+                mode="match_id_only",
+                warnings=["RuntimeError: store failed"],
+                fallback_reason="RuntimeError: store failed",
+            )
+        ),
+    )
+
+    await dispatcher.dispatch_update(telegram_update("/status"))
+
+    message = bot.messages[0][1]
+    assert "Match Unification: match_id_only (match_id_only)" in message
+    assert "Match Unification fallback: RuntimeError: store failed" in message
+    assert "Match Unification warning: RuntimeError: store failed" in message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add typed Match Unification persistence metrics and adapter validation
- make MatchUnificationStatus the canonical operational result while preserving benchmark/API compatibility fields
- thread fallback visibility through cycle results, scheduler/API status, Telegram status, and benchmark data

## Tests
- cd backend && ./venv/bin/pytest -q

Closes #139