### PR TITLE
Deepen event pairing pipeline

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,3 +31,11 @@ The Match Unification work that turns raw bookmaker events, normalized odds, and
 normalized outcome offers into event candidates before grouping. It owns source
 matching, raw source metadata, candidate precedence, football raw event candidate
 enrichment, and extraction benchmark counters.
+
+### Event Pairing
+
+The Match Unification work that compares bookmaker-specific event candidates
+within a temporal bucket to decide whether they describe the same real-world
+event. It owns sport-specific pairing rules, team text similarity, orientation
+scoring, pair ranking, large-bucket fan-out diagnostics, and reusable similarity
+state that prevents repeated fuzzy scoring inside one scrape cycle.

--- a/backend/app/services/event_pairing.py
+++ b/backend/app/services/event_pairing.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import Callable, TypeVar, cast
+
+_EventT = TypeVar("_EventT")
+_CacheT = TypeVar("_CacheT")
+
+
+@dataclass(frozen=True)
+class EventPairingBucketSummary:
+    sport: str
+    start_time: str
+    event_count: int
+    bookmaker_count: int
+    candidate_pair_count: int
+
+
+class EventPairingCycle:
+    """Cycle-level Event Pairing state shared by scrape pipeline phases."""
+
+    def __init__(self) -> None:
+        self._caches: dict[str, object] = {}
+
+    def cache(self, name: str, factory: Callable[[], _CacheT]) -> _CacheT:
+        cached = self._caches.get(name)
+        if cached is None:
+            cached = factory()
+            self._caches[name] = cached
+        return cast(_CacheT, cached)
+
+    @staticmethod
+    def pair_bucket_key(sport: str, start_time: str) -> tuple[str, str]:
+        if sport == "tennis":
+            return (sport, "__tennis_time_drift__")
+        return (sport, start_time)
+
+    def pair_buckets(
+        self,
+        events: list[_EventT],
+        *,
+        sport: Callable[[_EventT], str],
+        start_time: Callable[[_EventT], str],
+    ) -> list[list[_EventT]]:
+        buckets: dict[tuple[str, str], list[_EventT]] = defaultdict(list)
+        for event in events:
+            buckets[self.pair_bucket_key(sport(event), start_time(event))].append(event)
+        return list(buckets.values())
+
+    def slot_summaries(
+        self,
+        events: list[_EventT],
+        *,
+        sport: Callable[[_EventT], str],
+        start_time: Callable[[_EventT], str],
+        bookmaker_id: Callable[[_EventT], str],
+    ) -> list[EventPairingBucketSummary]:
+        events_by_slot: dict[tuple[str, str], list[_EventT]] = defaultdict(list)
+        for event in events:
+            events_by_slot[(sport(event), start_time(event))].append(event)
+
+        summaries: list[EventPairingBucketSummary] = []
+        for (slot_sport, slot_start_time), slot_events in events_by_slot.items():
+            bookmaker_counts = Counter(bookmaker_id(event) for event in slot_events)
+            total_pairs = len(slot_events) * (len(slot_events) - 1) // 2
+            same_bookmaker_pairs = sum(
+                count * (count - 1) // 2 for count in bookmaker_counts.values()
+            )
+            summaries.append(
+                EventPairingBucketSummary(
+                    sport=slot_sport,
+                    start_time=slot_start_time,
+                    event_count=len(slot_events),
+                    bookmaker_count=len(bookmaker_counts),
+                    candidate_pair_count=total_pairs - same_bookmaker_pairs,
+                )
+            )
+        return summaries

--- a/backend/app/services/match_unification/types.py
+++ b/backend/app/services/match_unification/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from ...models.schemas import (
     BenchmarkEventCoverageOut,
@@ -16,6 +16,9 @@ from ...models.schemas import (
     RawOddsData,
     RawOutcomeOffer,
 )
+
+if TYPE_CHECKING:
+    from ..outcome_normalizer import FootballEventResolutionMap
 
 MatchUnificationMode = Literal["resolved_event_graph", "match_id_only"]
 MatchUnificationState = Literal[
@@ -52,6 +55,7 @@ class MatchUnificationRows:
     raw_outcome_offers: Sequence[RawOutcomeOffer]
     normalized_odds: Sequence[NormalizedOdds]
     normalized_outcome_offers: Sequence[NormalizedOutcomeOffer]
+    football_event_resolutions: FootballEventResolutionMap | None = None
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/match_unification/unifier.py
+++ b/backend/app/services/match_unification/unifier.py
@@ -79,11 +79,13 @@ class MatchUnification:
     ) -> MatchUnificationResult:
         extraction_stats = candidate_extraction._EventCandidateExtractionStats()
         extraction_started_at = time.perf_counter()
-        football_event_resolutions = (
-            candidate_extraction._build_football_event_resolutions(
-                list(rows.raw_outcome_offers)
+        football_event_resolutions = rows.football_event_resolutions
+        if football_event_resolutions is None:
+            football_event_resolutions = (
+                candidate_extraction._build_football_event_resolutions(
+                    list(rows.raw_outcome_offers)
+                )
             )
-        )
         candidates = candidate_extraction.extract_event_candidates(
             raw_odds=list(rows.raw_odds),
             raw_outcome_offers=list(rows.raw_outcome_offers),

--- a/backend/app/services/outcome_normalizer.py
+++ b/backend/app/services/outcome_normalizer.py
@@ -29,6 +29,7 @@ from .normalizer import (
 from .team_registry import create_canonical_team, create_canonical_teams_batch
 from .tennis_name_matcher import (
     TENNIS_BROAD_DRIFT_MINUTES,
+    TennisCompetitorPairMatch,
     match_tennis_player_names,
     tennis_competitor_pair_matches,
 )
@@ -44,6 +45,7 @@ from .team_identity import (
     team_qualifiers as _team_qualifiers,
     team_similarity as _team_similarity,
 )
+from .event_pairing import EventPairingCycle
 from .text_normalizer import normalize_identity_text
 
 logger = logging.getLogger(__name__)
@@ -176,6 +178,13 @@ class _OutcomeTextCache:
         self._comparison_text: dict[tuple[str, str | None], str] = {}
         self._significant_tokens: dict[tuple[str, str | None], set[str]] = {}
         self._women_marker_forms: dict[str, frozenset[str]] = {}
+        self._team_similarity: dict[tuple[str, str, str | None], float] = {}
+        self._tennis_competitor_pair_matches: dict[
+            tuple[str, str, str, str], tuple[TennisCompetitorPairMatch, ...]
+        ] = {}
+
+    def bind_stats(self, stats: _FootballEventResolutionStats | None) -> None:
+        self._stats = stats
 
     def qualifiers(self, name: str, *, sport: str | None = None) -> set[str]:
         key = (name, sport)
@@ -219,6 +228,14 @@ class _OutcomeTextCache:
         *,
         sport: str | None = None,
     ) -> float:
+        key = (left, right, sport)
+        reverse_key = (right, left, sport)
+        cached = self._team_similarity.get(key)
+        if cached is None:
+            cached = self._team_similarity.get(reverse_key)
+        if cached is not None:
+            return cached
+
         score_result = _event_similarity_score_from_parts(
             self.comparison_text(left, sport=sport),
             self.comparison_text(right, sport=sport),
@@ -227,7 +244,29 @@ class _OutcomeTextCache:
         )
         if self._stats is not None and score_result.used_fuzzy_score:
             self._stats.football_event_fuzzy_score_count += 1
-        return score_result.score
+        score = score_result.score
+        self._team_similarity[key] = score
+        return score
+
+    def tennis_competitor_pair_matches(
+        self,
+        left_home: str,
+        left_away: str,
+        right_home: str,
+        right_away: str,
+    ) -> tuple[TennisCompetitorPairMatch, ...]:
+        key = (left_home, left_away, right_home, right_away)
+        cached = self._tennis_competitor_pair_matches.get(key)
+        if cached is not None:
+            return cached
+        matches = tennis_competitor_pair_matches(
+            left_home,
+            left_away,
+            right_home,
+            right_away,
+        )
+        self._tennis_competitor_pair_matches[key] = matches
+        return matches
 
     def comparison_texts_are_compatible(
         self,
@@ -427,7 +466,7 @@ def _pair_candidates(
     text_cache = text_cache or _OutcomeTextCache(stats)
     candidates: list[_OutcomeEventPair] = []
     if left.sport == "tennis":
-        for tennis_match in tennis_competitor_pair_matches(
+        for tennis_match in text_cache.tennis_competitor_pair_matches(
             left.home_team,
             left.away_team,
             right.home_team,
@@ -880,35 +919,27 @@ def _rank_event_pairs(
     *,
     resolutions: dict[tuple[str, str, str, str, str], _OutcomeEventResolution] | None = None,
     stats: _FootballEventResolutionStats | None = None,
+    event_pairing: EventPairingCycle | None = None,
 ) -> list[_OutcomeEventPair]:
-    events_by_slot: dict[tuple[str, str], list[_OutcomeEvent]] = defaultdict(list)
-    events_by_pair_bucket: dict[tuple[str, str], list[_OutcomeEvent]] = defaultdict(list)
-    for event in events:
-        events_by_slot[(event.sport, event.start_time)].append(event)
-        pair_bucket = (
-            (event.sport, "__tennis_time_drift__")
-            if event.sport == "tennis"
-            else (event.sport, event.start_time)
-        )
-        events_by_pair_bucket[pair_bucket].append(event)
+    pairing = event_pairing or EventPairingCycle()
     if stats is not None:
         bucket_rows: list[OutcomeFootballEventBucketBenchmarkOut] = []
-        for (sport, start_time), slot_events in events_by_slot.items():
-            bookmaker_counts = Counter(event.bookmaker_id for event in slot_events)
-            total_pairs = len(slot_events) * (len(slot_events) - 1) // 2
-            same_bookmaker_pairs = sum(
-                count * (count - 1) // 2 for count in bookmaker_counts.values()
-            )
+        for summary in pairing.slot_summaries(
+            events,
+            sport=lambda event: event.sport,
+            start_time=lambda event: event.start_time,
+            bookmaker_id=lambda event: event.bookmaker_id,
+        ):
             bucket_rows.append(
                 OutcomeFootballEventBucketBenchmarkOut(
-                    sport=sport,
-                    start_time=start_time,
-                    event_count=len(slot_events),
-                    bookmaker_count=len(bookmaker_counts),
-                    candidate_pair_count=total_pairs - same_bookmaker_pairs,
+                    sport=summary.sport,
+                    start_time=summary.start_time,
+                    event_count=summary.event_count,
+                    bookmaker_count=summary.bookmaker_count,
+                    candidate_pair_count=summary.candidate_pair_count,
                 )
             )
-        stats.football_event_time_slot_count = len(events_by_slot)
+        stats.football_event_time_slot_count = len(bucket_rows)
         stats.football_event_max_events_per_slot = max(
             (row.event_count for row in bucket_rows),
             default=0,
@@ -924,8 +955,13 @@ def _rank_event_pairs(
         )[:20]
 
     accepted: list[_OutcomeEventPair] = []
-    for events in events_by_pair_bucket.values():
-        text_cache = _OutcomeTextCache(stats)
+    for events in pairing.pair_buckets(
+        events,
+        sport=lambda event: event.sport,
+        start_time=lambda event: event.start_time,
+    ):
+        text_cache = pairing.cache("outcome_text", _OutcomeTextCache)
+        text_cache.bind_stats(stats)
         resolution_by_event = (
             {event: resolutions.get(_event_key(event)) for event in events}
             if resolutions is not None
@@ -1036,6 +1072,7 @@ def _build_football_event_resolutions(
     raw_list: list[RawOutcomeOffer],
     *,
     stats: _FootballEventResolutionStats | None = None,
+    event_pairing: EventPairingCycle | None = None,
 ) -> FootballEventResolutionMap:
     events = _unique_events(raw_list)
     if stats is not None:
@@ -1051,7 +1088,12 @@ def _build_football_event_resolutions(
         stats.football_event_slot_lookup_ms += _elapsed_ms(lookup_started_at)
 
     ranking_started_at = time.perf_counter()
-    ranked_pairs = _rank_event_pairs(events, resolutions=resolutions, stats=stats)
+    ranked_pairs = _rank_event_pairs(
+        events,
+        resolutions=resolutions,
+        stats=stats,
+        event_pairing=event_pairing,
+    )
     if stats is not None:
         stats.football_event_pair_ranking_ms += _elapsed_ms(ranking_started_at)
 
@@ -1392,6 +1434,8 @@ def _normalized_offer_from_resolution(
 
 def normalize_outcome_offers_with_context(
     raw_list: list[RawOutcomeOffer],
+    *,
+    event_pairing: EventPairingCycle | None = None,
 ) -> OutcomeNormalizationResult:
     normalization_started_at = time.perf_counter()
     autocreate_started_at = time.perf_counter()
@@ -1403,6 +1447,7 @@ def normalize_outcome_offers_with_context(
     event_resolutions = _build_football_event_resolutions(
         raw_list,
         stats=football_resolution_stats,
+        event_pairing=event_pairing,
     )
     event_slots_by_time = _build_event_slots_by_time(event_resolutions)
     football_event_resolution_ms = _elapsed_ms(event_resolution_started_at)

--- a/backend/app/services/scrape_pipeline.py
+++ b/backend/app/services/scrape_pipeline.py
@@ -1744,6 +1744,12 @@ class ScrapePipeline:
                 int((time.perf_counter() - persist_snapshot_started_at) * 1000),
             )
 
+            football_event_resolutions_for_match_unification = (
+                event_resolution_batch.football_event_resolutions
+            )
+            if rerun_decision.skipped and (applied_auto_aliases or applied_auto_merges):
+                football_event_resolutions_for_match_unification = None
+
             match_unification_started_at = time.perf_counter()
             match_unification_result = await self.match_unification.unify_after_snapshot(
                 snapshot=PersistedScrapeSnapshot(
@@ -1756,9 +1762,7 @@ class ScrapePipeline:
                     raw_outcome_offers=all_raw_outcome_offers,
                     normalized_odds=event_resolution_batch.odds,
                     normalized_outcome_offers=event_resolution_batch.outcome_offers,
-                    football_event_resolutions=(
-                        event_resolution_batch.football_event_resolutions
-                    ),
+                    football_event_resolutions=football_event_resolutions_for_match_unification,
                 ),
             )
             self.benchmark.record_phase_duration(

--- a/backend/app/services/scrape_pipeline.py
+++ b/backend/app/services/scrape_pipeline.py
@@ -27,6 +27,7 @@ from ..services.market_allowlist import (
     MARKET_TYPE_ALIASES,
     MarketAllowlist,
 )
+from ..services.event_pairing import EventPairingCycle
 from ..services.rate_limit_policy import DetailMode
 from ..services.normalizer import (
     ANCHORED_AUTO_APPLY_THRESHOLD,
@@ -810,6 +811,7 @@ def _normalize_pipeline_batch(
     raw_outcome_offers: list[RawOutcomeOffer],
     *,
     benchmark,
+    event_pairing: EventPairingCycle | None = None,
     log_unresolved_shared_platform: bool = True,
 ) -> _NormalizedPipelineBatch:
     threshold_started_at = time.perf_counter()
@@ -822,7 +824,10 @@ def _normalize_pipeline_batch(
         int((time.perf_counter() - threshold_started_at) * 1000),
     )
     outcome_started_at = time.perf_counter()
-    outcome_result = normalize_outcome_offers_with_context(raw_outcome_offers)
+    outcome_result = normalize_outcome_offers_with_context(
+        raw_outcome_offers,
+        event_pairing=event_pairing,
+    )
     normalized_outcome_offers = outcome_result.normalized
     unresolved_outcome_offers = outcome_result.unresolved
     outcome_team_review_cases = outcome_result.team_review_cases
@@ -1559,11 +1564,13 @@ class ScrapePipeline:
         applied_auto_aliases: list[tuple[str, str, str]] = []
         applied_auto_merges: list[tuple[int, int]] = []
         auto_approved_team_review_case_ids: list[int] = []
+        event_pairing = EventPairingCycle()
 
         full_normalized_batch = _normalize_pipeline_batch(
             all_raw,
             all_raw_outcome_offers,
             benchmark=self.benchmark,
+            event_pairing=event_pairing,
             log_unresolved_shared_platform=False,
         )
         normalized_batch = _filter_normalized_pipeline_batch_by_market_allowlist(
@@ -1643,6 +1650,7 @@ class ScrapePipeline:
                     all_raw,
                     all_raw_outcome_offers,
                     benchmark=self.benchmark,
+                    event_pairing=event_pairing,
                 )
                 normalized_batch = _filter_normalized_pipeline_batch_by_market_allowlist(
                     full_normalized_batch,
@@ -1748,6 +1756,9 @@ class ScrapePipeline:
                     raw_outcome_offers=all_raw_outcome_offers,
                     normalized_odds=event_resolution_batch.odds,
                     normalized_outcome_offers=event_resolution_batch.outcome_offers,
+                    football_event_resolutions=(
+                        event_resolution_batch.football_event_resolutions
+                    ),
                 ),
             )
             self.benchmark.record_phase_duration(

--- a/backend/tests/test_outcome_normalizer.py
+++ b/backend/tests/test_outcome_normalizer.py
@@ -20,6 +20,7 @@ from app.services.outcome_normalizer import (
     normalize_outcome_offers_with_benchmark,
     normalize_outcome_offers_with_diagnostics,
 )
+from app.services.event_pairing import EventPairingCycle
 from app.services.team_registry import create_canonical_team, remember_team_alias
 
 
@@ -286,6 +287,33 @@ def test_football_event_resolution_benchmark_counts_pair_and_fuzzy_work(team_reg
 
     assert stats.football_event_pair_candidate_count == 1
     assert stats.football_event_fuzzy_score_count >= 1
+
+
+def test_football_event_resolution_reuses_cycle_similarity_cache(team_registry_file):
+    raw = [
+        _offer("maxbet", "Basket Sibirsk", "CSKA Moscow", outcome_code="over"),
+        _offer("balkanbet", "Blec Sybirsk", "CSKA Moscow", outcome_code="under"),
+    ]
+    event_pairing = EventPairingCycle()
+    first_stats = _FootballEventResolutionStats()
+    second_stats = _FootballEventResolutionStats()
+
+    first = _build_football_event_resolutions(
+        raw,
+        stats=first_stats,
+        event_pairing=event_pairing,
+    )
+    second = _build_football_event_resolutions(
+        raw,
+        stats=second_stats,
+        event_pairing=event_pairing,
+    )
+
+    assert second == first
+    assert first_stats.football_event_pair_candidate_count == 1
+    assert second_stats.football_event_pair_candidate_count == 1
+    assert first_stats.football_event_fuzzy_score_count >= 1
+    assert second_stats.football_event_fuzzy_score_count == 0
 
 
 def test_football_event_resolution_skips_supported_disjoint_canonical_slots(

--- a/backend/tests/test_scrape_pipeline.py
+++ b/backend/tests/test_scrape_pipeline.py
@@ -139,8 +139,10 @@ async def _load_empty_canonical_analysis(_store, **_kwargs):
 class FakeMatchUnification:
     def __init__(self, result: MatchUnificationResult | None = None) -> None:
         self.result = result
+        self.calls: list[dict] = []
 
-    async def unify_after_snapshot(self, **_kwargs):
+    async def unify_after_snapshot(self, **kwargs):
+        self.calls.append(kwargs)
         return self.result or MatchUnificationResult(
             status=MatchUnificationStatus.unified(snapshot_id="snapshot-1"),
         )
@@ -324,3 +326,18 @@ async def test_pipeline_keeps_auto_approved_audit_rows_after_failed_rollback():
         ).run(_pipeline_input())
 
     assert store.deleted_case_ids == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_discards_cached_event_resolutions_after_skipped_registry_change():
+    store = FakeStore()
+    match_unification = FakeMatchUnification()
+
+    await _pipeline(
+        store=store,
+        team_actions=FakeTeamActions(applied_aliases=[("demo", "Raw", "football")]),
+        match_unification=match_unification,
+    ).run(_pipeline_input())
+
+    rows = match_unification.calls[-1]["rows"]
+    assert rows.football_event_resolutions is None


### PR DESCRIPTION
## Summary
- Add a cycle-level Event Pairing Module for temporal bucketing and per-cycle pairing cache state
- Reuse outcome event similarity/tennis pair caches across normalization reruns
- Reuse already-built football event resolutions in Match Unification instead of recomputing them
- Document Event Pairing in CONTEXT.md and add cache-reuse coverage

## Verification
- `cd backend && ./venv/bin/pytest -q tests/test_outcome_normalizer.py tests/test_match_unification_resolution.py tests/test_scraper_benchmarks.py`
- `cd backend && ./venv/bin/pytest -q`
- Fresh isolated real-mode benchmark on separate SQLite DB: cycle 145.5s; normalized outcome pair-ranking improved from 0.391ms/candidate to 0.273ms/candidate versus prior evidence; Match Unification extraction dropped from 95.5s to 1.8s by reusing resolutions.