### PR TITLE
Clarify canonical team merge safety

### DIFF
--- a/backend/app/api/canonical_teams.py
+++ b/backend/app/api/canonical_teams.py
@@ -14,6 +14,7 @@ from ..models.schemas import (
 )
 from ..services.scheduler import scheduler
 from ..services.team_registry import (
+    MERGE_SOURCE_MANUAL_API,
     list_canonical_teams,
     list_canonical_teams_page,
     merge_canonical_teams,
@@ -83,11 +84,18 @@ async def merge_team(
     team_id: int,
     payload: CanonicalTeamMergeIn,
 ) -> CanonicalTeamMergeOut:
+    if scheduler.is_cycle_in_progress:
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot merge canonical teams while a scrape cycle is in progress; try again shortly",
+        )
     try:
         merged = await asyncio.to_thread(
             merge_canonical_teams,
             source_team_id=team_id,
             target_team_id=payload.target_team_id,
+            merge_source=MERGE_SOURCE_MANUAL_API,
+            merge_reason="manual_api_merge",
         )
     except ValueError as exc:
         detail = str(exc)

--- a/backend/app/api/matches.py
+++ b/backend/app/api/matches.py
@@ -16,6 +16,7 @@ from ..models.schemas import (
 )
 from ..services.scheduler import scheduler
 from ..services.team_registry import (
+    MERGE_SOURCE_MANUAL_MATCH_MERGE,
     merge_canonical_teams,
     validate_canonical_team_merge_identity,
 )
@@ -247,7 +248,7 @@ async def merge_matches(payload: MatchMergeIn) -> MatchMergeOut:
             validate_canonical_team_merge_identity(
                 source_team_id=source_team_id,
                 target_team_id=target_team_id,
-                allow_unsafe_subset=True,
+                allow_unsafe_subset_override=True,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -273,7 +274,9 @@ async def merge_matches(payload: MatchMergeIn) -> MatchMergeOut:
                 merge_canonical_teams,
                 source_team_id=source_team_id,
                 target_team_id=target_team_id,
-                allow_unsafe_subset=True,
+                allow_unsafe_subset_override=True,
+                merge_source=MERGE_SOURCE_MANUAL_MATCH_MERGE,
+                merge_reason="manual_match_merge_pairing",
             )
             merged_pairings.append(
                 MatchMergeTeamPairing(

--- a/backend/app/api/team_review.py
+++ b/backend/app/api/team_review.py
@@ -12,9 +12,11 @@ from ..models.schemas import (
     TeamReviewApprovalOut,
     TeamReviewOut,
 )
+from ..services.scheduler import scheduler
 from ..services.team_registry import (
     CanonicalTeamSummary,
     CircularAliasError,
+    MERGE_SOURCE_TEAM_REVIEW_APPROVAL,
     TeamAliasResolution,
     create_canonical_team,
     get_canonical_team,
@@ -87,11 +89,18 @@ async def _merge_existing_canonical_duplicate_for_review(
         return None
 
     assert source_team is not None
+    if scheduler.is_cycle_in_progress:
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot merge canonical teams while a scrape cycle is in progress; try again shortly",
+        )
     await asyncio.to_thread(
         merge_canonical_teams,
         source_team_id=source_team.id,
         target_team_id=target_team_id,
-        allow_unsafe_subset=True,
+        allow_unsafe_subset_override=True,
+        merge_source=MERGE_SOURCE_TEAM_REVIEW_APPROVAL,
+        merge_reason="team_review_duplicate_canonical",
     )
     resolution = await _remember_team_alias(case, target_team_name=target_team_name)
     return resolution, source_team
@@ -144,7 +153,7 @@ async def approve_team_review_case(
                 case.raw_team_name,
                 create_team_name,
                 sport=case.sport,
-                allow_unsafe_subset=True,
+                allow_unsafe_subset_override=True,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -186,7 +195,7 @@ async def approve_team_review_case(
             case.raw_team_name,
             target_team_name,
             sport=case.sport,
-            allow_unsafe_subset=True,
+            allow_unsafe_subset_override=True,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/migrations/versions/0008_team_merge_history_audit.py
+++ b/backend/app/migrations/versions/0008_team_merge_history_audit.py
@@ -1,0 +1,29 @@
+"""Add canonical team merge audit metadata.
+
+Revision ID: 0008_team_merge_history_audit
+Revises: 0007_telegram_command_permissions
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0008_team_merge_history_audit"
+down_revision = "0007_telegram_command_permissions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """ALTER TABLE team_merge_history
+           ADD COLUMN merge_source TEXT NOT NULL DEFAULT 'manual'"""
+    )
+    op.execute("ALTER TABLE team_merge_history ADD COLUMN merge_reason TEXT")
+    op.execute("ALTER TABLE team_merge_history ADD COLUMN identity_policy TEXT")
+    op.execute("ALTER TABLE team_merge_history ADD COLUMN identity_decision TEXT")
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Downgrades are not supported for KvotoLovac migrations.")

--- a/backend/app/services/match_unification/resolution.py
+++ b/backend/app/services/match_unification/resolution.py
@@ -39,6 +39,7 @@ from .event_matching import (
     _orientation_scores,
 )
 from ..team_identity import (
+    CANONICAL_TEAM_AUTO_MERGE_THRESHOLD as _CANONICAL_TEAM_AUTO_MERGE_THRESHOLD,
     canonical_team_auto_merge_analysis as _canonical_team_auto_merge_analysis,
     canonical_team_similarity_score as _canonical_team_similarity_score,
     comparison_team_text as _comparison_team_text,
@@ -63,7 +64,7 @@ _HIGH_FUZZY_AVG_SCORE_NON_SUBSET = 90.0
 _HIGH_FUZZY_SIDE_SCORE_NON_SUBSET = 82.0
 _REVIEW_FUZZY_AVG_SCORE = 65.0
 _FUZZY_ORIENTATION_MARGIN = 8.0
-CANONICAL_TEAM_AUTO_MERGE_THRESHOLD = 88.0
+CANONICAL_TEAM_AUTO_MERGE_THRESHOLD = _CANONICAL_TEAM_AUTO_MERGE_THRESHOLD
 # Anchored low-confidence merge: applies only when the two groups are at the
 # exact same (sport, start_time) slot AND a non-fuzzy corroborator is present
 # (token subset on the weak side, or shared significant token + same league).

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -87,6 +87,8 @@ from ..services.runtime_settings import (
 )
 from ..services.team_registry import (
     CircularAliasError,
+    MERGE_MODE_AUTOMATIC,
+    MERGE_SOURCE_AUTO_RESOLVER,
     forget_team_alias,
     get_canonical_team,
     list_canonical_teams,
@@ -1627,6 +1629,9 @@ class Scheduler:
                     merge_canonical_teams,
                     source_team_id=source_team.id,
                     target_team_id=target_team.id,
+                    merge_mode=MERGE_MODE_AUTOMATIC,
+                    merge_source=MERGE_SOURCE_AUTO_RESOLVER,
+                    merge_reason="auto_resolver_same_time",
                 )
                 pairing = (source_team.id, target_team.id)
                 applied_pairings.append(pairing)

--- a/backend/app/services/scrape_pipeline.py
+++ b/backend/app/services/scrape_pipeline.py
@@ -59,6 +59,8 @@ from ..services.outcome_normalizer import (
 from ..services.notifications import NotificationService
 from ..services.team_registry import (
     CircularAliasError,
+    MERGE_MODE_AUTOMATIC,
+    MERGE_SOURCE_AUTO_RESOLVER,
     forget_team_alias,
     get_canonical_team,
     list_canonical_teams,
@@ -1443,6 +1445,9 @@ class DefaultTeamRegistryActions:
                     merge_canonical_teams,
                     source_team_id=source_team.id,
                     target_team_id=target_team.id,
+                    merge_mode=MERGE_MODE_AUTOMATIC,
+                    merge_source=MERGE_SOURCE_AUTO_RESOLVER,
+                    merge_reason="auto_resolver_same_time",
                 )
                 pairing = (source_team.id, target_team.id)
                 applied_pairings.append(pairing)

--- a/backend/app/services/team_identity.py
+++ b/backend/app/services/team_identity.py
@@ -110,6 +110,10 @@ REASON_WOMEN_MISMATCH = "women_mismatch"
 REASON_YOUTH_AGE_MISMATCH = "youth_age_mismatch"
 REASON_YOUTH_MARKER_MISMATCH = "youth_marker_mismatch"
 REASON_RESERVE_MARKER_MISMATCH = "reserve_marker_mismatch"
+REASON_UNSAFE_SUBSET_OVERRIDE = "unsafe_subset_override"
+
+CANONICAL_TEAM_AUTO_MERGE_THRESHOLD = 88.0
+POLICY_CANONICAL_MERGE_SAFETY = "canonical_merge_safety"
 
 
 @dataclass(frozen=True)
@@ -162,6 +166,24 @@ class QualifierGateDecision:
     explicit_age_mismatch: bool = False
     women_mismatch: bool = False
     reasons: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class CanonicalTeamMergeSafetyDecision:
+    analysis: TeamIdentityComparison
+    merge_mode: str
+    allow_unsafe_subset_override: bool
+    blocking_reasons: frozenset[str]
+    override_reasons: frozenset[str] = frozenset()
+    policy: str = POLICY_CANONICAL_MERGE_SAFETY
+
+    @property
+    def allowed(self) -> bool:
+        return not self.blocking_reasons
+
+    @property
+    def reasons(self) -> frozenset[str]:
+        return self.analysis.reasons
 
 
 def team_qualifiers(name: str, *, sport: str | None = None) -> set[str]:
@@ -563,6 +585,67 @@ def canonical_team_auto_merge_analysis(
         dotted_expanded=False,
         unsafe_subset=unsafe_subset,
         reasons=frozenset(reasons),
+    )
+
+
+def canonical_team_merge_safety_decision_from_analysis(
+    analysis: TeamIdentityComparison,
+    *,
+    merge_mode: str = "manual",
+    allow_unsafe_subset_override: bool = False,
+) -> CanonicalTeamMergeSafetyDecision:
+    if merge_mode not in {"manual", "automatic"}:
+        raise ValueError("merge_mode must be either 'manual' or 'automatic'")
+
+    blocking_reasons: set[str] = set()
+    override_reasons: set[str] = set()
+
+    if REASON_QUALIFIER_MISMATCH in analysis.reasons:
+        blocking_reasons.add(REASON_QUALIFIER_MISMATCH)
+
+    if REASON_UNSAFE_SUBSET in analysis.reasons:
+        if allow_unsafe_subset_override:
+            override_reasons.add(REASON_UNSAFE_SUBSET_OVERRIDE)
+        else:
+            blocking_reasons.add(REASON_UNSAFE_SUBSET)
+
+    if (
+        merge_mode == "automatic"
+        and not analysis.auto_merge_safe
+        and not blocking_reasons
+    ):
+        blocking_reasons.add(REASON_REVIEW_ONLY)
+        if REASON_LOW_FUZZY_SCORE in analysis.reasons:
+            blocking_reasons.add(REASON_LOW_FUZZY_SCORE)
+
+    return CanonicalTeamMergeSafetyDecision(
+        analysis=analysis,
+        merge_mode=merge_mode,
+        allow_unsafe_subset_override=allow_unsafe_subset_override,
+        blocking_reasons=frozenset(blocking_reasons),
+        override_reasons=frozenset(override_reasons),
+    )
+
+
+def canonical_team_merge_safety_decision(
+    source_team_name: str,
+    target_team_name: str,
+    *,
+    sport: str | None = None,
+    merge_mode: str = "manual",
+    allow_unsafe_subset_override: bool = False,
+    auto_merge_threshold: float = CANONICAL_TEAM_AUTO_MERGE_THRESHOLD,
+) -> CanonicalTeamMergeSafetyDecision:
+    analysis = canonical_team_auto_merge_analysis(
+        source_team_name,
+        target_team_name,
+        sport=sport,
+        threshold=auto_merge_threshold,
+    )
+    return canonical_team_merge_safety_decision_from_analysis(
+        analysis,
+        merge_mode=merge_mode,
+        allow_unsafe_subset_override=allow_unsafe_subset_override,
     )
 
 

--- a/backend/app/services/team_registry.py
+++ b/backend/app/services/team_registry.py
@@ -15,10 +15,9 @@ from ..config import settings
 from .team_seed_data import SPORT_ALIAS_SEEDS
 from .team_abbreviations import expand_team_abbreviations
 from .team_identity import (
-    REASON_QUALIFIER_MISMATCH,
-    REASON_UNSAFE_SUBSET,
+    CanonicalTeamMergeSafetyDecision,
     canonical_candidate_qualifier_gate,
-    canonical_team_auto_merge_analysis,
+    canonical_team_merge_safety_decision,
     team_qualifiers,
 )
 from .text_normalizer import normalize_identity_text
@@ -65,6 +64,10 @@ CREATE TABLE IF NOT EXISTS team_merge_history (
     target_team_id INTEGER NOT NULL REFERENCES canonical_teams(id),
     alias_snapshot TEXT,
     review_case_snapshot TEXT,
+    merge_source TEXT NOT NULL DEFAULT 'manual',
+    merge_reason TEXT,
+    identity_policy TEXT,
+    identity_decision TEXT,
     unmerged_at TIMESTAMP,
     merged_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -1180,9 +1183,98 @@ def _partial_ratio_admissible(raw_key: str, candidate_key: str) -> bool:
 # fuzzy match (>= 80) can still surface a mismatched candidate near the top
 # of the result list as a *suggestion* the operator can review.
 _QUALIFIER_MISMATCH_PENALTY: float = 15.0
-_MANUAL_MERGE_BLOCK_REASONS = frozenset(
-    {REASON_QUALIFIER_MISMATCH, REASON_UNSAFE_SUBSET}
+MERGE_MODE_MANUAL = "manual"
+MERGE_MODE_AUTOMATIC = "automatic"
+MERGE_SOURCE_MANUAL = "manual"
+MERGE_SOURCE_MANUAL_API = "manual_api"
+MERGE_SOURCE_MANUAL_MATCH_MERGE = "manual_match_merge"
+MERGE_SOURCE_TEAM_REVIEW_APPROVAL = "team_review_approval"
+MERGE_SOURCE_AUTO_RESOLVER = "auto_resolver"
+_MERGE_SOURCES = frozenset(
+    {
+        MERGE_SOURCE_MANUAL,
+        MERGE_SOURCE_MANUAL_API,
+        MERGE_SOURCE_MANUAL_MATCH_MERGE,
+        MERGE_SOURCE_TEAM_REVIEW_APPROVAL,
+        MERGE_SOURCE_AUTO_RESOLVER,
+    }
 )
+
+
+def _unsafe_subset_override_enabled(
+    *,
+    allow_unsafe_subset: bool,
+    allow_unsafe_subset_override: bool | None,
+) -> bool:
+    return (
+        allow_unsafe_subset
+        if allow_unsafe_subset_override is None
+        else allow_unsafe_subset_override
+    )
+
+
+def _merge_identity_error(
+    decision: CanonicalTeamMergeSafetyDecision,
+    *,
+    source_team_name: str,
+    target_team_name: str,
+) -> str:
+    joined_reasons = ", ".join(sorted(decision.blocking_reasons))
+    return (
+        "Canonical team merge rejected by identity policy "
+        f"({joined_reasons}): "
+        f"{source_team_name} -> {target_team_name}"
+    )
+
+
+def _canonical_merge_safety_decision_for_rows(
+    source_row: sqlite3.Row,
+    target_row: sqlite3.Row,
+    *,
+    merge_mode: str = MERGE_MODE_MANUAL,
+    allow_unsafe_subset: bool = False,
+    allow_unsafe_subset_override: bool | None = None,
+) -> CanonicalTeamMergeSafetyDecision:
+    return canonical_team_merge_safety_decision(
+        str(source_row["display_name"]),
+        str(target_row["display_name"]),
+        sport=str(source_row["sport"]),
+        merge_mode=merge_mode,
+        allow_unsafe_subset_override=_unsafe_subset_override_enabled(
+            allow_unsafe_subset=allow_unsafe_subset,
+            allow_unsafe_subset_override=allow_unsafe_subset_override,
+        ),
+    )
+
+
+def _validate_canonical_merge_rows(
+    conn: sqlite3.Connection,
+    *,
+    source_team_id: int,
+    target_team_id: int,
+) -> tuple[sqlite3.Row, sqlite3.Row]:
+    if source_team_id == target_team_id:
+        raise ValueError("Cannot merge a canonical team into itself")
+
+    source_row = _query_any_team_by_id(conn, source_team_id)
+    target_row = _query_any_team_by_id(conn, target_team_id)
+    if source_row is None or target_row is None:
+        raise ValueError("Both canonical teams must exist before merging")
+    if not bool(source_row["is_active"]):
+        raise ValueError(
+            "Source canonical team is inactive; unmerge it before merging again"
+        )
+    if not bool(target_row["is_active"]):
+        raise ValueError(
+            "Target canonical team is inactive; use its active merged target instead"
+        )
+    if source_row["merged_into_team_id"] is not None:
+        raise ValueError("Source canonical team already points to another team")
+    if target_row["merged_into_team_id"] is not None:
+        raise ValueError("Target canonical team already points to another team")
+    if str(source_row["sport"]) != str(target_row["sport"]):
+        raise ValueError("Only canonical teams from the same sport can be merged")
+    return source_row, target_row
 
 
 def _validate_manual_canonical_merge_identity(
@@ -1190,13 +1282,24 @@ def _validate_manual_canonical_merge_identity(
     target_row: sqlite3.Row,
     *,
     allow_unsafe_subset: bool = False,
+    allow_unsafe_subset_override: bool | None = None,
+    merge_mode: str = MERGE_MODE_MANUAL,
 ) -> None:
-    validate_team_name_identity(
-        str(source_row["display_name"]),
-        str(target_row["display_name"]),
-        sport=str(source_row["sport"]),
+    decision = _canonical_merge_safety_decision_for_rows(
+        source_row,
+        target_row,
+        merge_mode=merge_mode,
         allow_unsafe_subset=allow_unsafe_subset,
+        allow_unsafe_subset_override=allow_unsafe_subset_override,
     )
+    if not decision.allowed:
+        raise ValueError(
+            _merge_identity_error(
+                decision,
+                source_team_name=str(source_row["display_name"]),
+                target_team_name=str(target_row["display_name"]),
+            )
+        )
 
 
 def validate_team_name_identity(
@@ -1205,25 +1308,26 @@ def validate_team_name_identity(
     *,
     sport: str,
     allow_unsafe_subset: bool = False,
+    allow_unsafe_subset_override: bool | None = None,
+    merge_mode: str = MERGE_MODE_MANUAL,
 ) -> None:
-    analysis = canonical_team_auto_merge_analysis(
+    decision = canonical_team_merge_safety_decision(
         source_team_name,
         target_team_name,
         sport=sport,
-        threshold=0.0,
+        merge_mode=merge_mode,
+        allow_unsafe_subset_override=_unsafe_subset_override_enabled(
+            allow_unsafe_subset=allow_unsafe_subset,
+            allow_unsafe_subset_override=allow_unsafe_subset_override,
+        ),
     )
-    block_reasons = (
-        _MANUAL_MERGE_BLOCK_REASONS
-        if not allow_unsafe_subset
-        else frozenset({REASON_QUALIFIER_MISMATCH})
-    )
-    blocking_reasons = sorted(analysis.reasons & block_reasons)
-    if blocking_reasons:
-        joined_reasons = ", ".join(blocking_reasons)
+    if not decision.allowed:
         raise ValueError(
-            "Cannot use incompatible team identity "
-            f"({joined_reasons}): "
-            f"{source_team_name} -> {target_team_name}"
+            _merge_identity_error(
+                decision,
+                source_team_name=source_team_name,
+                target_team_name=target_team_name,
+            )
         )
 
 
@@ -1232,19 +1336,22 @@ def validate_canonical_team_merge_identity(
     source_team_id: int,
     target_team_id: int,
     allow_unsafe_subset: bool = False,
+    allow_unsafe_subset_override: bool | None = None,
+    merge_mode: str = MERGE_MODE_MANUAL,
 ) -> None:
     _ensure_bootstrapped()
     with _connect() as conn:
-        source_row = _query_team_by_id(conn, source_team_id)
-        target_row = _query_team_by_id(conn, target_team_id)
-        if source_row is None or target_row is None:
-            raise ValueError("Both canonical teams must exist before merging")
-        if str(source_row["sport"]) != str(target_row["sport"]):
-            raise ValueError("Only canonical teams from the same sport can be merged")
+        source_row, target_row = _validate_canonical_merge_rows(
+            conn,
+            source_team_id=source_team_id,
+            target_team_id=target_team_id,
+        )
         _validate_manual_canonical_merge_identity(
             source_row,
             target_row,
             allow_unsafe_subset=allow_unsafe_subset,
+            allow_unsafe_subset_override=allow_unsafe_subset_override,
+            merge_mode=merge_mode,
         )
 
 
@@ -1615,16 +1722,104 @@ def _team_review_case_snapshot(
     ]
 
 
+_ALIAS_SNAPSHOT_ERROR = "Stored merge rollback metadata is invalid"
+_REVIEW_CASE_SNAPSHOT_ERROR = "Stored merge review-case rollback metadata is invalid"
+
+
+def _validate_alias_snapshot(snapshot: Any) -> list[dict[str, Any]]:
+    if not isinstance(snapshot, list):
+        raise ValueError(_ALIAS_SNAPSHOT_ERROR)
+
+    validated: list[dict[str, Any]] = []
+    for item in snapshot:
+        if not isinstance(item, dict):
+            raise ValueError(_ALIAS_SNAPSHOT_ERROR)
+        alias = item.get("alias")
+        normalized_alias = item.get("normalized_alias")
+        bookmaker_id = item.get("bookmaker_id", _GLOBAL_BOOKMAKER_ID)
+        source = item.get("source", "manual_review")
+        legacy_competition_id = item.get("legacy_competition_id")
+        was_conflict = item.get("was_conflict", False)
+        if (
+            not isinstance(alias, str)
+            or not alias.strip()
+            or not isinstance(normalized_alias, str)
+            or not normalized_alias
+            or not isinstance(bookmaker_id, str)
+            or not isinstance(source, str)
+            or not isinstance(was_conflict, bool)
+            or (
+                legacy_competition_id is not None
+                and not isinstance(legacy_competition_id, str)
+            )
+        ):
+            raise ValueError(_ALIAS_SNAPSHOT_ERROR)
+        validated.append(
+            {
+                "alias": alias,
+                "normalized_alias": normalized_alias,
+                "bookmaker_id": bookmaker_id,
+                "source": source or "manual_review",
+                "legacy_competition_id": legacy_competition_id,
+                "was_conflict": was_conflict,
+            }
+        )
+    return validated
+
+
+def _validate_review_case_snapshot(snapshot: Any) -> list[dict[str, Any]]:
+    if not isinstance(snapshot, list):
+        raise ValueError(_REVIEW_CASE_SNAPSHOT_ERROR)
+
+    validated: list[dict[str, Any]] = []
+    for item in snapshot:
+        if not isinstance(item, dict):
+            raise ValueError(_REVIEW_CASE_SNAPSHOT_ERROR)
+        case_id = item.get("id")
+        suggested_team_id = item.get("suggested_team_id")
+        suggested_team_name = item.get("suggested_team_name")
+        candidate_teams = item.get("candidate_teams")
+        canonical_home_team = item.get("canonical_home_team")
+        canonical_away_team = item.get("canonical_away_team")
+        if not isinstance(case_id, int):
+            raise ValueError(_REVIEW_CASE_SNAPSHOT_ERROR)
+        if suggested_team_id is not None and not isinstance(suggested_team_id, int):
+            raise ValueError(_REVIEW_CASE_SNAPSHOT_ERROR)
+        for value in (
+            suggested_team_name,
+            canonical_home_team,
+            canonical_away_team,
+        ):
+            if value is not None and not isinstance(value, str):
+                raise ValueError(_REVIEW_CASE_SNAPSHOT_ERROR)
+        if candidate_teams is not None:
+            if not isinstance(candidate_teams, str):
+                raise ValueError(_REVIEW_CASE_SNAPSHOT_ERROR)
+            try:
+                parsed_candidates = json.loads(candidate_teams)
+            except json.JSONDecodeError as exc:
+                raise ValueError(_REVIEW_CASE_SNAPSHOT_ERROR) from exc
+            if not isinstance(parsed_candidates, list):
+                raise ValueError(_REVIEW_CASE_SNAPSHOT_ERROR)
+        validated.append(
+            {
+                "id": case_id,
+                "suggested_team_id": suggested_team_id,
+                "suggested_team_name": suggested_team_name,
+                "candidate_teams": candidate_teams,
+                "canonical_home_team": canonical_home_team,
+                "canonical_away_team": canonical_away_team,
+            }
+        )
+    return validated
+
+
 def _restore_pending_team_review_cases(
     conn: sqlite3.Connection,
-    review_case_snapshot: list[Any],
+    review_case_snapshot: list[dict[str, Any]],
 ) -> None:
     for item in review_case_snapshot:
-        if not isinstance(item, dict):
-            raise ValueError("Stored merge review-case rollback metadata is invalid")
         case_id = item.get("id")
-        if not isinstance(case_id, int):
-            raise ValueError("Stored merge review-case rollback metadata is invalid")
 
         current_row = conn.execute(
             """
@@ -1891,39 +2086,92 @@ def _team_alias_snapshot(
     ]
 
 
+def _normalize_merge_source(merge_source: str | None) -> str:
+    normalized = (merge_source or MERGE_SOURCE_MANUAL).strip()
+    if normalized not in _MERGE_SOURCES:
+        allowed = ", ".join(sorted(_MERGE_SOURCES))
+        raise ValueError(f"merge_source must be one of: {allowed}")
+    return normalized
+
+
+def _merge_identity_decision_payload(
+    decision: CanonicalTeamMergeSafetyDecision,
+) -> dict[str, Any]:
+    analysis = decision.analysis
+    return {
+        "schema_version": 1,
+        "policy": decision.policy,
+        "merge_mode": decision.merge_mode,
+        "allowed": decision.allowed,
+        "score": analysis.score,
+        "reasons": sorted(analysis.reasons),
+        "blocking_reasons": sorted(decision.blocking_reasons),
+        "override_reasons": sorted(decision.override_reasons),
+        "allow_unsafe_subset_override": decision.allow_unsafe_subset_override,
+        "left_qualifiers": sorted(analysis.left_qualifiers),
+        "right_qualifiers": sorted(analysis.right_qualifiers),
+        "left_comparison_text": analysis.left_comparison_text,
+        "right_comparison_text": analysis.right_comparison_text,
+        "left_significant_tokens": sorted(analysis.left_significant_tokens),
+        "right_significant_tokens": sorted(analysis.right_significant_tokens),
+        "unsafe_subset": analysis.unsafe_subset,
+    }
+
+
 def merge_canonical_teams(
     *,
     source_team_id: int,
     target_team_id: int,
     allow_unsafe_subset: bool = False,
+    allow_unsafe_subset_override: bool | None = None,
+    merge_mode: str = MERGE_MODE_MANUAL,
+    merge_source: str = MERGE_SOURCE_MANUAL,
+    merge_reason: str | None = None,
 ) -> CanonicalTeamSummary:
-    if source_team_id == target_team_id:
-        raise ValueError("Cannot merge a canonical team into itself")
-
+    normalized_merge_source = _normalize_merge_source(merge_source)
+    normalized_merge_reason = merge_reason.strip() if merge_reason else None
     _ensure_bootstrapped()
     with _connect() as conn:
         conn.execute("BEGIN IMMEDIATE")
-        source_row = _query_team_by_id(conn, source_team_id)
-        target_row = _query_team_by_id(conn, target_team_id)
-        if source_row is None or target_row is None:
-            raise ValueError("Both canonical teams must exist before merging")
-        if str(source_row["sport"]) != str(target_row["sport"]):
-            raise ValueError("Only canonical teams from the same sport can be merged")
-        _validate_manual_canonical_merge_identity(
-            source_row,
-            target_row,
-            allow_unsafe_subset=allow_unsafe_subset,
-        )
-
-        alias_snapshot = _team_alias_snapshot(
+        source_row, target_row = _validate_canonical_merge_rows(
             conn,
             source_team_id=source_team_id,
             target_team_id=target_team_id,
         )
-        review_case_snapshot = _team_review_case_snapshot(
-            conn,
-            source_team_id=source_team_id,
-            source_team_name=str(source_row["display_name"]),
+        decision = _canonical_merge_safety_decision_for_rows(
+            source_row,
+            target_row,
+            merge_mode=merge_mode,
+            allow_unsafe_subset=allow_unsafe_subset,
+            allow_unsafe_subset_override=allow_unsafe_subset_override,
+        )
+        if not decision.allowed:
+            raise ValueError(
+                _merge_identity_error(
+                    decision,
+                    source_team_name=str(source_row["display_name"]),
+                    target_team_name=str(target_row["display_name"]),
+                )
+            )
+        if decision.override_reasons and not normalized_merge_reason:
+            raise ValueError(
+                "Unsafe-subset merge override requires an auditable merge_reason"
+            )
+        identity_decision = _merge_identity_decision_payload(decision)
+
+        alias_snapshot = _validate_alias_snapshot(
+            _team_alias_snapshot(
+                conn,
+                source_team_id=source_team_id,
+                target_team_id=target_team_id,
+            )
+        )
+        review_case_snapshot = _validate_review_case_snapshot(
+            _team_review_case_snapshot(
+                conn,
+                source_team_id=source_team_id,
+                source_team_name=str(source_row["display_name"]),
+            )
         )
         conflict_rows = conn.execute(
             """
@@ -1984,15 +2232,23 @@ def merge_canonical_teams(
                 source_team_id,
                 target_team_id,
                 alias_snapshot,
-                review_case_snapshot
+                review_case_snapshot,
+                merge_source,
+                merge_reason,
+                identity_policy,
+                identity_decision
             )
-            VALUES (?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 source_team_id,
                 target_team_id,
                 json.dumps(alias_snapshot),
                 json.dumps(review_case_snapshot),
+                normalized_merge_source,
+                normalized_merge_reason,
+                decision.policy,
+                json.dumps(identity_decision, sort_keys=True),
             ),
         )
         _reassign_pending_team_review_cases(
@@ -2055,23 +2311,23 @@ def unmerge_canonical_team(
             raise ValueError("Canonical team is not currently merged into the recorded target")
 
         try:
-            alias_snapshot = json.loads(str(history_row["alias_snapshot"]))
+            alias_snapshot = _validate_alias_snapshot(
+                json.loads(str(history_row["alias_snapshot"]))
+            )
         except json.JSONDecodeError as exc:
-            raise ValueError("Stored merge rollback metadata is invalid") from exc
-        if not isinstance(alias_snapshot, list):
-            raise ValueError("Stored merge rollback metadata is invalid")
+            raise ValueError(_ALIAS_SNAPSHOT_ERROR) from exc
         try:
-            review_case_snapshot = json.loads(str(history_row["review_case_snapshot"]))
+            review_case_snapshot = _validate_review_case_snapshot(
+                json.loads(str(history_row["review_case_snapshot"]))
+            )
         except json.JSONDecodeError as exc:
-            raise ValueError("Stored merge review-case rollback metadata is invalid") from exc
-        if not isinstance(review_case_snapshot, list):
-            raise ValueError("Stored merge review-case rollback metadata is invalid")
+            raise ValueError(_REVIEW_CASE_SNAPSHOT_ERROR) from exc
 
         for item in alias_snapshot:
-            if not isinstance(item, dict) or item.get("was_conflict"):
+            if item["was_conflict"]:
                 continue
-            normalized_alias = str(item.get("normalized_alias") or "")
-            bookmaker_id = str(item.get("bookmaker_id") or _GLOBAL_BOOKMAKER_ID)
+            normalized_alias = item["normalized_alias"]
+            bookmaker_id = item["bookmaker_id"]
             existing_alias = conn.execute(
                 """
                 SELECT canonical_team_id
@@ -2090,9 +2346,9 @@ def unmerge_canonical_team(
 
         source_display_key = str(source_row["normalized_display_name"])
         snapshot_keys = {
-            (str(item.get("normalized_alias") or ""), str(item.get("bookmaker_id") or _GLOBAL_BOOKMAKER_ID))
+            (item["normalized_alias"], item["bookmaker_id"])
             for item in alias_snapshot
-            if isinstance(item, dict) and not item.get("was_conflict")
+            if not item["was_conflict"]
         }
         if (source_display_key, _GLOBAL_BOOKMAKER_ID) not in snapshot_keys:
             conn.execute(
@@ -2113,15 +2369,15 @@ def unmerge_canonical_team(
             )
 
         for item in alias_snapshot:
-            if not isinstance(item, dict) or item.get("was_conflict"):
+            if item["was_conflict"]:
                 continue
             _upsert_alias(
                 conn,
                 sport=str(source_row["sport"]),
-                alias=str(item.get("alias") or ""),
+                alias=item["alias"],
                 canonical_team_id=source_team_id,
-                bookmaker_id=str(item.get("bookmaker_id") or _GLOBAL_BOOKMAKER_ID),
-                source=str(item.get("source") or "manual_review"),
+                bookmaker_id=item["bookmaker_id"],
+                source=item["source"],
                 legacy_competition_id=item.get("legacy_competition_id"),
             )
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1996,6 +1996,52 @@ async def test_merge_canonical_teams_rejects_missing_target(
 
 
 @pytest.mark.asyncio
+async def test_merge_canonical_teams_rejects_unsafe_identity_with_detail(
+    client: AsyncClient,
+    team_registry_file,
+):
+    source = create_canonical_team(display_name="Arsenal Tula", sport="football")
+    target = create_canonical_team(display_name="Arsenal", sport="football")
+
+    resp = await client.post(
+        f"/api/v1/canonical-teams/{source.team_id}/merge",
+        json={"target_team_id": target.team_id},
+    )
+
+    assert resp.status_code == 400
+    assert "identity policy" in resp.json()["detail"]
+    assert "unsafe_subset" in resp.json()["detail"]
+    assert "Arsenal Tula -> Arsenal" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_merge_canonical_teams_rejects_during_scrape_cycle(
+    client: AsyncClient,
+    team_registry_file,
+):
+    source = create_canonical_team(display_name="QA Busy Merge Source")
+    target = create_canonical_team(display_name="QA Busy Merge Target")
+    scheduler._cycle_task = asyncio.create_task(asyncio.sleep(0.1))
+    try:
+        resp = await client.post(
+            f"/api/v1/canonical-teams/{source.team_id}/merge",
+            json={"target_team_id": target.team_id},
+        )
+    finally:
+        scheduler._cycle_task.cancel()
+        try:
+            await scheduler._cycle_task
+        except asyncio.CancelledError:
+            pass
+        scheduler._cycle_task = None
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == (
+        "Cannot merge canonical teams while a scrape cycle is in progress; try again shortly"
+    )
+
+
+@pytest.mark.asyncio
 async def test_unmerge_canonical_teams_restores_aliases(
     client: AsyncClient,
     team_registry_file,
@@ -2469,6 +2515,82 @@ async def test_team_review_approval_merges_existing_canonical_duplicate(
     assert normalize_team_name("Amambay", None, "volcanobet") == target.team_name
     assert duplicate_rows[0]["is_active"] == 0
     assert duplicate_rows[0]["merged_into_team_id"] == target.team_id
+
+
+@pytest.mark.asyncio
+async def test_team_review_duplicate_merge_rejects_during_scrape_cycle(
+    client: AsyncClient,
+    team_registry_file,
+):
+    batch_scraped_at = "2026-04-16T21:55:00+00:00"
+    await odds_store.upsert_bookmaker("volcanobet", "VolcanoBet")
+    await odds_store.upsert_league("paraguay_lnb", "Paraguay LNB", "basketball", "Paraguay")
+    target = create_canonical_team(display_name="Deportivo Amambay", sport="basketball")
+    duplicate = create_canonical_team(display_name="Amambay", sport="basketball")
+    case_id = await odds_store.insert_team_review_case(
+        TeamReviewDiagnostic.model_validate(
+            {
+                "bookmaker_id": "volcanobet",
+                "raw_league_id": "Paraguay LNB",
+                "normalized_raw_league_id": "paraguay lnb",
+                "sport": "basketball",
+                "scope_league_id": "paraguay_lnb",
+                "raw_team_name": "Amambay",
+                "normalized_raw_team_name": "Amambay",
+                "suggested_team_id": target.team_id,
+                "suggested_team_name": target.team_name,
+                "start_time": batch_scraped_at,
+                "reason_code": "candidate_team_match_same_start_time",
+                "confidence": "high",
+                "similarity_score": 100,
+                "candidate_teams": [
+                    {
+                        "team_id": target.team_id,
+                        "team_name": target.team_name,
+                        "score": 100,
+                    },
+                    {
+                        "team_id": duplicate.team_id,
+                        "team_name": duplicate.team_name,
+                        "score": 100,
+                    },
+                ],
+                "evidence": ["Stronger competing canonical event: support x3"],
+                "status": "pending",
+            }
+        ),
+        scraped_at=batch_scraped_at,
+    )
+    await odds_store.set_current_snapshot(batch_scraped_at)
+
+    scheduler._cycle_task = asyncio.create_task(asyncio.sleep(0.1))
+    try:
+        approve_resp = await client.post(
+            f"/api/v1/team-review/cases/{case_id}/approve",
+            json={"team_id": target.team_id},
+        )
+    finally:
+        scheduler._cycle_task.cancel()
+        try:
+            await scheduler._cycle_task
+        except asyncio.CancelledError:
+            pass
+        scheduler._cycle_task = None
+    case = await odds_store.get_team_review_case(case_id)
+    db = await get_db()
+    duplicate_rows = await db.execute_fetchall(
+        "SELECT is_active, merged_into_team_id FROM canonical_teams WHERE id = ?",
+        (duplicate.team_id,),
+    )
+
+    assert approve_resp.status_code == 409
+    assert approve_resp.json()["detail"] == (
+        "Cannot merge canonical teams while a scrape cycle is in progress; try again shortly"
+    )
+    assert case is not None
+    assert case.status == "pending"
+    assert duplicate_rows[0]["is_active"] == 1
+    assert duplicate_rows[0]["merged_into_team_id"] is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_match_merge.py
+++ b/backend/tests/test_match_merge.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import sqlite3
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -143,6 +146,20 @@ async def test_merge_matches_happy_path(client: AsyncClient, team_registry_file)
     # Source display name disappears (merged into target); target remains.
     assert "Partizan Belgrade" in display_names
     assert "KK Partizan" not in display_names
+    with sqlite3.connect(settings.db_path) as conn:
+        history_rows = conn.execute(
+            """
+            SELECT merge_source, merge_reason, identity_decision
+            FROM team_merge_history
+            ORDER BY source_team_id
+            """
+        ).fetchall()
+    assert {row[0] for row in history_rows} == {"manual_match_merge"}
+    assert {row[1] for row in history_rows} == {"manual_match_merge_pairing"}
+    assert any(
+        "unsafe_subset_override" in json.loads(row[2])["override_reasons"]
+        for row in history_rows
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_match_unification_resolution.py
+++ b/backend/tests/test_match_unification_resolution.py
@@ -125,6 +125,25 @@ def test_team_auto_merge_guardrails_require_qualifier_compatibility():
     assert _same_time_slot_orientation(source_slot, target_slot) is None
 
 
+def test_team_auto_merge_guardrails_reject_unsafe_subset_identity():
+    source_slot = _canonical_slot(
+        home_team_id=1,
+        away_team_id=2,
+        home_team="Arsenal",
+        away_team="Rival",
+        support_bookmakers=frozenset({"book-c"}),
+    )
+    target_slot = _canonical_slot(
+        home_team_id=3,
+        away_team_id=4,
+        home_team="Arsenal Tula",
+        away_team="Rival",
+        support_bookmakers=frozenset({"book-a", "book-b"}),
+    )
+
+    assert _same_time_slot_orientation(source_slot, target_slot) is None
+
+
 def test_event_review_case_metadata_records_exact_source_variant_pairs():
     left_candidate = EventCandidate(
         match_id="match-z",

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -32,6 +32,10 @@ async def test_upgrade_database_creates_current_schema(tmp_path):
         opportunity_fks = conn.execute(
             "PRAGMA foreign_key_list(opportunities)"
         ).fetchall()
+        merge_history_columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(team_merge_history)").fetchall()
+        }
 
     assert {
         "alembic_version",
@@ -51,6 +55,12 @@ async def test_upgrade_database_creates_current_schema(tmp_path):
     assert ("resolved_event_id", "resolved_events") in {
         (row[3], row[2]) for row in opportunity_fks
     }
+    assert {
+        "merge_source",
+        "merge_reason",
+        "identity_policy",
+        "identity_decision",
+    }.issubset(merge_history_columns)
 
     await init_db(str(db_path))
     db = await get_db()
@@ -93,10 +103,16 @@ def test_migrate_database_to_head_upgrades_stale_database(tmp_path):
                 "PRAGMA index_list(telegram_notification_profiles)"
             ).fetchall()
         }
+        merge_history_columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(team_merge_history)").fetchall()
+        }
     assert "min_middle_ev_percent" in profile_columns
     assert "command_permission_preset" in profile_columns
     assert "allowed_commands" in profile_columns
     assert "ux_telegram_profiles_command_chat" in index_names
+    assert "merge_source" in merge_history_columns
+    assert "identity_decision" in merge_history_columns
 
 
 def test_telegram_command_migration_does_not_grant_admin_by_label(tmp_path):

--- a/backend/tests/test_scrape_pipeline.py
+++ b/backend/tests/test_scrape_pipeline.py
@@ -213,7 +213,7 @@ async def test_default_team_registry_actions_returns_applied_merge_result(
     monkeypatch.setattr(
         scrape_pipeline,
         "merge_canonical_teams",
-        lambda *, source_team_id, target_team_id: merged_pairings.append(
+        lambda *, source_team_id, target_team_id, **_kwargs: merged_pairings.append(
             (source_team_id, target_team_id)
         ),
     )

--- a/backend/tests/test_team_identity.py
+++ b/backend/tests/test_team_identity.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import pytest
 
 from app.services.team_identity import (
+    REASON_AUTO_MERGE_SAFE,
     REASON_DOTTED_EXPANSION,
+    REASON_LOW_FUZZY_SCORE,
     REASON_QUALIFIER_MISMATCH,
+    REASON_REVIEW_ONLY,
     REASON_UNSAFE_SUBSET,
+    REASON_UNSAFE_SUBSET_OVERRIDE,
     canonical_candidate_qualifier_gate,
     canonical_team_auto_merge_analysis,
+    canonical_team_merge_safety_decision,
     comparison_team_text,
     event_team_similarity,
     expand_dotted_team_pair,
@@ -187,3 +192,60 @@ def test_canonical_candidate_qualifier_gate_returns_structural_decision():
     assert age_mismatch.explicit_age_mismatch
     assert marker_mismatch.admit
     assert marker_mismatch.youth_marker_mismatch
+
+
+def test_canonical_merge_safety_decision_classifies_manual_and_automatic_paths():
+    manual_review_only = canonical_team_merge_safety_decision(
+        "Manchester United",
+        "Manchester City",
+        sport="football",
+        merge_mode="manual",
+    )
+    automatic_review_only = canonical_team_merge_safety_decision(
+        "Manchester United",
+        "Manchester City",
+        sport="football",
+        merge_mode="automatic",
+    )
+    unsafe_subset_override = canonical_team_merge_safety_decision(
+        "Arsenal Tula",
+        "Arsenal",
+        sport="football",
+        merge_mode="manual",
+        allow_unsafe_subset_override=True,
+    )
+    qualifier_mismatch = canonical_team_merge_safety_decision(
+        "Partizan",
+        "Partizan Women",
+        sport="basketball",
+        merge_mode="manual",
+        allow_unsafe_subset_override=True,
+    )
+
+    assert manual_review_only.allowed
+    assert REASON_REVIEW_ONLY in manual_review_only.reasons
+    assert not automatic_review_only.allowed
+    assert automatic_review_only.blocking_reasons == frozenset(
+        {REASON_LOW_FUZZY_SCORE, REASON_REVIEW_ONLY}
+    )
+    assert unsafe_subset_override.allowed
+    assert unsafe_subset_override.override_reasons == frozenset(
+        {REASON_UNSAFE_SUBSET_OVERRIDE}
+    )
+    assert REASON_UNSAFE_SUBSET in unsafe_subset_override.reasons
+    assert not qualifier_mismatch.allowed
+    assert qualifier_mismatch.blocking_reasons == frozenset(
+        {REASON_QUALIFIER_MISMATCH}
+    )
+
+
+def test_canonical_merge_safety_decision_marks_auto_safe_pair():
+    decision = canonical_team_merge_safety_decision(
+        "Sao Jose W",
+        "Sao Jose Women",
+        sport="basketball",
+        merge_mode="automatic",
+    )
+
+    assert decision.allowed
+    assert REASON_AUTO_MERGE_SAFE in decision.reasons

--- a/backend/tests/test_team_registry.py
+++ b/backend/tests/test_team_registry.py
@@ -8,6 +8,7 @@ import pytest
 from app.config import settings
 from app.services import team_registry
 from app.services.team_registry import (
+    MERGE_SOURCE_MANUAL_MATCH_MERGE,
     clear_team_registry_cache,
     create_canonical_team,
     merge_canonical_teams,
@@ -67,7 +68,9 @@ def test_merge_canonical_teams_allows_review_opt_in_for_unsafe_subset(team_regis
     merged = merge_canonical_teams(
         source_team_id=subset.team_id,
         target_team_id=base.team_id,
-        allow_unsafe_subset=True,
+        allow_unsafe_subset_override=True,
+        merge_source=MERGE_SOURCE_MANUAL_MATCH_MERGE,
+        merge_reason="reviewed_unsafe_subset_override",
     )
 
     assert merged.id == base.team_id
@@ -83,7 +86,99 @@ def test_merge_canonical_teams_review_opt_in_still_rejects_qualifier_mismatch(
         merge_canonical_teams(
             source_team_id=women.team_id,
             target_team_id=men.team_id,
-            allow_unsafe_subset=True,
+            allow_unsafe_subset_override=True,
+            merge_source=MERGE_SOURCE_MANUAL_MATCH_MERGE,
+            merge_reason="reviewed_unsafe_subset_override",
+        )
+
+
+def test_merge_canonical_teams_rejects_cross_sport(team_registry_file):
+    basketball = create_canonical_team(display_name="QA Cross Sport", sport="basketball")
+    football = create_canonical_team(display_name="QA Cross Sport", sport="football")
+
+    with pytest.raises(ValueError, match="same sport"):
+        merge_canonical_teams(
+            source_team_id=football.team_id,
+            target_team_id=basketball.team_id,
+        )
+
+
+def test_merge_canonical_teams_rejects_inactive_source_and_target(team_registry_file):
+    source = create_canonical_team(display_name="QA Inactive Source")
+    target = create_canonical_team(display_name="QA Inactive Target")
+    fresh = create_canonical_team(display_name="QA Inactive Fresh")
+
+    merge_canonical_teams(source_team_id=source.team_id, target_team_id=target.team_id)
+
+    with pytest.raises(ValueError, match="Source canonical team is inactive"):
+        merge_canonical_teams(
+            source_team_id=source.team_id,
+            target_team_id=fresh.team_id,
+        )
+    with pytest.raises(ValueError, match="Target canonical team is inactive"):
+        merge_canonical_teams(
+            source_team_id=fresh.team_id,
+            target_team_id=source.team_id,
+        )
+
+
+def test_merge_canonical_teams_records_auditable_override(team_registry_file):
+    base = create_canonical_team(display_name="Deportivo Amambay", sport="basketball")
+    subset = create_canonical_team(display_name="Amambay", sport="basketball")
+
+    merge_canonical_teams(
+        source_team_id=subset.team_id,
+        target_team_id=base.team_id,
+        allow_unsafe_subset_override=True,
+        merge_source=MERGE_SOURCE_MANUAL_MATCH_MERGE,
+        merge_reason="reviewed_unsafe_subset_override",
+    )
+
+    with sqlite3.connect(settings.db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT merge_source, merge_reason, identity_policy, identity_decision
+            FROM team_merge_history
+            WHERE source_team_id = ? AND target_team_id = ?
+            """,
+            (subset.team_id, base.team_id),
+        ).fetchone()
+
+    assert row is not None
+    payload = json.loads(row[3])
+    assert row[0] == MERGE_SOURCE_MANUAL_MATCH_MERGE
+    assert row[1] == "reviewed_unsafe_subset_override"
+    assert row[2] == "canonical_merge_safety"
+    assert payload["allowed"] is True
+    assert payload["unsafe_subset"] is True
+    assert payload["override_reasons"] == ["unsafe_subset_override"]
+    assert "unsafe_subset" in payload["reasons"]
+
+
+def test_merge_canonical_teams_requires_reason_for_unsafe_subset_override(
+    team_registry_file,
+):
+    base = create_canonical_team(display_name="Arsenal", sport="football")
+    compound = create_canonical_team(display_name="Arsenal Tula", sport="football")
+
+    with pytest.raises(ValueError, match="requires an auditable merge_reason"):
+        merge_canonical_teams(
+            source_team_id=compound.team_id,
+            target_team_id=base.team_id,
+            allow_unsafe_subset_override=True,
+            merge_source=MERGE_SOURCE_MANUAL_MATCH_MERGE,
+        )
+
+
+def test_automatic_merge_rejects_review_only_identity_decision(team_registry_file):
+    source = create_canonical_team(display_name="QA Auto Merge Source")
+    target = create_canonical_team(display_name="Different Auto Target")
+
+    with pytest.raises(ValueError, match="review_only"):
+        merge_canonical_teams(
+            source_team_id=source.team_id,
+            target_team_id=target.team_id,
+            merge_mode="automatic",
         )
 
 
@@ -464,6 +559,118 @@ def test_unmerge_canonical_team_restores_pending_review_cases(team_registry_file
         candidate_teams,
         source.team_name,
     )
+
+
+def test_unmerge_canonical_team_restores_multiple_pending_review_cases(
+    team_registry_file,
+):
+    source = create_canonical_team(display_name="QA Multi Review Source")
+    target = create_canonical_team(display_name="QA Multi Review Target")
+    candidate_teams = json.dumps(
+        [{"team_id": source.team_id, "team_name": source.team_name, "score": 95}]
+    )
+    with sqlite3.connect(settings.db_path) as conn:
+        for raw_team_name, canonical_column in (
+            ("QA Multi Review Raw One", "canonical_home_team"),
+            ("QA Multi Review Raw Two", "canonical_away_team"),
+        ):
+            conn.execute(
+                f"""
+                INSERT INTO team_review_cases (
+                    bookmaker_id,
+                    raw_league_id,
+                    normalized_raw_league_id,
+                    sport,
+                    raw_team_name,
+                    normalized_raw_team_name,
+                    suggested_team_id,
+                    suggested_team_name,
+                    reason_code,
+                    candidate_teams,
+                    canonical_home_team,
+                    canonical_away_team,
+                    status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')
+                """,
+                (
+                    "meridian",
+                    "QA League",
+                    "qa league",
+                    "basketball",
+                    raw_team_name,
+                    normalize_identity_text(raw_team_name),
+                    source.team_id,
+                    source.team_name,
+                    "candidate_team_match_same_start_time",
+                    candidate_teams,
+                    source.team_name if canonical_column == "canonical_home_team" else "Rival",
+                    source.team_name if canonical_column == "canonical_away_team" else "Rival",
+                ),
+            )
+        conn.commit()
+
+    merge_canonical_teams(source_team_id=source.team_id, target_team_id=target.team_id)
+    unmerge_canonical_team(source_team_id=source.team_id)
+
+    with sqlite3.connect(settings.db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT suggested_team_id, suggested_team_name, canonical_home_team, canonical_away_team
+            FROM team_review_cases
+            ORDER BY raw_team_name
+            """
+        ).fetchall()
+
+    assert rows == [
+        (source.team_id, source.team_name, source.team_name, "Rival"),
+        (source.team_id, source.team_name, "Rival", source.team_name),
+    ]
+
+
+def test_unmerge_canonical_team_rejects_malformed_alias_snapshot(team_registry_file):
+    source = create_canonical_team(display_name="QA Bad Alias Snapshot Source")
+    target = create_canonical_team(display_name="QA Bad Alias Snapshot Target")
+    merge_canonical_teams(source_team_id=source.team_id, target_team_id=target.team_id)
+    with sqlite3.connect(settings.db_path) as conn:
+        conn.execute(
+            "UPDATE team_merge_history SET alias_snapshot = ? WHERE source_team_id = ?",
+            ('[{"alias": "Missing Normalized"}]', source.team_id),
+        )
+        conn.commit()
+
+    with pytest.raises(ValueError, match="Stored merge rollback metadata is invalid"):
+        unmerge_canonical_team(source_team_id=source.team_id)
+
+    with sqlite3.connect(settings.db_path) as conn:
+        row = conn.execute(
+            "SELECT is_active, merged_into_team_id FROM canonical_teams WHERE id = ?",
+            (source.team_id,),
+        ).fetchone()
+    assert row == (0, target.team_id)
+
+
+def test_unmerge_canonical_team_rejects_malformed_review_case_snapshot(
+    team_registry_file,
+):
+    source = create_canonical_team(display_name="QA Bad Review Snapshot Source")
+    target = create_canonical_team(display_name="QA Bad Review Snapshot Target")
+    merge_canonical_teams(source_team_id=source.team_id, target_team_id=target.team_id)
+    with sqlite3.connect(settings.db_path) as conn:
+        conn.execute(
+            """
+            UPDATE team_merge_history
+            SET review_case_snapshot = ?
+            WHERE source_team_id = ?
+            """,
+            ('[{"id": 1, "candidate_teams": "not json"}]', source.team_id),
+        )
+        conn.commit()
+
+    with pytest.raises(
+        ValueError,
+        match="Stored merge review-case rollback metadata is invalid",
+    ):
+        unmerge_canonical_team(source_team_id=source.team_id)
 
 
 def test_unmerge_canonical_team_rejects_legacy_history_without_snapshot(team_registry_file):


### PR DESCRIPTION
## Summary
- centralize canonical team merge safety through the shared team identity policy
- add auditable canonical merge history metadata and snapshot validation
- gate destructive canonical merge paths during scrape cycles

Closes #137

## Tests
- cd backend && ./venv/bin/pytest -q